### PR TITLE
fix: docker-composeでMCP_GITHUB_PATを渡す

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     command: ["http", "--port", "${GITHUB_MCP_HTTP_PORT:-8082}"]
 
     environment:
-      - MCP_GITHUB_PAT=${GITHUB_PERSONAL_ACCESS_TOKEN}
+      - MCP_GITHUB_PAT=${MCP_GITHUB_PAT:-${GITHUB_PERSONAL_ACCESS_TOKEN}}
       - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
       - GITHUB_API_URL=${GITHUB_API_URL:-https://api.github.com}
       - LOG_LEVEL=${LOG_LEVEL:-info}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     command: ["http", "--port", "${GITHUB_MCP_HTTP_PORT:-8082}"]
 
     environment:
+      - MCP_GITHUB_PAT=${GITHUB_PERSONAL_ACCESS_TOKEN}
       - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
       - GITHUB_API_URL=${GITHUB_API_URL:-https://api.github.com}
       - LOG_LEVEL=${LOG_LEVEL:-info}


### PR DESCRIPTION
## 変更内容
- `docker-compose.yml` の環境変数に `MCP_GITHUB_PAT` を追加
- 既存の `GITHUB_PERSONAL_ACCESS_TOKEN` を `MCP_GITHUB_PAT` に割り当て

## 背景
GitHub MCP SDK（v0.0.422）では、MCPヘッダー展開時に `GITHUB_PERSONAL_ACCESS_TOKEN` が除外されます。
そのため、`MCP_GITHUB_PAT` を明示的に渡す必要があります。