### PR TITLE
feat: add list_pull_request_review_threads tool (v2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-03-17
+
+### ✨ 新機能
+
+- `list_pull_request_review_threads` ツールを追加（Goソースパッチビルド方式）
+  - `resolve_pull_request_review_thread` との一気通貫フローを実現
+  - GraphQL API 経由でレビュースレッドの node ID（`PRRT_xxx`）を取得可能に
+  - `is_resolved` 引数で解決済み/未解決フィルタが可能（省略時は全件）
+  - `patches/github/list_pr_review_threads.go` を `Dockerfile.github-mcp-server` で注入するソースパッチ方式
+  - カスタムイメージのビルド・起動は `make build-custom` / `make start-custom`
+
 ### 🐛 Fixes
 
-- `generate-ide-config.sh --ide copilot-cli` の出力形式を TOML から JSON（`mcp-config.json`）へ修正
-- README とシェルテストを Copilot CLI の JSON 設定方式に合わせて更新
+- `generate-ide-config.sh --ide claude-desktop` の設定を HTTP から stdio（`docker run -i`）へ修正
+  - Claude Desktop は HTTP transport 非対応のため、`docker run --rm -i` でバイナリを直接 stdio 起動する設定に変更
+  - `GITHUB_MCP_IMAGE` 環境変数でカスタムビルドイメージも指定可能
 
 ## [2.1.0] - 2026-02-07
 

--- a/Dockerfile.github-mcp-server
+++ b/Dockerfile.github-mcp-server
@@ -46,6 +46,17 @@ RUN go mod edit -require=github.com/modelcontextprotocol/go-sdk@${GO_SDK_VERSION
     go mod tidy && \
     test "$(go list -m -f '{{.Version}}' github.com/modelcontextprotocol/go-sdk)" = "${GO_SDK_VERSION}"
 
+# Inject list_pull_request_review_threads tool (patches/github/list_pr_review_threads.go).
+# This tool exposes GraphQL-only PRRT_ thread node IDs needed by
+# resolve_pull_request_review_thread.
+COPY patches/github/list_pr_review_threads.go /src/pkg/github/
+
+# Register the new tool in AllTools() immediately after AddReplyToPullRequestComment.
+RUN sed -i \
+    's/AddReplyToPullRequestComment(t),/AddReplyToPullRequestComment(t),\n\t\tListPullRequestReviewThreads(t),/' \
+    /src/pkg/github/tools.go && \
+    grep -q 'ListPullRequestReviewThreads' /src/pkg/github/tools.go
+
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags="-s -w" -o /server/github-mcp-server ./cmd/github-mcp-server
 

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ pull: ## Dockerイメージを取得
 .PHONY: build
 build: pull ## 互換性のため pull を実行
 
+.PHONY: build-custom
+build-custom: ## カスタムビルド（list_pull_request_review_threads パッチ適用）
+	GITHUB_MCP_IMAGE=mcp-github-patched:latest docker compose build github-mcp
+
+.PHONY: start-custom
+start-custom: build-custom ## カスタムビルド後に起動
+	GITHUB_MCP_IMAGE=mcp-github-patched:latest docker compose up -d github-mcp
+
 # ----------------------------------------
 # 開発
 # ----------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,12 @@
 services:
   github-mcp:
     image: ${GITHUB_MCP_IMAGE:-ghcr.io/github/github-mcp-server:main}
+    # To use the custom-patched image (adds list_pull_request_review_threads):
+    #   make build-custom          # build and tag as mcp-github-patched:latest
+    #   make start-custom          # build + start with the patched image
+    build:
+      context: .
+      dockerfile: Dockerfile.github-mcp-server
     container_name: mcp-github
     restart: unless-stopped
     command: ["http", "--port", "${GITHUB_MCP_HTTP_PORT:-8082}"]

--- a/docs/design/pr-review-thread-list-design.md
+++ b/docs/design/pr-review-thread-list-design.md
@@ -1,0 +1,379 @@
+# PRレビュースレッド一覧取得ツール 設計ドキュメント
+
+**作成日**: 2026-03-17  
+**バージョン**: 1.0.0  
+**ステータス**: Approved  
+**対象**: `github-mcp-server` カスタムビルド（方式C: ソースパッチビルド）
+
+---
+
+## 1. 背景と課題
+
+### 1.1 現状の「片手落ち」問題
+
+`github-mcp-server` には `resolve_pull_request_review_thread` ツールが実装されている。
+しかし、このツールの必須引数 `thread_id` に渡す `PRRT_xxxx` 形式の **node ID** は、
+GitHub REST API では取得できない。GraphQL API (`pullRequest.reviewThreads.nodes[].id`) にしか存在しない。
+
+```
+■ 問題のあるワークフロー (現状)
+  [AI] → list_pull_requests  OK: PR一覧取得
+  [AI] → ??? スレッド一覧?   ← ツールが存在しない
+  [AI] → resolve_pull_request_review_thread(thread_id="PRRT_???")
+                              ← PRRT_ の ID をどこで入手する？
+```
+
+### 1.2 解決方針
+
+`list_pull_request_review_threads` ツールを追加し、以下のフローを成立させる:
+
+```
+■ 解決後のワークフロー (一気通貫)
+  [AI] → list_pull_request_review_threads(owner, repo, pull_number)
+         → [{id: "PRRT_xxx", isResolved: false, path: "src/foo.go", body: "この実装は..."}]
+  [AI] → (コメント内容を見てどのスレッドを解決すべきか判断)
+  [AI] → resolve_pull_request_review_thread(owner, repo, pull_number, thread_id: "PRRT_xxx")
+         → 解決完了
+```
+
+---
+
+## 2. 決定事項（合意済み）
+
+| # | 項目 | 決定内容 | 理由 |
+|---|------|----------|------|
+| Q1 | 実装場所 | **方式C: ソースパッチビルド** | 既存 `Dockerfile.github-mcp-server` の COPY/sed パッチ方式を拡張して Go ファイルを注入する。単一コンテナで完結。上流が追いついたら公式イメージに乗り換える一時つなぎ。 |
+| Q2 | ツールスコープ | **`list_pull_request_review_threads` のみ追加** | unresolve は不要。resolve フローの一気通貫を目的とする。 |
+| Q3 | 返却フィールド | **全フィールド** (id, isResolved, isOutdated, path, line, comments[0]) | AIが「何についてのスレッドか」を判断するために全フィールドが必要。 |
+| Q4 | フィルタ/ページネーション | **`is_resolved` オプション引数（デフォルト: null=全件）、最大100件** | 1PRのスレッドは多くても数十件が通常。 |
+| Q5 | PAT スコープ | **既存スコープのまま変更なし** | Fine-grained token の `Pull requests: Read and write` で GraphQL API の読み取りが可能。 |
+| Q6 | フォールバック | **方式C 優先、難しければ方式B（サイドカー）** | 方式Cが技術的に困難な場合のみサイドカーへ移行。 |
+
+---
+
+## 3. アーキテクチャ
+
+### 3.1 方式C: ソースパッチビルド の仕組み
+
+```
+Dockerfile.github-mcp-server ビルドフロー (変更後)
+┌──────────────────────────────────────────────────────────────────┐
+│ Stage 2: builder (golang:1.26-bookworm)                          │
+│                                                                  │
+│  1. git fetch github/github-mcp-server@main              (既存)  │
+│  2. sed パッチ (Capabilities.Extensions → Experimental)   (既存)  │
+│  3. go mod edit -require=go-sdk@v1.3.1                   (既存)  │
+│  ↓                                                               │
+│  4. COPY patches/github/ → /src/pkg/github/              (追加)  │
+│     - list_pr_review_threads.go  ← 新ツール実装                  │
+│  5. RUN patch コマンドで server.go にツール登録を追記    (追加)  │
+│  ↓                                                               │
+│  6. go build                                             (既存)  │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+         │
+         ▼ バイナリに新ツールが含まれる
+┌──────────────────────────────────────────────────────────────────┐
+│ Stage 3: distroless runtime                              (既存)  │
+│  COPY --from=builder /server/github-mcp-server .                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 追加ファイル構成
+
+```
+Mcp-Docker/
+├── Dockerfile.github-mcp-server   (変更: COPY/patch ステップ追加)
+├── patches/
+│   └── github/
+│       └── list_pr_review_threads.go   (新規: Goパッチファイル)
+└── docs/design/
+    └── pr-review-thread-list-design.md  (本ドキュメント)
+```
+
+---
+
+## 4. 追加MCPツール仕様
+
+### 4.1 `list_pull_request_review_threads`
+
+#### 概要
+
+指定したPRのレビュースレッド一覧をGraphQL APIで取得する。
+`resolve_pull_request_review_thread` と組み合わせて使う前段ツール。
+
+#### 引数
+
+| 引数名 | 型 | 必須 | デフォルト | 説明 |
+|--------|-----|------|-----------|------|
+| `owner` | string | ✓ | - | リポジトリオーナー名 |
+| `repo` | string | ✓ | - | リポジトリ名 |
+| `pull_number` | int | ✓ | - | PRの番号 |
+| `is_resolved` | bool/null | - | `null` | `true`: 解決済みのみ, `false`: 未解決のみ, `null` (省略): 全件 |
+
+#### 返却値（スレッド配列）
+
+```json
+[
+  {
+    "id": "PRRT_kwDOxxxxxxxxxxxxxxxx",
+    "isResolved": false,
+    "isOutdated": false,
+    "path": "src/foo.go",
+    "line": 42,
+    "startLine": 40,
+    "firstComment": {
+      "body": "この処理はエラーハンドリングが必要では？",
+      "author": "reviewer",
+      "createdAt": "2026-03-15T10:00:00Z"
+    }
+  }
+]
+```
+
+| フィールド | 説明 |
+|------------|------|
+| `id` | `PRRT_` プレフィックスの node ID（`resolve_pull_request_review_thread` の `thread_id` に渡す値） |
+| `isResolved` | スレッドが解決済みかどうか |
+| `isOutdated` | コードの変更で該当行が古くなったかどうか |
+| `path` | 対象ファイルのパス |
+| `line` | 対象行番号（末尾行） |
+| `startLine` | 対象行番号（開始行）。単一行コメントの場合は `line` と同じ |
+| `firstComment.body` | 最初のコメント本文（AIが内容を判断するために使用） |
+| `firstComment.author` | コメントしたユーザー名 |
+| `firstComment.createdAt` | コメント日時（ISO 8601） |
+
+#### エラーパターン
+
+| 状況 | 返却 |
+|------|------|
+| PR が存在しない | `404 Not Found` エラー |
+| 権限不足 | `403 Forbidden` エラー |
+| スレッドが0件 | 空配列 `[]` |
+
+---
+
+## 5. GraphQL クエリ設計
+
+### 5.1 使用するクエリ
+
+```graphql
+query ListPRReviewThreads($owner: String!, $repo: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          startLine
+          comments(first: 1) {
+            nodes {
+              body
+              author {
+                login
+              }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### 5.2 APIエンドポイント
+
+- URL: `${GITHUB_API_URL}/graphql` (デフォルト: `https://api.github.com/graphql`)
+- 認証: `Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}`
+- メソッド: `POST`
+- 依存ライブラリ: 追加なし（Go標準の `net/http` + `encoding/json` で実装）
+
+### 5.3 ページネーション
+
+初期実装は `first: 100` 固定。100件を超えるケースは現実的に稀なため、
+`pageInfo.hasNextPage` が `true` の場合は最初の100件を返し、警告メッセージを付加する。
+
+---
+
+## 6. AIワークフロー設計（一気通貫フロー）
+
+### 6.1 基本フロー：未解決スレッドを一括確認して対応
+
+```
+[ユーザー] 「PR #42 の未解決レビューを全部確認して解決してほしい」
+
+[AI]
+  Step 1: list_pull_request_review_threads(
+            owner="org", repo="repo", pull_number=42, is_resolved=false
+          )
+  → 3件の未解決スレッドを取得
+    - PRRT_aaa: src/foo.go:42 「エラーハンドリングが必要」
+    - PRRT_bbb: src/bar.go:15 「変数名が不明瞭」
+    - PRRT_ccc: README.md:8  「リンクが切れている」
+
+  Step 2: (AIが各スレッドへの対応を実施)
+    → コードを修正し、コメントに返信
+
+  Step 3: resolve_pull_request_review_thread(
+            owner="org", repo="repo", pull_number=42, thread_id="PRRT_aaa"
+          )
+  Step 4: resolve_pull_request_review_thread(..., thread_id="PRRT_bbb")
+  Step 5: resolve_pull_request_review_thread(..., thread_id="PRRT_ccc")
+
+[ユーザー] 全スレッド解決完了
+```
+
+### 6.2 ツール引数の統一性
+
+`list` と `resolve` が同じコンテキスト引数 (`owner`, `repo`, `pull_number`) を持つことで、
+AIがステップ間でコンテキストを再利用しやすい設計になっている。
+
+```
+list_pull_request_review_threads(owner, repo, pull_number [, is_resolved])
+                  ↕ id を引き継ぐ
+resolve_pull_request_review_thread(owner, repo, pull_number, thread_id)
+```
+
+---
+
+## 7. Go実装設計
+
+### 7.1 ファイル: `patches/github/list_pr_review_threads.go`
+
+```
+パッケージ: package github
+```
+
+#### 実装構造
+
+```go
+// GraphQL リクエスト構造体
+type listPRReviewThreadsInput struct { ... }
+
+// GraphQL レスポンス構造体
+type prReviewThreadsResponse struct { ... }
+
+// ツール実装関数
+func ListPullRequestReviewThreads(client *github.Client, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc)
+
+// GraphQL 実行ヘルパー（net/http で実装、外部依存なし）
+func executeGraphQL(ctx context.Context, token, apiURL, query string, variables map[string]interface{}, result interface{}) error
+```
+
+#### 実装の注意点
+
+- `GITHUB_PERSONAL_ACCESS_TOKEN` 環境変数は既存のコンテキスト経由で取得可能
+- `GITHUB_API_URL` もコンテキストまたは環境変数から取得
+- Go標準ライブラリのみ使用し、`go.mod` の変更を最小化する
+
+### 7.2 ツール登録の注入方法
+
+上流の `pkg/github/server.go` (またはそれに相当するファイル) において、
+既存のツール登録パターン（例: `s.RegisterTool("resolve_pull_request_review_thread", ...)`）の
+直後に以下を追記するパッチを Dockerfile で適用する:
+
+```
+# Dockerfile での sed/patch による登録行の追加イメージ
+RUN grep -n "resolve_pull_request_review_thread" /src/pkg/github/server.go | head -1
+RUN sed -i '/registerTool.*resolve_pull_request_review_thread/a\\t\tregisterTool(s, ListPullRequestReviewThreads(s.client, s.t))' /src/pkg/github/server.go
+```
+
+> **実装前確認事項**: 上流の `server.go` の実際のツール登録パターン（関数名・書き方）を
+> `git fetch` 後に確認してから正確な sed コマンドを決定する。
+
+---
+
+## 8. Dockerfile 変更設計
+
+### 8.1 変更差分（概要）
+
+```dockerfile
+# [既存] ソース取得・パッチ適用
+RUN git init . && git remote add origin ... && git fetch ...
+RUN sed -i 's/Capabilities.Extensions/Capabilities.Experimental/g' ...
+RUN go mod edit -require=... && go mod tidy
+
+# [追加] ここから
+# 新ツールの Go ファイルをソースツリーに注入
+COPY patches/github/list_pr_review_threads.go /src/pkg/github/
+
+# ツール登録を server.go に追記（実際の関数名は上流を確認して確定）
+RUN REGISTER_LINE=$(grep -n "resolve_pull_request_review_thread" /src/pkg/github/server.go | \
+      grep -i "register\|add\|tool" | head -1 | cut -d: -f1) && \
+    sed -i "${REGISTER_LINE}a\\$(printf '\t\t')listPRReviewThreadsTool" /src/pkg/github/server.go
+# [追加] ここまで
+
+# [既存] ビルド
+RUN CGO_ENABLED=0 ... go build ...
+```
+
+### 8.2 方式Bへの切り替え条件
+
+方式Cでの実装が以下のいずれかに該当する場合、方式B（サイドカー）に切り替える:
+
+- 上流の登録パターンが複雑で `sed` による注入が現実的でない
+- `go.mod` への外部ライブラリ追加が必要になった
+- 上流の構造変更で毎ビルドのたびにパッチが壊れる頻度が高い
+
+---
+
+## 9. テスト計画
+
+### 9.1 手動スモークテスト
+
+1. `make build-custom`（カスタムイメージのビルド）後に起動
+2. `list_pull_request_review_threads` がツール一覧に表示されることを確認
+3. 実際のPRに対して呼び出し、`PRRT_` 形式の ID が返ることを確認
+4. 返却された ID を使って `resolve_pull_request_review_thread` を呼び出し、解決できることを確認
+5. `is_resolved=false` フィルタで既解決スレッドが除外されることを確認
+
+### 9.2 CI への組み込み
+
+- 既存の `shellcheck` / `bats` テストの範囲外（Go コード）なので、
+  手動テストサマリー（`docs/MCP_MANUAL_TEST_SUMMARY_*.md`）として記録する。
+
+---
+
+## 10. 上流移行・撤退計画
+
+### 上流が追いついたときの移行手順
+
+1. `github/github-mcp-server` の公式リリースノートで `list_pull_request_review_threads` の追加を確認
+2. `docker-compose.yml` の `GITHUB_MCP_IMAGE` を公式イメージに戻す
+3. `Dockerfile.github-mcp-server` のパッチ追加ステップを削除（または Dockerfile 自体の使用を停止）
+4. `patches/github/` ディレクトリを削除
+
+### CHANGELOG への反映
+
+```markdown
+## [Unreleased]
+### ✨ 新機能
+- `list_pull_request_review_threads` ツールを追加（Goソースパッチビルド方式）
+  - resolve_pull_request_review_thread との一気通貫フローを実現
+  - GraphQL API 経由でスレッドのnode ID（PRRT_）を取得可能に
+```
+
+---
+
+## 付録A: `resolve_pull_request_review_thread` 現状確認
+
+上流に実装済みのツールのシグネチャ（参考）:
+
+```
+resolve_pull_request_review_thread(
+  owner:       string,  // リポジトリオーナー
+  repo:        string,  // リポジトリ名
+  pull_number: int,     // PR番号
+  thread_id:   string   // PRRT_xxxx (今回追加するツールで取得する値)
+)
+```
+
+今回追加する `list_pull_request_review_threads` はこのシグネチャと**同じコンテキスト引数** (`owner`, `repo`, `pull_number`) を持つように設計し、AIが自然につなげられるようにする。

--- a/patches/github/list_pr_review_threads.go
+++ b/patches/github/list_pr_review_threads.go
@@ -1,0 +1,209 @@
+// Package github provides MCP tools for interacting with GitHub.
+// This file adds the list_pull_request_review_threads tool, which exposes
+// GraphQL-only thread node IDs (PRRT_xxx) needed by
+// resolve_pull_request_review_thread.
+package github
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ghErrors "github.com/github/github-mcp-server/pkg/errors"
+	"github.com/github/github-mcp-server/pkg/inventory"
+	"github.com/github/github-mcp-server/pkg/scopes"
+	"github.com/github/github-mcp-server/pkg/translations"
+	"github.com/github/github-mcp-server/pkg/utils"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/shurcooL/githubv4"
+)
+
+// prListReviewThreadsQuery is the GraphQL query for listing PR review threads.
+// Distinct type names are used to avoid conflicts with reviewThreadsQuery /
+// reviewThreadNode defined in pullrequests.go.
+type prListReviewThreadsQuery struct {
+	Repository struct {
+		PullRequest struct {
+			ReviewThreads struct {
+				Nodes    []prListReviewThreadNode
+				PageInfo struct {
+					HasNextPage githubv4.Boolean
+					EndCursor   githubv4.String
+				}
+				TotalCount githubv4.Int
+			} `graphql:"reviewThreads(first: 100)"`
+		} `graphql:"pullRequest(number: $prNum)"`
+	} `graphql:"repository(owner: $owner, name: $repo)"`
+}
+
+type prListReviewThreadNode struct {
+	ID         githubv4.ID
+	IsResolved githubv4.Boolean
+	IsOutdated githubv4.Boolean
+	Path       githubv4.String
+	Line       *githubv4.Int
+	StartLine  *githubv4.Int
+	Comments   struct {
+		Nodes []struct {
+			Body   githubv4.String
+			Author struct {
+				Login githubv4.String
+			}
+			CreatedAt githubv4.DateTime
+		}
+	} `graphql:"comments(first: 1)"`
+}
+
+type prReviewThreadListResult struct {
+	ID           string                      `json:"id"`
+	IsResolved   bool                        `json:"isResolved"`
+	IsOutdated   bool                        `json:"isOutdated"`
+	Path         string                      `json:"path"`
+	Line         *int32                      `json:"line,omitempty"`
+	StartLine    *int32                      `json:"startLine,omitempty"`
+	FirstComment *prReviewThreadFirstComment `json:"firstComment,omitempty"`
+}
+
+type prReviewThreadFirstComment struct {
+	Body      string `json:"body"`
+	Author    string `json:"author"`
+	CreatedAt string `json:"createdAt"`
+}
+
+// ListPullRequestReviewThreads creates a tool to list review threads on a pull
+// request. The returned thread node IDs (PRRT_xxx) can be passed directly to
+// resolve_pull_request_review_thread.
+func ListPullRequestReviewThreads(t translations.TranslationHelperFunc) inventory.ServerTool {
+	return NewTool(
+		ToolsetMetadataPullRequests,
+		mcp.Tool{
+			Name: "list_pull_request_review_threads",
+			Description: t("TOOL_LIST_PR_REVIEW_THREADS_DESCRIPTION",
+				"List review threads on a pull request. "+
+					"Use this tool when you need the thread node ID (PRRT_xxx format) to resolve a review thread with resolve_pull_request_review_thread. "+
+					"Returns each thread's node ID, resolution status (isResolved, isOutdated), file path, line numbers, and the first comment's body, author, and timestamp. "+
+					"Use is_resolved=false to list only unresolved threads (e.g. to find what still needs attention), "+
+					"is_resolved=true for resolved threads, or omit is_resolved to return all threads. "+
+					"Unlike pull_request_read with method=get_review_comments, this tool returns the PRRT_ node ID required for resolving threads."),
+			Annotations: &mcp.ToolAnnotations{
+				Title:        t("TOOL_LIST_PR_REVIEW_THREADS_USER_TITLE", "List pull request review threads"),
+				ReadOnlyHint: true,
+			},
+			InputSchema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"owner": {
+						Type:        "string",
+						Description: "Repository owner",
+					},
+					"repo": {
+						Type:        "string",
+						Description: "Repository name",
+					},
+					"pull_number": {
+						Type:        "number",
+						Description: "Pull request number",
+					},
+					"is_resolved": {
+						Type: "boolean",
+						Description: "Filter by resolution status: " +
+							"true returns only resolved threads, " +
+							"false returns only unresolved threads, " +
+							"omit (default) returns all threads",
+					},
+				},
+				Required: []string{"owner", "repo", "pull_number"},
+			},
+		},
+		[]scopes.Scope{scopes.Repo},
+		func(ctx context.Context, deps ToolDependencies, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			owner, err := RequiredParam[string](args, "owner")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			repo, err := RequiredParam[string](args, "repo")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+			pullNumber, err := RequiredInt(args, "pull_number")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			// isResolvedProvided distinguishes "not given" (all threads) from
+			// explicit true/false (filter by resolution status).
+			isResolved, isResolvedProvided, err := OptionalParamOK[bool](args, "is_resolved")
+			if err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
+			}
+
+			gqlClient, err := deps.GetGQLClient(ctx)
+			if err != nil {
+				return utils.NewToolResultErrorFromErr("failed to get GitHub GQL client", err), nil, nil
+			}
+
+			var query prListReviewThreadsQuery
+			vars := map[string]any{
+				"owner": githubv4.String(owner),
+				"repo":  githubv4.String(repo),
+				"prNum": githubv4.Int(int32(pullNumber)), //nolint:gosec // pullNumber is controlled by user input validation
+			}
+
+			if err := gqlClient.Query(ctx, &query, vars); err != nil {
+				return ghErrors.NewGitHubGraphQLErrorResponse(ctx,
+					"failed to list pull request review threads",
+					err,
+				), nil, nil
+			}
+
+			results := make([]prReviewThreadListResult, 0)
+			for _, node := range query.Repository.PullRequest.ReviewThreads.Nodes {
+				// Apply is_resolved filter when explicitly provided.
+				if isResolvedProvided && bool(node.IsResolved) != isResolved {
+					continue
+				}
+
+				result := prReviewThreadListResult{
+					ID:         fmt.Sprintf("%v", node.ID),
+					IsResolved: bool(node.IsResolved),
+					IsOutdated: bool(node.IsOutdated),
+					Path:       string(node.Path),
+				}
+
+				if node.Line != nil {
+					v := int32(*node.Line) //nolint:gosec // line numbers are always small positive integers
+					result.Line = &v
+				}
+				if node.StartLine != nil {
+					v := int32(*node.StartLine) //nolint:gosec // line numbers are always small positive integers
+					result.StartLine = &v
+				}
+
+				if len(node.Comments.Nodes) > 0 {
+					c := node.Comments.Nodes[0]
+					result.FirstComment = &prReviewThreadFirstComment{
+						Body:      string(c.Body),
+						Author:    string(c.Author.Login),
+						CreatedAt: c.CreatedAt.Time.Format(time.RFC3339),
+					}
+				}
+
+				results = append(results, result)
+			}
+
+			type prReviewThreadsResponse struct {
+				Threads    []prReviewThreadListResult `json:"threads"`
+				TotalCount int                        `json:"totalCount"`
+				// Truncated is true when the PR has more than 100 review threads
+				// and results are incomplete.
+				Truncated bool `json:"truncated,omitempty"`
+			}
+
+			return MarshalledTextResult(prReviewThreadsResponse{
+				Threads:    results,
+				TotalCount: int(query.Repository.PullRequest.ReviewThreads.TotalCount),
+				Truncated:  bool(query.Repository.PullRequest.ReviewThreads.PageInfo.HasNextPage),
+			}), nil, nil
+		})
+}

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -110,14 +110,21 @@ EOF
         ;;
     
     claude-desktop)
+        # Claude Desktop は HTTP transport 非対応 (stdio のみ)
+        # docker run -i でバイナリを直接 stdio モードで起動する
+        local CLAUDE_IMAGE="${GITHUB_MCP_IMAGE:-ghcr.io/github/github-mcp-server:main}"
         cat > "${OUTPUT_DIR}/claude_desktop_config.json" <<EOF
 {
   "mcpServers": {
     "github": {
-      "type": "http",
-      "url": "${SERVER_URL}",
-      "headers": {
-        "Authorization": "Bearer \${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "${CLAUDE_IMAGE}"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_your_token_here"
       }
     }
   }
@@ -125,17 +132,20 @@ EOF
 EOF
         echo "✅ Claude Desktop設定を生成しました: ${OUTPUT_DIR}/claude_desktop_config.json"
         echo ""
+        echo "⚠️  Claude Desktop は HTTP transport 非対応のため stdio (docker run -i) を使用します"
+        echo "   docker compose up は不要です。Claude Desktop が docker run を直接実行します。"
+        echo ""
         echo "📋 設定方法:"
-        echo "   1. Dockerコンテナを起動: docker compose up -d"
-        echo "   2. Claude Desktop設定ファイルを開く"
+        echo "   1. Claude Desktop設定ファイルを開く"
         echo "      macOS: ~/Library/Application Support/Claude/claude_desktop_config.json"
         echo "      Linux: ~/.config/Claude/claude_desktop_config.json"
         echo "      Windows: %APPDATA%\\Claude\\claude_desktop_config.json"
-        echo "   3. 上記の設定を追加"
-        echo "   4. 接続先URL: ${SERVER_URL}"
+        echo "   2. 上記の設定を追加し、GITHUB_PERSONAL_ACCESS_TOKEN の値を実際のトークンに変更"
+        echo "   3. Claude Desktop を再起動"
         echo ""
-        echo "💡 環境変数の設定も忘れずに:"
-        echo "   export GITHUB_PERSONAL_ACCESS_TOKEN=your_token_here"
+        echo "💡 カスタムビルドイメージを使う場合:"
+        echo "   GITHUB_MCP_IMAGE=mcp-github-patched:latest $0 --ide claude-desktop"
+        echo "   (事前に make build-custom でイメージをビルドしてください)"
         ;;
     
     kiro)


### PR DESCRIPTION
## 概要

`github-mcp-server` に `list_pull_request_review_threads` ツールを追加します。

`resolve_pull_request_review_thread` を呼ぶには `PRRT_xxx` 形式の node ID が必要ですが、これは REST API では取得できず GraphQL のみで取得可能です。本 PR により、レビュースレッドの一覧取得 → 解決の一気通貫フローが実現します。

## 変更内容

### ✨ 新機能

- **`patches/github/list_pr_review_threads.go`** — 新ツールの Go 実装
  - `github.com/shurcooL/githubv4` (既存依存) を使用し GraphQL でレビュースレッドを取得
  - 各スレッドの `PRRT_xxx` node ID・解決状態・ファイルパス・行番号・最初のコメントを返却
  - `is_resolved` 引数で未解決/解決済みフィルタが可能（省略時は全件）
  - 上流の型名（`reviewThreadsQuery` 等）と競合しない独自型名を使用

- **`Dockerfile.github-mcp-server`** — パッチ注入ステップを追加
  - `COPY patches/github/list_pr_review_threads.go /src/pkg/github/`
  - `sed` で `AllTools()` の `AddReplyToPullRequestComment(t),` 直後に `ListPullRequestReviewThreads(t),` を注入
  - `grep -q` で注入成功を検証

- **`Makefile`** — `build-custom` / `start-custom` ターゲットを追加
  ```
  make build-custom   # カスタムイメージのビルド
  make start-custom   # ビルド後に起動
  ```

- **`docker-compose.yml`** — `build:` セクションを追加（デフォルトは引き続き公式イメージ）

- **`docs/design/pr-review-thread-list-design.md`** — 設計書を追加

### 🐛 修正

- **`scripts/generate-ide-config.sh --ide claude-desktop`**
  - Claude Desktop は HTTP transport 非対応のため、設定を `"type": "http"` から `docker run --rm -i` の stdio 起動方式に修正
  - `GITHUB_MCP_IMAGE` 環境変数でカスタムビルドイメージにも対応

## 動作確認済み

```json
{"threads":[{"id":"PRRT_kwDORYgMu8500w7n","isResolved":false,...},...], "totalCount":4}
```

- `list_pull_request_review_threads` がツール一覧に表示される ✅
- `PRRT_xxx` 形式の node ID が返却される ✅  
- `is_resolved=false` フィルタが機能する ✅
- 返却された ID で `resolve_pull_request_review_thread` が実行可能 ✅

## 関連

- 上流 PR 待ち: 公式 `github-mcp-server` に同機能が追加されたら本パッチは不要になります