### PR TITLE
fix: address all 5 auto-review comments from PR #13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build: pull ## 互換性のため pull を実行
 
 .PHONY: build-custom
 build-custom: ## カスタムビルド（list_pull_request_review_threads パッチ適用）
-	GITHUB_MCP_IMAGE=mcp-github-patched:latest docker compose build github-mcp
+	GITHUB_MCP_IMAGE=mcp-github-patched:latest docker compose -f docker-compose.yml -f docker-compose.custom.yml build github-mcp
 
 .PHONY: start-custom
 start-custom: build-custom ## カスタムビルド後に起動

--- a/docker-compose.custom.yml
+++ b/docker-compose.custom.yml
@@ -1,0 +1,13 @@
+# Docker Compose override for custom patched image builds.
+# Use with:
+#   make build-custom   # equivalent to:
+#   docker compose -f docker-compose.yml -f docker-compose.custom.yml build github-mcp
+#
+# This file adds the build: section only when explicitly requested,
+# keeping the default docker-compose.yml clean for normal pull-based operation.
+
+services:
+  github-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile.github-mcp-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,6 @@ services:
     # To use the custom-patched image (adds list_pull_request_review_threads):
     #   make build-custom          # build and tag as mcp-github-patched:latest
     #   make start-custom          # build + start with the patched image
-    build:
-      context: .
-      dockerfile: Dockerfile.github-mcp-server
     container_name: mcp-github
     restart: unless-stopped
     command: ["http", "--port", "${GITHUB_MCP_HTTP_PORT:-8082}"]

--- a/docs/design/pr-review-thread-list-design.md
+++ b/docs/design/pr-review-thread-list-design.md
@@ -111,24 +111,28 @@ Mcp-Docker/
 | `pull_number` | int | ✓ | - | PRの番号 |
 | `is_resolved` | bool/null | - | `null` | `true`: 解決済みのみ, `false`: 未解決のみ, `null` (省略): 全件 |
 
-#### 返却値（スレッド配列）
+#### 返却値
 
 ```json
-[
-  {
-    "id": "PRRT_kwDOxxxxxxxxxxxxxxxx",
-    "isResolved": false,
-    "isOutdated": false,
-    "path": "src/foo.go",
-    "line": 42,
-    "startLine": 40,
-    "firstComment": {
-      "body": "この処理はエラーハンドリングが必要では？",
-      "author": "reviewer",
-      "createdAt": "2026-03-15T10:00:00Z"
+{
+  "threads": [
+    {
+      "id": "PRRT_kwDOxxxxxxxxxxxxxxxx",
+      "isResolved": false,
+      "isOutdated": false,
+      "path": "src/foo.go",
+      "line": 42,
+      "startLine": 40,
+      "firstComment": {
+        "body": "この処理はエラーハンドリングが必要では？",
+        "author": "reviewer",
+        "createdAt": "2026-03-15T10:00:00Z"
+      }
     }
-  }
-]
+  ],
+  "totalCount": 1,
+  "truncated": false
+}
 ```
 
 | フィールド | 説明 |
@@ -194,7 +198,7 @@ query ListPRReviewThreads($owner: String!, $repo: String!, $number: Int!, $after
 - URL: `${GITHUB_API_URL}/graphql` (デフォルト: `https://api.github.com/graphql`)
 - 認証: `Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}`
 - メソッド: `POST`
-- 依存ライブラリ: 追加なし（Go標準の `net/http` + `encoding/json` で実装）
+- 依存ライブラリ: `github.com/shurcooL/githubv4`（既存の依存、`go.mod` への追加変更なし）
 
 ### 5.3 ページネーション
 

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -112,7 +112,7 @@ EOF
     claude-desktop)
         # Claude Desktop は HTTP transport 非対応 (stdio のみ)
         # docker run -i でバイナリを直接 stdio モードで起動する
-        local CLAUDE_IMAGE="${GITHUB_MCP_IMAGE:-ghcr.io/github/github-mcp-server:main}"
+        CLAUDE_IMAGE="${GITHUB_MCP_IMAGE:-ghcr.io/github/github-mcp-server:main}"
         cat > "${OUTPUT_DIR}/claude_desktop_config.json" <<EOF
 {
   "mcpServers": {
@@ -121,7 +121,8 @@ EOF
       "args": [
         "run", "--rm", "-i",
         "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "${CLAUDE_IMAGE}"
+        "${CLAUDE_IMAGE}",
+        "stdio"
       ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_your_token_here"


### PR DESCRIPTION
## 概要

PR #13 の自動レビュー指摘（5件）を全件修正します。

## 修正内容

### 🐛 バグ修正

**1. `local` をトップレベルで使用（`generate-ide-config.sh` L115）**
- `local` は関数内でのみ有効。`case` ブロックはトップレベルのため `local: can only be used in a function` でスクリプトが失敗していた
- `local CLAUDE_IMAGE=...` → `CLAUDE_IMAGE=...`

**2. `docker run` に `stdio` 引数がない（`generate-ide-config.sh` L124）**
- `CMD ["http", "--port", "8082"]` がデフォルトのため、引数なし `docker run` では HTTP サーバーとして起動していた
- `"${CLAUDE_IMAGE}"` の後に `"stdio"` を追加し、stdio モードで起動するよう修正

### 🔧 改善

**3. `image:` + `build:` の同時指定（`docker-compose.yml`）**
- `docker compose up` 時にリモートイメージを pull せずローカルビルドに寄る可能性があった
- `build:` セクションを `docker-compose.yml` から削除し、新設の `docker-compose.custom.yml` override ファイルに移動
- `make build-custom` は `-f docker-compose.yml -f docker-compose.custom.yml` で override ファイルを明示的に指定

### 📝 ドキュメント修正

**4. 返却値の例が実装と乖離（`docs/design/pr-review-thread-list-design.md`）**
- 配列 `[...]` → `{ threads: [...], totalCount: N, truncated: bool }` オブジェクト形式に修正

**5. 依存ライブラリ記述が実装と乖離（`docs/design/pr-review-thread-list-design.md`）**
- 「Go標準の `net/http` + `encoding/json`、追加依存なし」→ 「`github.com/shurcooL/githubv4`（既存依存、`go.mod` 変更なし）」に修正
