### PR TITLE
fix: update claude-desktop config generation for correct image and token handling

### DIFF
--- a/.kiro/settings/mcp.json
+++ b/.kiro/settings/mcp.json
@@ -11,14 +11,13 @@
       "disabled": false,
       "autoApprove": []
     },
-    "github-docker": {
+    "github-mcp-server-docker": {
       "command": "docker",
       "args": [
-        "exec",
-        "-i",
-        "mcp-github",
-        "node",
-        "/usr/local/lib/node_modules/@modelcontextprotocol/server-github/dist/index.js"
+        "run", "--rm", "-i",
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "mcp-github-patched:latest",
+        "stdio"
       ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"

--- a/docs/simplification/github-mcp-server-design.md
+++ b/docs/simplification/github-mcp-server-design.md
@@ -113,7 +113,7 @@ deploy:
 ```json
 {
   "mcpServers": {
-    "github": {
+    "github-mcp-server-docker": {
       "command": "docker",
       "args": [
         "exec",
@@ -134,7 +134,7 @@ deploy:
 ```json
 {
   "mcpServers": {
-    "github": {
+    "github-mcp-server-docker": {
       "command": "docker",
       "args": [
         "exec",
@@ -156,7 +156,7 @@ deploy:
 {
   "mcp": {
     "servers": {
-      "github": {
+      "github-mcp-server-docker": {
         "type": "docker",
         "container": "mcp-github",
         "command": "node /app/dist/index.js",

--- a/docs/simplification/github-mcp-server-implementation.md
+++ b/docs/simplification/github-mcp-server-implementation.md
@@ -229,7 +229,7 @@ case "$IDE" in
         cat > "${OUTPUT_DIR}/settings.json" <<'EOF'
 {
   "mcpServers": {
-    "github": {
+    "github-mcp-server-docker": {
       "command": "docker",
       "args": [
         "exec",
@@ -257,7 +257,7 @@ EOF
         cat > "${OUTPUT_DIR}/claude_desktop_config.json" <<'EOF'
 {
   "mcpServers": {
-    "github": {
+    "github-mcp-server-docker": {
       "command": "docker",
       "args": [
         "exec",
@@ -288,7 +288,7 @@ EOF
 {
   "mcp": {
     "servers": {
-      "github": {
+      "github-mcp-server-docker": {
         "type": "docker",
         "container": "mcp-github",
         "command": "node /app/dist/index.js",

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -5,6 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 ENV_FILE="${PROJECT_ROOT}/.env"
 
+# MCP サーバー識別子（全IDE設定で統一）
+MCP_SERVER_KEY="github-mcp-server-docker"
+
 usage() {
     cat <<EOF
 使用方法: $0 --ide <IDE名>
@@ -23,6 +26,11 @@ IDE名:
   $0 --ide amazonq
   $0 --ide codex
   $0 --ide copilot-cli
+
+環境変数:
+  GITHUB_MCP_IMAGE        使用する Docker イメージ（claude-desktop では必須）
+  GITHUB_MCP_SERVER_URL   HTTP 接続先 URL（未設定時は GITHUB_MCP_HTTP_PORT から生成）
+  GITHUB_MCP_HTTP_PORT    HTTP ポート番号（デフォルト: 8082）
 EOF
     exit 1
 }
@@ -86,7 +94,7 @@ case "$IDE" in
         cat > "${OUTPUT_DIR}/settings.json" <<EOF
 {
   "mcpServers": {
-    "github": {
+    "${MCP_SERVER_KEY}": {
       "type": "http",
       "url": "${SERVER_URL}",
       "headers": {
@@ -108,17 +116,32 @@ EOF
         echo "💡 環境変数の設定も忘れずに:"
         echo "   export GITHUB_PERSONAL_ACCESS_TOKEN=your_token_here"
         ;;
-    
+
     claude-desktop)
         # Claude Desktop は HTTP transport 非対応 (stdio のみ)
         # docker run -i でバイナリを直接 stdio モードで起動する
         # ※ Claude Desktop はシェル環境変数を引き継がないため、
         #   env ブロックにトークンを平文で記載する必要がある（テンプレートではプレースホルダー）
-        CLAUDE_IMAGE="${GITHUB_MCP_IMAGE:-mcp-github-patched:latest}"
+        CLAUDE_IMAGE="${GITHUB_MCP_IMAGE:-}"
+        if [[ -z "${CLAUDE_IMAGE}" ]]; then
+            cat >&2 <<'ERRMSG'
+エラー: Claude Desktop 用の GitHub MCP サーバーイメージが設定されていません。
+
+- カスタムイメージを利用する場合（推奨・PRRT対応）:
+    make build-custom
+    GITHUB_MCP_IMAGE=mcp-github-patched:latest ./scripts/generate-ide-config.sh --ide claude-desktop
+
+- 公式イメージを利用する場合:
+    GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:main ./scripts/generate-ide-config.sh --ide claude-desktop
+
+このスクリプトは、利用可能なイメージが明示的に指定されるまで Claude Desktop 用設定を生成しません。
+ERRMSG
+            exit 1
+        fi
         cat > "${OUTPUT_DIR}/claude_desktop_config.json" <<EOF
 {
   "mcpServers": {
-    "github-mcp-server-docker": {
+    "${MCP_SERVER_KEY}": {
       "command": "docker",
       "args": [
         "run", "--rm", "-i",
@@ -145,25 +168,22 @@ EOF
         echo "   ※ このファイルをリポジトリにコミットしないよう注意してください。"
         echo ""
         echo "📋 設定方法:"
-        echo "   1. 生成されたファイルのトークンを書き換える"
+        echo "   1. カスタムイメージをビルド（未実施の場合）: make build-custom"
+        echo "   2. 生成されたファイルのトークンを書き換える"
         echo "      ${OUTPUT_DIR}/claude_desktop_config.json"
-        echo "   2. Claude Desktop設定ファイルに内容をマージする"
+        echo "   3. Claude Desktop設定ファイルに内容をマージする"
         echo "      macOS: ~/Library/Application Support/Claude/claude_desktop_config.json"
         echo "      Linux: ~/.config/Claude/claude_desktop_config.json"
         echo "      Windows: %APPDATA%\\Claude\\claude_desktop_config.json"
-        echo "   3. Claude Desktop を再起動"
-        echo ""
-        echo "💡 カスタムビルドイメージ (make build-custom) を使用するのがデフォルトです"
-        echo "   公式イメージを使う場合:"
-        echo "   GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:main $0 --ide claude-desktop"
+        echo "   4. Claude Desktop を再起動"
         ;;
-    
+
     kiro)
         cat > "${OUTPUT_DIR}/mcp.json" <<EOF
 {
   "mcp": {
     "servers": {
-      "github": {
+      "${MCP_SERVER_KEY}": {
         "type": "http",
         "url": "${SERVER_URL}",
         "headers": {
@@ -186,12 +206,12 @@ EOF
         echo "💡 環境変数の設定も忘れずに:"
         echo "   export GITHUB_PERSONAL_ACCESS_TOKEN=your_token_here"
         ;;
-    
+
     amazonq)
         cat > "${OUTPUT_DIR}/mcp.json" <<EOF
 {
   "mcpServers": {
-    "github": {
+    "${MCP_SERVER_KEY}": {
       "type": "http",
       "url": "${SERVER_URL}",
       "headers": {
@@ -216,7 +236,7 @@ EOF
 
     codex)
         cat > "${OUTPUT_DIR}/config.toml" <<EOF
-[mcp_servers.github]
+[mcp_servers.${MCP_SERVER_KEY}]
 url = "${SERVER_URL}"
 bearer_token_env_var = "GITHUB_PERSONAL_ACCESS_TOKEN"
 EOF
@@ -237,7 +257,7 @@ EOF
         cat > "${OUTPUT_DIR}/mcp-config.json" <<EOF
 {
   "mcpServers": {
-    "github": {
+    "${MCP_SERVER_KEY}": {
       "type": "http",
       "url": "${SERVER_URL}",
       "headers": {
@@ -258,7 +278,7 @@ EOF
         echo "💡 環境変数の設定も忘れずに:"
         echo "   export GITHUB_PERSONAL_ACCESS_TOKEN=your_token_here"
         ;;
-    
+
     *)
         echo "❌ 未対応のIDE: $IDE"
         usage

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -28,9 +28,10 @@ IDE名:
   $0 --ide copilot-cli
 
 環境変数:
-  GITHUB_MCP_IMAGE        使用する Docker イメージ（claude-desktop では必須）
-  GITHUB_MCP_SERVER_URL   HTTP 接続先 URL（未設定時は GITHUB_MCP_HTTP_PORT から生成）
-  GITHUB_MCP_HTTP_PORT    HTTP ポート番号（デフォルト: 8082）
+  GITHUB_MCP_IMAGE              使用する Docker イメージ（claude-desktop では必須）
+  GITHUB_MCP_SERVER_URL         HTTP 接続先 URL（未設定時は GITHUB_MCP_HTTP_PORT から生成）
+  GITHUB_MCP_HTTP_PORT          HTTP ポート番号（デフォルト: 8082）
+  GITHUB_PERSONAL_ACCESS_TOKEN  GitHub API 用の個人アクセストークン（fine-grained PAT 推奨。生成される各 IDE 設定で使用）
 EOF
     exit 1
 }

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -112,11 +112,13 @@ EOF
     claude-desktop)
         # Claude Desktop は HTTP transport 非対応 (stdio のみ)
         # docker run -i でバイナリを直接 stdio モードで起動する
-        CLAUDE_IMAGE="${GITHUB_MCP_IMAGE:-ghcr.io/github/github-mcp-server:main}"
+        # ※ Claude Desktop はシェル環境変数を引き継がないため、
+        #   env ブロックにトークンを平文で記載する必要がある（テンプレートではプレースホルダー）
+        CLAUDE_IMAGE="${GITHUB_MCP_IMAGE:-mcp-github-patched:latest}"
         cat > "${OUTPUT_DIR}/claude_desktop_config.json" <<EOF
 {
   "mcpServers": {
-    "github": {
+    "github-mcp-server-docker": {
       "command": "docker",
       "args": [
         "run", "--rm", "-i",
@@ -125,7 +127,7 @@ EOF
         "stdio"
       ],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_your_token_here"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "github_pat_your_token_here"
       }
     }
   }
@@ -136,17 +138,24 @@ EOF
         echo "⚠️  Claude Desktop は HTTP transport 非対応のため stdio (docker run -i) を使用します"
         echo "   docker compose up は不要です。Claude Desktop が docker run を直接実行します。"
         echo ""
+        echo "⚠️  トークンについて:"
+        echo "   Claude Desktop はシェル環境変数を引き継がないため、"
+        echo "   env.GITHUB_PERSONAL_ACCESS_TOKEN に実際のトークンを平文で記載する必要があります。"
+        echo "   生成されたファイルの 'github_pat_your_token_here' を実際のトークンに書き換えてください。"
+        echo "   ※ このファイルをリポジトリにコミットしないよう注意してください。"
+        echo ""
         echo "📋 設定方法:"
-        echo "   1. Claude Desktop設定ファイルを開く"
+        echo "   1. 生成されたファイルのトークンを書き換える"
+        echo "      ${OUTPUT_DIR}/claude_desktop_config.json"
+        echo "   2. Claude Desktop設定ファイルに内容をマージする"
         echo "      macOS: ~/Library/Application Support/Claude/claude_desktop_config.json"
         echo "      Linux: ~/.config/Claude/claude_desktop_config.json"
         echo "      Windows: %APPDATA%\\Claude\\claude_desktop_config.json"
-        echo "   2. 上記の設定を追加し、GITHUB_PERSONAL_ACCESS_TOKEN の値を実際のトークンに変更"
         echo "   3. Claude Desktop を再起動"
         echo ""
-        echo "💡 カスタムビルドイメージを使う場合:"
-        echo "   GITHUB_MCP_IMAGE=mcp-github-patched:latest $0 --ide claude-desktop"
-        echo "   (事前に make build-custom でイメージをビルドしてください)"
+        echo "💡 カスタムビルドイメージ (make build-custom) を使用するのがデフォルトです"
+        echo "   公式イメージを使う場合:"
+        echo "   GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:main $0 --ide claude-desktop"
         ;;
     
     kiro)

--- a/tests/shell/test_scripts.bats
+++ b/tests/shell/test_scripts.bats
@@ -71,8 +71,14 @@ setup() {
     [ -f "${PROJECT_ROOT}/config/ide-configs/vscode/settings.json" ]
 }
 
-@test "generate-ide-config.sh: claude-desktop設定生成が動作する" {
-    run "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop
+@test "generate-ide-config.sh: claude-desktop設定生成がGITHUB_MCP_IMAGE未設定でエラー終了する" {
+    run env -u GITHUB_MCP_IMAGE "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "エラー" ]]
+}
+
+@test "generate-ide-config.sh: claude-desktop設定生成がGITHUB_MCP_IMAGE設定時に動作する" {
+    run env GITHUB_MCP_IMAGE=mcp-github-patched:latest "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Claude Desktop設定を生成しました" ]]
     [ -f "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json" ]


### PR DESCRIPTION
## 概要

`scripts/generate-ide-config.sh` の `claude-desktop` セクションを実際の動作確認結果に基づいて修正し、全IDE設定のサーバーキー名を `github-mcp-server-docker` に統一。

## 変更内容

### `scripts/generate-ide-config.sh`
- **MCPサーバーキー名を全IDE統一**: `MCP_SERVER_KEY="github-mcp-server-docker"` 変数を導入し、vscode / claude-desktop / kiro / amazonq / codex / copilot-cli 全ての生成設定に適用
- **`GITHUB_MCP_IMAGE` の明示指定を必須化**: 未設定時はエラーメッセージを出力して `exit 1`（デフォルト値なし）
- **usage に `GITHUB_PERSONAL_ACCESS_TOKEN` を追加**: 各IDE設定で使用するトークンの説明と fine-grained PAT 推奨を明記
- **`make build-custom` を claude-desktop 手順のステップ1に追加**
- **平文トークン必須の警告追加**: Claude Desktop はシェル環境変数を引き継がないため、`env` ブロックへの平文記載が必要な旨を明記
- **コミット禁止の注意追加**: 生成されたファイルをリポジトリにコミットしないよう警告

### `.kiro/settings/mcp.json`
- **キー名を `github-mcp-server-docker` に統一**（旧: `github-docker`）
- **コマンドを動作確認済み構成に更新**: `docker exec` → `docker run --rm -i mcp-github-patched:latest stdio`

### `docs/simplification/github-mcp-server-design.md` / `github-mcp-server-implementation.md`
- 各IDE設定例のサーバーキー名を `github-mcp-server-docker` に更新

## 背景

Claude Desktop 1.1.7714 にて HTTP transport 対応が確認できず、`mcp-remote` 経由でも OAuth discovery エラーが発生。
`docker run -i` + `stdio` モードが唯一の動作確認済み構成であることが判明。

`GITHUB_MCP_IMAGE` はデフォルト値を持たず、明示的な指定が必須。カスタムビルド使用時は事前に `make build-custom` が必要。