### PR TITLE
Add MCP HTTP bridge for Claude Desktop

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -10,6 +10,20 @@ permissions:
   contents: read
 
 jobs:
+  test-node:
+    name: Nodeテスト
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Node.jsセットアップ
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Nodeテスト実行
+        run: npm test
+
   lint-shell:
     name: シェルスクリプトLint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # GitHub MCP Server - Docker統合環境
 
-VS Code、Cursor、Kiro等の統合IDEにGitHub MCP Server機能を提供するDocker常駐サービス。
+VS Code、Cursor、Kiro、Claude Desktop等の統合IDEにGitHub MCP Server機能を提供するDocker常駐サービス。
 
 ## HTTP transport対応
 
-このプロジェクトは `github-mcp-server` のHTTP接続を優先採用しています。  
+このプロジェクトは `github-mcp-server` のHTTP接続を優先採用しています。
 複数IDEウィンドウから同時接続しやすく、`stdio` 方式より並列利用に向いた構成です。
+Claude Desktop だけは HTTP transport 非対応のため、同梱の `mcp-http-bridge` で `stdio -> HTTP` を中継します。
 
 **イメージ方針（2026-02-07時点）:**
 - 既定イメージ: `ghcr.io/github/github-mcp-server:main`
@@ -30,6 +31,7 @@ GitHub公式のMCPサーバーをDockerコンテナとして常駐させ、各ID
 ### 前提条件
 
 - Docker 20.10+
+- Node.js 18+ / `npx`（Claude Desktop で bridge を使う場合）
 - GitHub Personal Access Token (PAT) または OAuth対応クライアント
 
 ### インストール
@@ -108,7 +110,8 @@ GITHUB_PERSONAL_ACCESS_TOKEN=ghp_your_token_here
 
 - 既定URL: `http://127.0.0.1:8082`
 - ポートを変更する場合: `GITHUB_MCP_HTTP_PORT` を設定（未設定時は `8082`）
-- HTTPモードでは各クライアントから `Authorization: Bearer <PAT/OAuth Token>` ヘッダーを送る必要があります。
+- 直接 HTTP 接続するクライアントでは、必要に応じて `Authorization: Bearer <PAT/OAuth Token>` ヘッダーを送ってください。
+- Claude Desktop は `mcp-http-bridge` を使って stdio から接続します。トークンをコンテナ内環境変数で運用している場合、Claude Desktop 側に追加の env は不要です。
 - 疎通確認（`401 Unauthorized` でもサーバー起動確認としては正常）:
 
 ```bash
@@ -145,6 +148,65 @@ docker compose up -d github-mcp
 # Linux: ~/.config/Claude/claude_desktop_config.json
 # Windows: %APPDATA%\Claude\claude_desktop_config.json
 ```
+
+生成される設定は `npx mcp-http-bridge --url http://127.0.0.1:8082` を使う stdio bridge です。
+
+```json
+{
+  "mcpServers": {
+    "github-mcp-server-docker": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-http-bridge",
+        "--url",
+        "http://127.0.0.1:8082",
+        "--timeout",
+        "30000"
+      ]
+    }
+  }
+}
+```
+
+bridge に追加ヘッダが必要な場合:
+
+```json
+{
+  "command": "npx",
+  "args": [
+    "-y",
+    "mcp-http-bridge",
+    "--url",
+    "http://127.0.0.1:8082",
+    "--header",
+    "Authorization: Bearer your_token_here"
+  ]
+}
+```
+
+`-y` は初回の `npx` 実行時に対話プロンプトで停止しないために付けています。
+
+### mcp-http-bridge
+
+`mcp-http-bridge` は MCP stdio フレームを受け取り、HTTP POST で MCP サーバーへそのまま転送する最小CLIです。
+
+```bash
+npx -y mcp-http-bridge --url http://127.0.0.1:8082
+```
+
+```bash
+npx -y mcp-http-bridge \
+  --url http://127.0.0.1:8082 \
+  --header "Authorization: Bearer your_token_here" \
+  --timeout 10000
+```
+
+サポートするオプション:
+
+- `--url`: 転送先の MCP HTTP エンドポイント
+- `--header`: 追加 HTTP ヘッダ。複数回指定可能
+- `--timeout`: HTTP タイムアウト（ミリ秒、既定 `30000`）
 
 ### Kiro
 
@@ -443,7 +505,7 @@ docker compose up -d --force-recreate github-mcp
 
 ## 運用ガードレール
 
-- トークンは`.env`ファイルで管理（gitignore済み）
+- トークンは`.env`ファイルやコンテナ環境変数で管理し、Claude Desktop 側には極力持ち込まない
 - コンテナは専用ネットワークで分離
 - ログは機密情報をマスキング
 - リソース制限: 512MB/1CPU

--- a/bin/mcp-http-bridge.js
+++ b/bin/mcp-http-bridge.js
@@ -9,7 +9,7 @@ function printUsage() {
   process.stdout.write(`mcp-http-bridge
 
 Usage:
-  mcp-http-bridge --url <http-url> [--header "Name: Value"]... [--timeout <ms>]
+  mcp-http-bridge --url <http-url> [--header "Name: Value"]... [--timeout <ms>] [--max-frame-size <bytes>]
   mcp-http-bridge --help
   mcp-http-bridge --version
 
@@ -17,6 +17,7 @@ Options:
   --url       MCP HTTP endpoint URL. Required.
   --header    Additional HTTP header. Repeatable. Example: --header "Authorization: Bearer token"
   --timeout   Request timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}
+  --max-frame-size   Maximum accepted MCP frame size in bytes. Default: 1048576
   --help      Show this help.
   --version   Show the package version.
 `);

--- a/bin/mcp-http-bridge.js
+++ b/bin/mcp-http-bridge.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const process = require('node:process');
+const { DEFAULT_TIMEOUT_MS, parseArgs, startBridge } = require('../src/mcp-http-bridge');
+
+function printUsage() {
+  process.stdout.write(`mcp-http-bridge
+
+Usage:
+  mcp-http-bridge --url <http-url> [--header "Name: Value"]... [--timeout <ms>]
+  mcp-http-bridge --help
+  mcp-http-bridge --version
+
+Options:
+  --url       MCP HTTP endpoint URL. Required.
+  --header    Additional HTTP header. Repeatable. Example: --header "Authorization: Bearer token"
+  --timeout   Request timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}
+  --help      Show this help.
+  --version   Show the package version.
+`);
+}
+
+function printVersion() {
+  const packageJson = require('../package.json');
+  process.stdout.write(`${packageJson.version}\n`);
+}
+
+function failCli(message) {
+  process.stderr.write(`[mcp-http-bridge] ${message}\n`);
+  process.exitCode = 1;
+}
+
+function logError(message, error) {
+  const suffix = error && error.message ? `: ${error.message}` : '';
+  process.stderr.write(`[mcp-http-bridge] ${message}${suffix}\n`);
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--help') || argv.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  if (argv.includes('--version') || argv.includes('-v')) {
+    printVersion();
+    return;
+  }
+
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    failCli(error.message);
+    printUsage();
+    return;
+  }
+
+  startBridge(options);
+  process.on('SIGINT', () => process.exit(0));
+  process.on('SIGTERM', () => process.exit(0));
+}
+
+main().catch((error) => {
+  logError('Fatal error', error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node --test --test-isolation=none tests/node/**/*.test.js"
+    "test": "node --test tests/node/**/*.test.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mcp-http-bridge",
+  "version": "0.1.0",
+  "description": "Minimal stdio-to-HTTP bridge for MCP servers",
+  "license": "MIT",
+  "bin": {
+    "mcp-http-bridge": "bin/mcp-http-bridge.js"
+  },
+  "files": [
+    "bin/",
+    "src/",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "test": "node --test --test-isolation=none tests/node/**/*.test.js"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node --test tests/node/**/*.test.js"
+    "test": "node --test tests/node/*.test.js"
   }
 }

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -28,10 +28,11 @@ IDE名:
   $0 --ide copilot-cli
 
 環境変数:
-  GITHUB_MCP_IMAGE              使用する Docker イメージ（claude-desktop では必須）
   GITHUB_MCP_SERVER_URL         HTTP 接続先 URL（未設定時は GITHUB_MCP_HTTP_PORT から生成）
   GITHUB_MCP_HTTP_PORT          HTTP ポート番号（デフォルト: 8082）
   GITHUB_PERSONAL_ACCESS_TOKEN  GitHub API 用の個人アクセストークン（fine-grained PAT 推奨。生成される各 IDE 設定で使用）
+  MCP_HTTP_BRIDGE_PACKAGE       Claude Desktop 用 bridge の npx パッケージ名（デフォルト: mcp-http-bridge）
+  MCP_HTTP_BRIDGE_TIMEOUT_MS    Claude Desktop 用 bridge の HTTP タイムアウト（デフォルト: 30000）
 EOF
     exit 1
 }
@@ -87,6 +88,8 @@ resolve_server_url() {
 }
 
 SERVER_URL="$(resolve_server_url)"
+BRIDGE_PACKAGE="${MCP_HTTP_BRIDGE_PACKAGE:-mcp-http-bridge}"
+BRIDGE_TIMEOUT_MS="${MCP_HTTP_BRIDGE_TIMEOUT_MS:-30000}"
 OUTPUT_DIR="${PROJECT_ROOT}/config/ide-configs/${IDE}"
 mkdir -p "${OUTPUT_DIR}"
 
@@ -119,64 +122,38 @@ EOF
         ;;
 
     claude-desktop)
-        # Claude Desktop は HTTP transport 非対応 (stdio のみ)
-        # docker run -i でバイナリを直接 stdio モードで起動する
-        # ※ Claude Desktop はシェル環境変数を引き継がないため、
-        #   env ブロックにトークンを平文で記載する必要がある（テンプレートではプレースホルダー）
-        CLAUDE_IMAGE="${GITHUB_MCP_IMAGE:-}"
-        if [[ -z "${CLAUDE_IMAGE}" ]]; then
-            cat >&2 <<'ERRMSG'
-エラー: Claude Desktop 用の GitHub MCP サーバーイメージが設定されていません。
-
-- カスタムイメージを利用する場合（推奨・PRRT対応）:
-    make build-custom
-    GITHUB_MCP_IMAGE=mcp-github-patched:latest ./scripts/generate-ide-config.sh --ide claude-desktop
-
-- 公式イメージを利用する場合:
-    GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:main ./scripts/generate-ide-config.sh --ide claude-desktop
-
-このスクリプトは、利用可能なイメージが明示的に指定されるまで Claude Desktop 用設定を生成しません。
-ERRMSG
-            exit 1
-        fi
         cat > "${OUTPUT_DIR}/claude_desktop_config.json" <<EOF
 {
   "mcpServers": {
     "${MCP_SERVER_KEY}": {
-      "command": "docker",
+      "command": "npx",
       "args": [
-        "run", "--rm", "-i",
-        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "${CLAUDE_IMAGE}",
-        "stdio"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "github_pat_your_token_here"
-      }
+        "-y",
+        "${BRIDGE_PACKAGE}",
+        "--url",
+        "${SERVER_URL}",
+        "--timeout",
+        "${BRIDGE_TIMEOUT_MS}"
+      ]
     }
   }
 }
 EOF
         echo "✅ Claude Desktop設定を生成しました: ${OUTPUT_DIR}/claude_desktop_config.json"
         echo ""
-        echo "⚠️  Claude Desktop は HTTP transport 非対応のため stdio (docker run -i) を使用します"
-        echo "   docker compose up は不要です。Claude Desktop が docker run を直接実行します。"
-        echo ""
-        echo "⚠️  トークンについて:"
-        echo "   Claude Desktop はシェル環境変数を引き継がないため、"
-        echo "   env.GITHUB_PERSONAL_ACCESS_TOKEN に実際のトークンを平文で記載する必要があります。"
-        echo "   生成されたファイルの 'github_pat_your_token_here' を実際のトークンに書き換えてください。"
-        echo "   ※ このファイルをリポジトリにコミットしないよう注意してください。"
+        echo "ℹ️  Claude Desktop は HTTP transport 非対応のため stdio bridge を使用します"
+        echo "   Claude Desktop -> npx ${BRIDGE_PACKAGE} -> ${SERVER_URL}"
         echo ""
         echo "📋 設定方法:"
-        echo "   1. カスタムイメージをビルド（未実施の場合）: make build-custom"
-        echo "   2. 生成されたファイルのトークンを書き換える"
+        echo "   1. Dockerコンテナを起動: docker compose up -d github-mcp"
+        echo "   2. 生成された設定を Claude Desktop設定ファイルにマージする"
         echo "      ${OUTPUT_DIR}/claude_desktop_config.json"
-        echo "   3. Claude Desktop設定ファイルに内容をマージする"
         echo "      macOS: ~/Library/Application Support/Claude/claude_desktop_config.json"
         echo "      Linux: ~/.config/Claude/claude_desktop_config.json"
         echo "      Windows: %APPDATA%\\Claude\\claude_desktop_config.json"
-        echo "   4. Claude Desktop を再起動"
+        echo "   3. Claude Desktop を再起動"
+        echo ""
+        echo "💡 追加ヘッダが必要な場合は args に --header \"Name: Value\" を追加してください"
         ;;
 
     kiro)

--- a/src/mcp-http-bridge.js
+++ b/src/mcp-http-bridge.js
@@ -1,0 +1,371 @@
+'use strict';
+
+const DEFAULT_TIMEOUT_MS = 30000;
+const JSON_RPC_VERSION = '2.0';
+const JSON_RPC_PARSE_ERROR = -32700;
+const JSON_RPC_SERVER_ERROR = -32000;
+
+function parseArgs(argv) {
+  const headers = {};
+  let url = '';
+  let timeoutMs = DEFAULT_TIMEOUT_MS;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    switch (arg) {
+      case '--url': {
+        const value = argv[index + 1];
+        if (!value) {
+          throw new Error('Missing value for --url');
+        }
+        url = value;
+        index += 1;
+        break;
+      }
+      case '--header': {
+        const value = argv[index + 1];
+        if (!value) {
+          throw new Error('Missing value for --header');
+        }
+
+        const separatorIndex = value.indexOf(':');
+        if (separatorIndex <= 0) {
+          throw new Error(`Invalid header format: ${value}`);
+        }
+
+        const name = value.slice(0, separatorIndex).trim();
+        const headerValue = value.slice(separatorIndex + 1).trim();
+
+        if (!name) {
+          throw new Error(`Invalid header name: ${value}`);
+        }
+
+        headers[name] = headerValue;
+        index += 1;
+        break;
+      }
+      case '--timeout': {
+        const value = argv[index + 1];
+        if (!value) {
+          throw new Error('Missing value for --timeout');
+        }
+
+        const parsed = Number.parseInt(value, 10);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          throw new Error(`Invalid timeout value: ${value}`);
+        }
+
+        timeoutMs = parsed;
+        index += 1;
+        break;
+      }
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!url) {
+    throw new Error('Missing required --url');
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (_error) {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+
+  if (!/^https?:$/.test(parsedUrl.protocol)) {
+    throw new Error(`Unsupported protocol: ${parsedUrl.protocol}`);
+  }
+
+  if (!hasHeader(headers, 'content-type')) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  if (!hasHeader(headers, 'accept')) {
+    headers.Accept = 'application/json';
+  }
+
+  return {
+    headers,
+    timeoutMs,
+    url: parsedUrl.toString()
+  };
+}
+
+function hasHeader(headers, targetName) {
+  return Object.keys(headers).some((name) => name.toLowerCase() === targetName.toLowerCase());
+}
+
+function frameMessage(payload) {
+  const content = Buffer.from(payload, 'utf8');
+  const header = Buffer.from(
+    `Content-Length: ${content.length}\r\nContent-Type: application/json\r\n\r\n`,
+    'utf8'
+  );
+  return Buffer.concat([header, content]);
+}
+
+function writeMessage(output, message) {
+  output.write(frameMessage(JSON.stringify(message)));
+}
+
+function createJsonRpcError(id, code, message, data) {
+  const error = {
+    jsonrpc: JSON_RPC_VERSION,
+    id: id ?? null,
+    error: {
+      code,
+      message
+    }
+  };
+
+  if (data !== undefined) {
+    error.error.data = data;
+  }
+
+  return error;
+}
+
+function findHeaderBoundary(buffer) {
+  const crlfIndex = buffer.indexOf('\r\n\r\n');
+  const lfIndex = buffer.indexOf('\n\n');
+
+  if (crlfIndex === -1 && lfIndex === -1) {
+    return null;
+  }
+
+  if (crlfIndex !== -1 && (lfIndex === -1 || crlfIndex < lfIndex)) {
+    return { headerEnd: crlfIndex, separatorLength: 4 };
+  }
+
+  return { headerEnd: lfIndex, separatorLength: 2 };
+}
+
+function parseHeaders(headerText) {
+  const headers = {};
+  const lines = headerText.split(/\r?\n/).filter(Boolean);
+
+  for (const line of lines) {
+    const separatorIndex = line.indexOf(':');
+    if (separatorIndex <= 0) {
+      throw new Error(`Malformed header line: ${line}`);
+    }
+
+    const name = line.slice(0, separatorIndex).trim().toLowerCase();
+    const value = line.slice(separatorIndex + 1).trim();
+    headers[name] = value;
+  }
+
+  if (!headers['content-length']) {
+    throw new Error('Missing Content-Length header');
+  }
+
+  const contentLength = Number.parseInt(headers['content-length'], 10);
+  if (!Number.isFinite(contentLength) || contentLength < 0) {
+    throw new Error(`Invalid Content-Length value: ${headers['content-length']}`);
+  }
+
+  return {
+    contentLength
+  };
+}
+
+function getRequestId(request) {
+  if (!request || typeof request !== 'object' || Array.isArray(request)) {
+    return undefined;
+  }
+
+  return Object.prototype.hasOwnProperty.call(request, 'id') ? request.id : undefined;
+}
+
+function truncate(text, maxLength = 500) {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, maxLength)}...`;
+}
+
+function logError(errorStream, message, error) {
+  const suffix = error && error.message ? `: ${error.message}` : '';
+  errorStream.write(`[mcp-http-bridge] ${message}${suffix}\n`);
+}
+
+async function forwardRequest(rawPayload, options) {
+  const response = await fetch(options.url, {
+    method: 'POST',
+    headers: options.headers,
+    body: rawPayload,
+    signal: AbortSignal.timeout(options.timeoutMs)
+  });
+
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.toLowerCase().startsWith('text/event-stream')) {
+    throw new Error('text/event-stream responses are not supported');
+  }
+
+  const responseText = await response.text();
+
+  if (!response.ok) {
+    const statusLabel = `HTTP ${response.status} ${response.statusText}`.trim();
+    const details = responseText.trim();
+    throw new Error(details ? `${statusLabel}: ${truncate(details)}` : statusLabel);
+  }
+
+  return responseText.trim() ? responseText : null;
+}
+
+function startBridge(options, io = {}) {
+  const input = io.input ?? process.stdin;
+  const output = io.output ?? process.stdout;
+  const error = io.error ?? process.stderr;
+
+  input.resume();
+  input.on('error', (streamError) => {
+    logError(error, 'stdin error', streamError);
+  });
+
+  let buffer = Buffer.alloc(0);
+  let expectedBodyLength = null;
+  const queue = [];
+  let processing = false;
+
+  const flushQueue = async () => {
+    if (processing) {
+      return;
+    }
+
+    processing = true;
+
+    try {
+      while (queue.length > 0) {
+        const rawBuffer = queue.shift();
+        const rawPayload = rawBuffer.toString('utf8');
+
+        let request;
+        try {
+          request = JSON.parse(rawPayload);
+        } catch (parseError) {
+          logError(error, 'Failed to parse JSON-RPC request', parseError);
+          writeMessage(
+            output,
+            createJsonRpcError(null, JSON_RPC_PARSE_ERROR, 'Failed to parse JSON-RPC request', parseError.message)
+          );
+          continue;
+        }
+
+        try {
+          const responseText = await forwardRequest(rawPayload, options);
+          if (responseText === null) {
+            continue;
+          }
+
+          let responsePayload;
+          try {
+            responsePayload = JSON.parse(responseText);
+          } catch (upstreamParseError) {
+            logError(error, 'Upstream returned invalid JSON', upstreamParseError);
+            const requestId = getRequestId(request);
+            if (requestId !== undefined) {
+              writeMessage(
+                output,
+                createJsonRpcError(
+                  requestId,
+                  JSON_RPC_SERVER_ERROR,
+                  'Upstream returned invalid JSON',
+                  truncate(responseText)
+                )
+              );
+            }
+            continue;
+          }
+
+          writeMessage(output, responsePayload);
+        } catch (requestError) {
+          logError(error, 'HTTP forwarding failed', requestError);
+          const requestId = getRequestId(request);
+          if (requestId !== undefined) {
+            writeMessage(
+              output,
+              createJsonRpcError(requestId, JSON_RPC_SERVER_ERROR, 'HTTP transport failed', requestError.message)
+            );
+          }
+        }
+      }
+    } finally {
+      processing = false;
+    }
+  };
+
+  const extractMessages = () => {
+    while (true) {
+      if (expectedBodyLength === null) {
+        const headerBoundary = findHeaderBoundary(buffer);
+        if (!headerBoundary) {
+          break;
+        }
+
+        const headerText = buffer.slice(0, headerBoundary.headerEnd).toString('utf8');
+        let parsedHeaders;
+        try {
+          parsedHeaders = parseHeaders(headerText);
+        } catch (frameError) {
+          logError(error, 'Invalid MCP stdio frame', frameError);
+          writeMessage(
+            output,
+            createJsonRpcError(null, JSON_RPC_PARSE_ERROR, 'Invalid MCP stdio frame', frameError.message)
+          );
+          buffer = Buffer.alloc(0);
+          expectedBodyLength = null;
+          break;
+        }
+
+        expectedBodyLength = parsedHeaders.contentLength;
+        buffer = buffer.slice(headerBoundary.headerEnd + headerBoundary.separatorLength);
+      }
+
+      if (buffer.length < expectedBodyLength) {
+        break;
+      }
+
+      queue.push(buffer.slice(0, expectedBodyLength));
+      buffer = buffer.slice(expectedBodyLength);
+      expectedBodyLength = null;
+    }
+
+    flushQueue().catch((unexpectedError) => {
+      logError(error, 'Unexpected bridge error', unexpectedError);
+    });
+  };
+
+  const onData = (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    extractMessages();
+  };
+
+  const onEnd = () => {
+    if (buffer.length > 0) {
+      logError(error, 'stdin closed with an incomplete MCP frame');
+    }
+  };
+
+  input.on('data', onData);
+  input.on('end', onEnd);
+
+  return {
+    close() {
+      input.off('data', onData);
+      input.off('end', onEnd);
+    }
+  };
+}
+
+module.exports = {
+  DEFAULT_TIMEOUT_MS,
+  parseArgs,
+  startBridge,
+  frameMessage
+};

--- a/src/mcp-http-bridge.js
+++ b/src/mcp-http-bridge.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const DEFAULT_TIMEOUT_MS = 30000;
+const DEFAULT_MAX_FRAME_SIZE_BYTES = 1024 * 1024;
 const JSON_RPC_VERSION = '2.0';
 const JSON_RPC_PARSE_ERROR = -32700;
 const JSON_RPC_SERVER_ERROR = -32000;
@@ -9,6 +10,7 @@ function parseArgs(argv) {
   const headers = {};
   let url = '';
   let timeoutMs = DEFAULT_TIMEOUT_MS;
+  let maxFrameSizeBytes = DEFAULT_MAX_FRAME_SIZE_BYTES;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -60,6 +62,21 @@ function parseArgs(argv) {
         index += 1;
         break;
       }
+      case '--max-frame-size': {
+        const value = argv[index + 1];
+        if (!value) {
+          throw new Error('Missing value for --max-frame-size');
+        }
+
+        const parsed = Number.parseInt(value, 10);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          throw new Error(`Invalid max frame size value: ${value}`);
+        }
+
+        maxFrameSizeBytes = parsed;
+        index += 1;
+        break;
+      }
       default:
         throw new Error(`Unknown argument: ${arg}`);
     }
@@ -90,6 +107,7 @@ function parseArgs(argv) {
 
   return {
     headers,
+    maxFrameSizeBytes,
     timeoutMs,
     url: parsedUrl.toString()
   };
@@ -144,7 +162,7 @@ function findHeaderBoundary(buffer) {
   return { headerEnd: lfIndex, separatorLength: 2 };
 }
 
-function parseHeaders(headerText) {
+function parseHeaders(headerText, maxFrameSizeBytes) {
   const headers = {};
   const lines = headerText.split(/\r?\n/).filter(Boolean);
 
@@ -166,6 +184,9 @@ function parseHeaders(headerText) {
   const contentLength = Number.parseInt(headers['content-length'], 10);
   if (!Number.isFinite(contentLength) || contentLength < 0) {
     throw new Error(`Invalid Content-Length value: ${headers['content-length']}`);
+  }
+  if (contentLength > maxFrameSizeBytes) {
+    throw new Error(`Content-Length exceeds max frame size: ${contentLength} > ${maxFrameSizeBytes}`);
   }
 
   return {
@@ -222,11 +243,15 @@ function startBridge(options, io = {}) {
   const input = io.input ?? process.stdin;
   const output = io.output ?? process.stdout;
   const error = io.error ?? process.stderr;
+  const maxFrameSizeBytes = Number.isFinite(options.maxFrameSizeBytes)
+    ? options.maxFrameSizeBytes
+    : DEFAULT_MAX_FRAME_SIZE_BYTES;
 
   input.resume();
-  input.on('error', (streamError) => {
+  const onInputError = (streamError) => {
     logError(error, 'stdin error', streamError);
-  });
+  };
+  input.on('error', onInputError);
 
   let buffer = Buffer.alloc(0);
   let expectedBodyLength = null;
@@ -311,7 +336,7 @@ function startBridge(options, io = {}) {
         const headerText = buffer.slice(0, headerBoundary.headerEnd).toString('utf8');
         let parsedHeaders;
         try {
-          parsedHeaders = parseHeaders(headerText);
+          parsedHeaders = parseHeaders(headerText, maxFrameSizeBytes);
         } catch (frameError) {
           logError(error, 'Invalid MCP stdio frame', frameError);
           writeMessage(
@@ -359,11 +384,16 @@ function startBridge(options, io = {}) {
     close() {
       input.off('data', onData);
       input.off('end', onEnd);
+      input.off('error', onInputError);
+      if (typeof input.pause === 'function') {
+        input.pause();
+      }
     }
   };
 }
 
 module.exports = {
+  DEFAULT_MAX_FRAME_SIZE_BYTES,
   DEFAULT_TIMEOUT_MS,
   parseArgs,
   startBridge,

--- a/tests/node/mcp-http-bridge.test.js
+++ b/tests/node/mcp-http-bridge.test.js
@@ -1,0 +1,184 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { once } = require('node:events');
+const test = require('node:test');
+const { PassThrough } = require('node:stream');
+const { frameMessage, startBridge } = require('../../src/mcp-http-bridge');
+
+function readFramedMessage(stream) {
+  return new Promise((resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+
+    const cleanup = () => {
+      stream.off('data', onData);
+      stream.off('error', onError);
+      stream.off('end', onEnd);
+    };
+
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onEnd = () => {
+      cleanup();
+      reject(new Error('Stream ended before a complete frame was received'));
+    };
+
+    const onData = (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      const headerBoundary = buffer.indexOf('\r\n\r\n');
+      if (headerBoundary === -1) {
+        return;
+      }
+
+      const headerText = buffer.slice(0, headerBoundary).toString('utf8');
+      const contentLengthLine = headerText
+        .split(/\r?\n/)
+        .find((line) => line.toLowerCase().startsWith('content-length:'));
+
+      if (!contentLengthLine) {
+        return;
+      }
+
+      const contentLength = Number.parseInt(contentLengthLine.split(':')[1].trim(), 10);
+      const frameLength = headerBoundary + 4 + contentLength;
+      if (buffer.length < frameLength) {
+        return;
+      }
+
+      const body = buffer.slice(headerBoundary + 4, frameLength).toString('utf8');
+      cleanup();
+      resolve(JSON.parse(body));
+    };
+
+    stream.on('data', onData);
+    stream.on('error', onError);
+    stream.on('end', onEnd);
+  });
+}
+
+async function startServer(handler) {
+  const server = http.createServer(handler);
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+
+  return {
+    server,
+    url: `http://127.0.0.1:${address.port}/mcp`
+  };
+}
+
+test('forwards a stdio JSON-RPC frame to HTTP and returns the upstream response', async () => {
+  const receivedRequests = [];
+  const { server, url } = await startServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+
+    receivedRequests.push(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { ok: true } }));
+  });
+
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const error = new PassThrough();
+  const bridge = startBridge(
+    {
+      url,
+      timeoutMs: 5000,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      }
+    },
+    { input, output, error }
+  );
+
+  try {
+    const responsePromise = readFramedMessage(output);
+
+    input.write(
+      frameMessage(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/list',
+          params: {}
+        })
+      )
+    );
+
+    const response = await responsePromise;
+    assert.deepEqual(response, { jsonrpc: '2.0', id: 1, result: { ok: true } });
+    assert.deepEqual(receivedRequests, [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {}
+      }
+    ]);
+  } finally {
+    bridge.close();
+    input.end();
+    output.end();
+    error.end();
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});
+
+test('returns a JSON-RPC error when the upstream HTTP request fails', async () => {
+  const { server, url } = await startServer(async (_req, res) => {
+    res.writeHead(502, { 'Content-Type': 'text/plain' });
+    res.end('bad gateway');
+  });
+
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const error = new PassThrough();
+  const bridge = startBridge(
+    {
+      url,
+      timeoutMs: 5000,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      }
+    },
+    { input, output, error }
+  );
+
+  try {
+    const responsePromise = readFramedMessage(output);
+
+    input.write(
+      frameMessage(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 7,
+          method: 'initialize',
+          params: {}
+        })
+      )
+    );
+
+    const response = await responsePromise;
+    assert.equal(response.jsonrpc, '2.0');
+    assert.equal(response.id, 7);
+    assert.equal(response.error.code, -32000);
+    assert.equal(response.error.message, 'HTTP transport failed');
+    assert.match(response.error.data, /HTTP 502 Bad Gateway/i);
+  } finally {
+    bridge.close();
+    input.end();
+    output.end();
+    error.end();
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});

--- a/tests/node/mcp-http-bridge.test.js
+++ b/tests/node/mcp-http-bridge.test.js
@@ -182,3 +182,67 @@ test('returns a JSON-RPC error when the upstream HTTP request fails', async () =
     await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
   }
 });
+
+test('close removes input listeners including error handler', () => {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const error = new PassThrough();
+
+  const bridge = startBridge(
+    {
+      url: 'http://127.0.0.1:65535/mcp',
+      timeoutMs: 100,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      }
+    },
+    { input, output, error }
+  );
+
+  assert.equal(input.listenerCount('error'), 1);
+  assert.equal(input.listenerCount('data'), 1);
+  assert.equal(input.listenerCount('end'), 1);
+
+  bridge.close();
+
+  assert.equal(input.listenerCount('error'), 0);
+  assert.equal(input.listenerCount('data'), 0);
+  assert.equal(input.listenerCount('end'), 0);
+  input.end();
+  output.end();
+  error.end();
+});
+
+test('returns parse error when frame exceeds max frame size', async () => {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const error = new PassThrough();
+  const bridge = startBridge(
+    {
+      url: 'http://127.0.0.1:65535/mcp',
+      timeoutMs: 100,
+      maxFrameSizeBytes: 8,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      }
+    },
+    { input, output, error }
+  );
+
+  try {
+    const responsePromise = readFramedMessage(output);
+    input.write(Buffer.from('Content-Length: 9\r\n\r\n123456789', 'utf8'));
+
+    const response = await responsePromise;
+    assert.equal(response.error.code, -32700);
+    assert.equal(response.error.message, 'Invalid MCP stdio frame');
+    assert.match(response.error.data, /exceeds max frame size/i);
+  } finally {
+    bridge.close();
+    input.end();
+    output.end();
+    error.end();
+  }
+});

--- a/tests/shell/test_scripts.bats
+++ b/tests/shell/test_scripts.bats
@@ -71,17 +71,20 @@ setup() {
     [ -f "${PROJECT_ROOT}/config/ide-configs/vscode/settings.json" ]
 }
 
-@test "generate-ide-config.sh: claude-desktop設定生成がGITHUB_MCP_IMAGE未設定でエラー終了する" {
+@test "generate-ide-config.sh: claude-desktop設定生成がGITHUB_MCP_IMAGE未設定でも動作する" {
     run env -u GITHUB_MCP_IMAGE "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "エラー" ]]
-}
-
-@test "generate-ide-config.sh: claude-desktop設定生成がGITHUB_MCP_IMAGE設定時に動作する" {
-    run env GITHUB_MCP_IMAGE=mcp-github-patched:latest "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Claude Desktop設定を生成しました" ]]
     [ -f "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json" ]
+}
+
+@test "generate-ide-config.sh: claude-desktop設定生成でbridge設定が反映される" {
+    run env MCP_HTTP_BRIDGE_PACKAGE=custom-bridge MCP_HTTP_BRIDGE_TIMEOUT_MS=12345 "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Claude Desktop設定を生成しました" ]]
+    [ -f "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json" ]
+    grep -q '"custom-bridge"' "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json"
+    grep -q '"12345"' "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json"
 }
 
 @test "generate-ide-config.sh: amazonq設定生成が動作する" {


### PR DESCRIPTION
## Summary
- add an `mcp-http-bridge` npm CLI that accepts MCP stdio frames and forwards them to an HTTP MCP endpoint
- switch Claude Desktop config generation from `docker run ... stdio` to `npx -y mcp-http-bridge --url ... --timeout ...`
- document the bridge-based Claude Desktop setup and add Node tests for success and HTTP error paths

## Testing
- `npm test`

## Follow-up
- WSL-based verification of `scripts/generate-ide-config.sh --ide claude-desktop` is still pending and will be continued separately