### PR TITLE
feat: add SSE (Streamable HTTP) support to mcp-http-bridge

### DIFF
--- a/scripts/verify-bridge-e2e.js
+++ b/scripts/verify-bridge-e2e.js
@@ -30,40 +30,50 @@ const body = JSON.stringify({
 });
 const frame = `Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`;
 
-let stdout = '';
+let stdout = Buffer.alloc(0);
 proc.stdout.on('data', (chunk) => {
-  stdout += chunk.toString();
+  // バッファとして蓄積し、バイト長でフレームを判定
+  stdout = Buffer.concat([stdout, chunk]);
 
   // ヘッダとボディを分割
   const headerEnd = stdout.indexOf('\r\n\r\n');
   if (headerEnd !== -1) {
-    const headers = stdout.slice(0, headerEnd);
-    const responseBody = stdout.slice(headerEnd + 4);
+    const headers = stdout.slice(0, headerEnd).toString();
+    const responseBodyBuf = stdout.slice(headerEnd + 4);
     const lenMatch = headers.match(/Content-Length:\s*(\d+)/i);
-    if (lenMatch && responseBody.length >= parseInt(lenMatch[1])) {
-      try {
-        const json = JSON.parse(responseBody);
-        if (json.error) {
-          if (json.error.code === -32000 || json.error.message.includes('Unauthorized')) {
-            console.log('✅ ブリッジ正常動作 (401 Unauthorized → JSON-RPC エラー変換確認)');
-            console.log(`   error.code: ${json.error.code}`);
-            console.log(`   error.message: ${json.error.message}`);
+    if (lenMatch) {
+      const contentLength = parseInt(lenMatch[1], 10);
+      if (responseBodyBuf.length >= contentLength) {
+        const bodyBuf = responseBodyBuf.slice(0, contentLength);
+        try {
+          const json = JSON.parse(bodyBuf.toString());
+          if (json.error) {
+            if (json.error.code === -32000 || json.error.message.includes('Unauthorized')) {
+              console.log('✅ ブリッジ正常動作 (401 Unauthorized → JSON-RPC エラー変換確認)');
+              console.log(`   error.code: ${json.error.code}`);
+              console.log(`   error.message: ${json.error.message}`);
+            } else {
+              console.log(`✅ ブリッジ正常動作 (JSON-RPC レスポンス受信)`);
+              console.log(`   Response: ${JSON.stringify(json).slice(0, 200)}`);
+            }
+          } else if (json.result) {
+            console.log('✅ ブリッジ正常動作 (initialize 成功)');
+            console.log(`   Server: ${JSON.stringify(json.result.serverInfo || {})}`);
           } else {
-            console.log(`✅ ブリッジ正常動作 (JSON-RPC レスポンス受信)`);
+            console.log('✅ ブリッジ正常動作 (レスポンス受信)');
             console.log(`   Response: ${JSON.stringify(json).slice(0, 200)}`);
           }
-        } else if (json.result) {
-          console.log('✅ ブリッジ正常動作 (initialize 成功)');
-          console.log(`   Server: ${JSON.stringify(json.result.serverInfo || {})}`);
-        } else {
-          console.log('✅ ブリッジ正常動作 (レスポンス受信)');
-          console.log(`   Response: ${JSON.stringify(json).slice(0, 200)}`);
+          proc.kill();
+          process.exit(0);
+        } catch (e) {
+          console.log('❌ JSON パース失敗 (ブリッジ出力が不正な JSON-RPC フレームの可能性)');
+          console.log(`   Error: ${e.message}`);
+          console.log(`   Headers: ${headers.replace(/\r\n/g, ' | ').slice(0, 200)}`);
+          console.log(`   Body   : ${bodyBuf.toString().slice(0, 200)}`);
+          proc.kill();
+          process.exit(1);
         }
-      } catch (e) {
-        console.log(`⚠️  JSON パース失敗: ${responseBody.slice(0, 100)}`);
       }
-      proc.kill();
-      process.exit(0);
     }
   }
 });

--- a/scripts/verify-bridge-e2e.js
+++ b/scripts/verify-bridge-e2e.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * mcp-http-bridge エンドツーエンド検証スクリプト
+ * ブリッジがstdioフレームを正しくHTTP転送するかテスト
+ */
+const { spawn } = require('child_process');
+const path = require('path');
+
+const BRIDGE_BIN = path.join(__dirname, '../bin/mcp-http-bridge.js');
+const MCP_URL = process.env.MCP_URL || 'http://127.0.0.1:8082';
+
+console.log(`\n🔍 ブリッジ E2E 検証`);
+console.log(`   ブリッジ: ${BRIDGE_BIN}`);
+console.log(`   接続先  : ${MCP_URL}\n`);
+
+const proc = spawn('node', [BRIDGE_BIN, '--url', MCP_URL], {
+  stdio: ['pipe', 'pipe', 'inherit']
+});
+
+// MCP stdio フレームを組み立て
+const body = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'e2e-verify', version: '0.0.1' }
+  }
+});
+const frame = `Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`;
+
+let stdout = '';
+proc.stdout.on('data', (chunk) => {
+  stdout += chunk.toString();
+
+  // ヘッダとボディを分割
+  const headerEnd = stdout.indexOf('\r\n\r\n');
+  if (headerEnd !== -1) {
+    const headers = stdout.slice(0, headerEnd);
+    const responseBody = stdout.slice(headerEnd + 4);
+    const lenMatch = headers.match(/Content-Length:\s*(\d+)/i);
+    if (lenMatch && responseBody.length >= parseInt(lenMatch[1])) {
+      try {
+        const json = JSON.parse(responseBody);
+        if (json.error) {
+          if (json.error.code === -32000 || json.error.message.includes('Unauthorized')) {
+            console.log('✅ ブリッジ正常動作 (401 Unauthorized → JSON-RPC エラー変換確認)');
+            console.log(`   error.code: ${json.error.code}`);
+            console.log(`   error.message: ${json.error.message}`);
+          } else {
+            console.log(`✅ ブリッジ正常動作 (JSON-RPC レスポンス受信)`);
+            console.log(`   Response: ${JSON.stringify(json).slice(0, 200)}`);
+          }
+        } else if (json.result) {
+          console.log('✅ ブリッジ正常動作 (initialize 成功)');
+          console.log(`   Server: ${JSON.stringify(json.result.serverInfo || {})}`);
+        } else {
+          console.log('✅ ブリッジ正常動作 (レスポンス受信)');
+          console.log(`   Response: ${JSON.stringify(json).slice(0, 200)}`);
+        }
+      } catch (e) {
+        console.log(`⚠️  JSON パース失敗: ${responseBody.slice(0, 100)}`);
+      }
+      proc.kill();
+      process.exit(0);
+    }
+  }
+});
+
+proc.on('error', (e) => {
+  console.error(`❌ ブリッジ起動エラー: ${e.message}`);
+  process.exit(1);
+});
+
+proc.on('exit', (code, signal) => {
+  if (signal !== 'SIGTERM') {
+    console.log(`   ブリッジ終了 (code=${code}, signal=${signal})`);
+  }
+});
+
+setTimeout(() => {
+  console.error('❌ タイムアウト (8秒)');
+  proc.kill();
+  process.exit(1);
+}, 8000);
+
+proc.stdin.write(frame);

--- a/scripts/verify-mcp-endpoint.js
+++ b/scripts/verify-mcp-endpoint.js
@@ -4,9 +4,12 @@
  * Usage: node scripts/verify-mcp-endpoint.js [url]
  */
 const http = require('http');
+const https = require('https');
 const url = process.argv[2] || 'http://127.0.0.1:8082';
 
 const parsed = new URL(url);
+const isHttps = parsed.protocol === 'https:';
+const transport = isHttps ? https : http;
 const body = JSON.stringify({
   jsonrpc: '2.0',
   id: 1,
@@ -20,8 +23,8 @@ const body = JSON.stringify({
 
 const options = {
   hostname: parsed.hostname,
-  port: parseInt(parsed.port) || 80,
-  path: parsed.pathname || '/',
+  port: parseInt(parsed.port) || (isHttps ? 443 : 80),
+  path: (parsed.pathname || '/') + (parsed.search || ''),
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
@@ -31,24 +34,50 @@ const options = {
 
 console.log(`\n🔍 MCP エンドポイント確認: ${url}`);
 
-const req = http.request(options, (res) => {
+const req = transport.request(options, (res) => {
   let data = '';
   res.on('data', (chunk) => { data += chunk; });
   res.on('end', () => {
-    console.log(`✅ HTTP Status: ${res.statusCode}`);
+    const status = res.statusCode || 0;
+
+    if (status < 200 || status >= 300) {
+      console.error(`❌ HTTP Status: ${status}`);
+      if (data) {
+        console.error(`   Response body (first 200 chars): ${data.slice(0, 200)}`);
+      }
+      process.exit(1);
+    }
+
+    console.log(`✅ HTTP Status: ${status}`);
     try {
       const json = JSON.parse(data);
-      if (json.result) {
+      const hasValidResult =
+        json &&
+        typeof json === 'object' &&
+        json.result &&
+        typeof json.result === 'object' &&
+        typeof json.result.protocolVersion === 'string';
+
+      if (hasValidResult) {
         console.log(`✅ MCP initialize 成功`);
         console.log(`   Server info: ${JSON.stringify(json.result.serverInfo || {})}`);
         console.log(`   protocolVersion: ${json.result.protocolVersion}`);
-      } else if (json.error) {
-        console.log(`⚠️  MCP error: ${JSON.stringify(json.error)}`);
+        process.exit(0);
+      } else if (json && typeof json === 'object' && json.error) {
+        console.error(`❌ MCP error: ${JSON.stringify(json.error)}`);
+        process.exit(1);
       } else {
-        console.log(`   Response: ${data.slice(0, 200)}`);
+        console.error('❌ レスポンスが有効な JSON-RPC initialize 結果ではありません。');
+        console.error(`   Response (first 200 chars): ${data.slice(0, 200)}`);
+        process.exit(1);
       }
-    } catch {
-      console.log(`   Response (raw): ${data.slice(0, 200)}`);
+    } catch (err) {
+      console.error('❌ レスポンスの JSON パースに失敗しました。');
+      if (err && err.message) {
+        console.error(`   Error: ${err.message}`);
+      }
+      console.error(`   Response (raw, first 200 chars): ${data.slice(0, 200)}`);
+      process.exit(1);
     }
   });
 });

--- a/scripts/verify-mcp-endpoint.js
+++ b/scripts/verify-mcp-endpoint.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * MCP エンドポイント疎通確認スクリプト
+ * Usage: node scripts/verify-mcp-endpoint.js [url]
+ */
+const http = require('http');
+const url = process.argv[2] || 'http://127.0.0.1:8082';
+
+const parsed = new URL(url);
+const body = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'verify-script', version: '0.0.1' }
+  }
+});
+
+const options = {
+  hostname: parsed.hostname,
+  port: parseInt(parsed.port) || 80,
+  path: parsed.pathname || '/',
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+  },
+};
+
+console.log(`\n🔍 MCP エンドポイント確認: ${url}`);
+
+const req = http.request(options, (res) => {
+  let data = '';
+  res.on('data', (chunk) => { data += chunk; });
+  res.on('end', () => {
+    console.log(`✅ HTTP Status: ${res.statusCode}`);
+    try {
+      const json = JSON.parse(data);
+      if (json.result) {
+        console.log(`✅ MCP initialize 成功`);
+        console.log(`   Server info: ${JSON.stringify(json.result.serverInfo || {})}`);
+        console.log(`   protocolVersion: ${json.result.protocolVersion}`);
+      } else if (json.error) {
+        console.log(`⚠️  MCP error: ${JSON.stringify(json.error)}`);
+      } else {
+        console.log(`   Response: ${data.slice(0, 200)}`);
+      }
+    } catch {
+      console.log(`   Response (raw): ${data.slice(0, 200)}`);
+    }
+  });
+});
+
+req.on('error', (e) => {
+  console.error(`❌ 接続エラー: ${e.message}`);
+  if (e.code === 'ECONNREFUSED') {
+    console.error('   コンテナが起動していない可能性があります。');
+    console.error('   make start-custom を実行してください。');
+  }
+  process.exit(1);
+});
+
+req.setTimeout(5000, () => {
+  console.error('❌ タイムアウト (5秒)');
+  req.destroy();
+  process.exit(1);
+});
+
+req.write(body);
+req.end();

--- a/src/mcp-http-bridge.js
+++ b/src/mcp-http-bridge.js
@@ -224,8 +224,19 @@ async function forwardRequest(rawPayload, options) {
   });
 
   const contentType = response.headers.get('content-type') || '';
+
   if (contentType.toLowerCase().startsWith('text/event-stream')) {
-    throw new Error('text/event-stream responses are not supported');
+    // SSE (Streamable HTTP transport): extract each `data:` line as a JSON-RPC message.
+    const text = await response.text();
+    const results = [];
+    for (const line of text.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('data:')) {
+        const data = trimmed.slice(5).trim();
+        if (data) results.push(data);
+      }
+    }
+    return results.length > 0 ? results : null;
   }
 
   const responseText = await response.text();
@@ -288,27 +299,32 @@ function startBridge(options, io = {}) {
             continue;
           }
 
-          let responsePayload;
-          try {
-            responsePayload = JSON.parse(responseText);
-          } catch (upstreamParseError) {
-            logError(error, 'Upstream returned invalid JSON', upstreamParseError);
-            const requestId = getRequestId(request);
-            if (requestId !== undefined) {
-              writeMessage(
-                output,
-                createJsonRpcError(
-                  requestId,
-                  JSON_RPC_SERVER_ERROR,
-                  'Upstream returned invalid JSON',
-                  truncate(responseText)
-                )
-              );
-            }
-            continue;
-          }
+          // SSE returns string[], plain HTTP returns string
+          const messages = Array.isArray(responseText) ? responseText : [responseText];
 
-          writeMessage(output, responsePayload);
+          for (const msg of messages) {
+            let responsePayload;
+            try {
+              responsePayload = JSON.parse(msg);
+            } catch (upstreamParseError) {
+              logError(error, 'Upstream returned invalid JSON', upstreamParseError);
+              const requestId = getRequestId(request);
+              if (requestId !== undefined) {
+                writeMessage(
+                  output,
+                  createJsonRpcError(
+                    requestId,
+                    JSON_RPC_SERVER_ERROR,
+                    'Upstream returned invalid JSON',
+                    truncate(msg)
+                  )
+                );
+              }
+              continue;
+            }
+
+            writeMessage(output, responsePayload);
+          }
         } catch (requestError) {
           logError(error, 'HTTP forwarding failed', requestError);
           const requestId = getRequestId(request);

--- a/src/mcp-http-bridge.js
+++ b/src/mcp-http-bridge.js
@@ -226,16 +226,60 @@ async function forwardRequest(rawPayload, options) {
   const contentType = response.headers.get('content-type') || '';
 
   if (contentType.toLowerCase().startsWith('text/event-stream')) {
-    // SSE (Streamable HTTP transport): extract each `data:` line as a JSON-RPC message.
-    const text = await response.text();
-    const results = [];
-    for (const line of text.split('\n')) {
-      const trimmed = line.trim();
-      if (trimmed.startsWith('data:')) {
-        const data = trimmed.slice(5).trim();
-        if (data) results.push(data);
-      }
+    if (!response.ok) {
+      const errorText = await response.text();
+      const statusLabel = `HTTP ${response.status} ${response.statusText}`.trim();
+      const details = errorText.trim();
+      throw new Error(details ? `${statusLabel}: ${truncate(details)}` : statusLabel);
     }
+
+    // SSE (Streamable HTTP transport): parse by event boundaries.
+    // An SSE event may contain multiple `data:` lines joined with `\n` until a blank-line delimiter.
+    const results = [];
+    let currentDataLines = [];
+
+    const processLine = (rawLine) => {
+      const line = rawLine.replace(/\r$/, '');
+      const trimmed = line.trim();
+      if (trimmed === '') {
+        if (currentDataLines.length > 0) {
+          results.push(currentDataLines.join('\n'));
+          currentDataLines = [];
+        }
+        return;
+      }
+      if (trimmed.startsWith(':')) return;
+      const match = line.match(/^\s*data:(.*)$/);
+      if (match) {
+        const value = match[1].startsWith(' ') ? match[1].slice(1) : match[1];
+        currentDataLines.push(value);
+      }
+    };
+
+    if (response.body && typeof response.body.getReader === 'function') {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let lineBuffer = '';
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        lineBuffer += decoder.decode(value, { stream: true });
+        const lines = lineBuffer.split('\n');
+        lineBuffer = lines.pop() || '';
+        for (const line of lines) processLine(line);
+      }
+      if (lineBuffer) processLine(lineBuffer);
+    } else {
+      // Fallback: no streaming reader available, buffer entire body.
+      const text = await response.text();
+      for (const line of text.split('\n')) processLine(line);
+    }
+
+    // Flush last event if stream did not end with a blank line.
+    if (currentDataLines.length > 0) {
+      results.push(currentDataLines.join('\n'));
+    }
+
     return results.length > 0 ? results : null;
   }
 

--- a/tests/node/mcp-http-bridge.test.js
+++ b/tests/node/mcp-http-bridge.test.js
@@ -214,6 +214,110 @@ test('close removes input listeners including error handler', () => {
   error.end();
 });
 
+test('forwards SSE (text/event-stream) response and emits multiple framed JSON-RPC messages', async () => {
+  const msg1 = JSON.stringify({ jsonrpc: '2.0', id: 1, result: { tool: 'first' } });
+  const msg2 = JSON.stringify({ jsonrpc: '2.0', id: 2, result: { tool: 'second' } });
+
+  const { server, url } = await startServer(async (_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+    res.write(`data: ${msg1}\n\n`);
+    res.write(`data: ${msg2}\n\n`);
+    res.end();
+  });
+
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const error = new PassThrough();
+  const bridge = startBridge(
+    {
+      url,
+      timeoutMs: 5000,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream'
+      }
+    },
+    { input, output, error }
+  );
+
+  try {
+    // Register listener before writing to ensure no data is missed.
+    const firstPromise = readFramedMessage(output);
+
+    input.write(
+      frameMessage(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'test' }
+        })
+      )
+    );
+
+    // Await first message; the bridge writes both messages synchronously so the
+    // second frame is buffered in the stream by the time we set up the next read.
+    assert.deepEqual(await firstPromise, { jsonrpc: '2.0', id: 1, result: { tool: 'first' } });
+    assert.deepEqual(await readFramedMessage(output), { jsonrpc: '2.0', id: 2, result: { tool: 'second' } });
+  } finally {
+    bridge.close();
+    input.end();
+    output.end();
+    error.end();
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});
+
+test('returns a JSON-RPC transport error when SSE upstream responds with non-2xx status', async () => {
+  const { server, url } = await startServer(async (_req, res) => {
+    res.writeHead(401, { 'Content-Type': 'text/event-stream' });
+    res.end('Unauthorized');
+  });
+
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const error = new PassThrough();
+  const bridge = startBridge(
+    {
+      url,
+      timeoutMs: 5000,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream'
+      }
+    },
+    { input, output, error }
+  );
+
+  try {
+    const responsePromise = readFramedMessage(output);
+
+    input.write(
+      frameMessage(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 9,
+          method: 'initialize',
+          params: {}
+        })
+      )
+    );
+
+    const response = await responsePromise;
+    assert.equal(response.jsonrpc, '2.0');
+    assert.equal(response.id, 9);
+    assert.equal(response.error.code, -32000);
+    assert.equal(response.error.message, 'HTTP transport failed');
+    assert.match(response.error.data, /HTTP 401/i);
+  } finally {
+    bridge.close();
+    input.end();
+    output.end();
+    error.end();
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});
+
 test('returns parse error when frame exceeds max frame size', async () => {
   const input = new PassThrough();
   const output = new PassThrough();


### PR DESCRIPTION
## 概要

`mcp-http-bridge` が MCP Streamable HTTP transport (SSE) に対応していなかった問題を解消します。

## 変更内容

### `src/mcp-http-bridge.js`

- **SSE レスポンスのサポート追加**: `text/event-stream` レスポンスに対してエラーをスローする代わりに、`data:` 行を JSON-RPC メッセージとして解析するように変更
- **複数メッセージ処理**: SSE の場合は `string[]`、通常 HTTP の場合は `string` を返すよう統一し、ループで順次処理

### `scripts/verify-bridge-e2e.js` (新規)

- ブリッジが stdio フレームを正しく HTTP 転送するかを検証するエンドツーエンドスクリプト
- `MCP_URL` 環境変数でターゲットを指定可能

### `scripts/verify-mcp-endpoint.js` (新規)

- MCP エンドポイントへの疎通確認スクリプト
- `initialize` リクエストを送信してレスポンスを検証

## 背景

MCP 仕様 2025-03-26 で Streamable HTTP transport (SSE) が追加されたことにより、SSE レスポンスを返すサーバーとの通信時にブリッジがエラーを返す問題が発生していました。本変更により SSE / 通常 HTTP の両方に対応します。

## テスト

- 既存のノードテスト・シェルテストは影響を受けません
- `scripts/verify-mcp-endpoint.js` で疎通確認、`scripts/verify-bridge-e2e.js` でブリッジの動作確認が可能です