### PR TITLE
fix(claude-desktop): WSL環境でWindowsラッパー(.cmd)を生成してnode直接起動に変更

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,17 +56,17 @@ make clean-all       # Full cleanup including images
 - **Port**: Default MCP HTTP port is `8082`. Override with `GITHUB_MCP_HTTP_PORT`.
 - **Image override**: Set `GITHUB_MCP_IMAGE` to swap the default container image.
 - **HTTP transport only in `main` tag**: Using a pinned release (e.g. `v0.30.3`) will silently fall back to stdio-only mode and break.
-- **Claude Desktop exception**: Requires the `mcp-http-bridge` Node.js process (`src/mcp-http-bridge.js`) to translate between stdio MCP and HTTP. All other IDEs connect directly to port 8082.
+- **Claude Desktop exception**: Requires the `mcp-http-bridge` Node.js process (`bin/mcp-http-bridge.js`) to translate between stdio MCP and HTTP. All other IDEs connect directly to port 8082.
 - **Distroless container**: The container has no shell. Health checks are done host-side via `scripts/health-check.sh`, not inside the container.
 - **Go patches**: Source patches for the custom build live in `patches/github/`. They are copied into the builder stage in `Dockerfile.github-mcp-server`. Add new `.go` files there and reference them in the Dockerfile.
-- **Documentation language**: Docs, Makefile help output, and user-facing messages are written in Japanese.
+- **Documentation language**: User-facing docs, Makefile help output, and messages are written in Japanese.
 - **MCP server key**: Always use `github-mcp-server-docker` as the server identifier in IDE configs.
 
 ## Key Files
 
 | File | Role |
 |------|------|
-| `src/mcp-http-bridge.js` | stdio↔HTTP bridge for Claude Desktop |
+| `bin/mcp-http-bridge.js` | stdio↔HTTP bridge for Claude Desktop |
 | `Dockerfile.github-mcp-server` | 3-stage build: OpenSSL refresh → Go builder (injects patches) → distroless runtime |
 | `patches/github/list_pr_review_threads.go` | Custom GraphQL tool: `list_pull_request_review_threads` |
 | `docker-compose.yml` | Primary compose (official image, resource limits, log rotation) |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,91 @@
+# Mcp-Docker Project Guidelines
+
+## Architecture
+
+```
+IDEs (VS Code / Cursor / Kiro / Amazon Q / Copilot CLI)
+  ↓ HTTP (port 8082)
+Docker: ghcr.io/github/github-mcp-server  ← official image (default)
+  ↓
+GitHub API (REST v3 + GraphQL v4)
+
+Claude Desktop (stdio only)
+  ↓ stdio
+mcp-http-bridge (Node.js)  →  HTTP (port 8082)  →  same container above
+```
+
+Two image modes:
+- **Official** (`docker-compose.yml`): pulls `ghcr.io/github/github-mcp-server:main` — use `make start`
+- **Custom/Patched** (`docker-compose.custom.yml`): builds from source with Go patches in `patches/github/` — use `make build-custom && make start-custom`
+
+## Build & Test Commands
+
+```bash
+# Setup (first run — creates .env, validates Docker)
+./scripts/setup.sh
+
+# Service lifecycle
+make start           # Pull + start (official image)
+make stop
+make restart
+make logs
+make status
+
+# Custom patched image
+make build-custom
+make start-custom
+
+# Testing
+npm test             # Node.js unit tests (tests/node/)
+make test-shell      # BATS shell tests (tests/shell/)
+make lint            # All linting
+make lint-shell      # Shell script lint (shellcheck)
+
+# Validation
+./scripts/health-check.sh      # Checks container + HTTP endpoint + GitHub API
+./scripts/generate-ide-config.sh  # Prints IDE-specific MCP configs (VS Code, Claude Desktop, Kiro, Codex…)
+
+# Cleanup
+make clean           # Containers + volumes (keeps images)
+make clean-all       # Full cleanup including images
+```
+
+## Conventions
+
+- **Environment-first auth**: `GITHUB_PERSONAL_ACCESS_TOKEN` env var always wins over `.env` file. Set both consistently to avoid confusion.
+- **Port**: Default MCP HTTP port is `8082`. Override with `GITHUB_MCP_HTTP_PORT`.
+- **Image override**: Set `GITHUB_MCP_IMAGE` to swap the default container image.
+- **HTTP transport only in `main` tag**: Using a pinned release (e.g. `v0.30.3`) will silently fall back to stdio-only mode and break.
+- **Claude Desktop exception**: Requires the `mcp-http-bridge` Node.js process (`src/mcp-http-bridge.js`) to translate between stdio MCP and HTTP. All other IDEs connect directly to port 8082.
+- **Distroless container**: The container has no shell. Health checks are done host-side via `scripts/health-check.sh`, not inside the container.
+- **Go patches**: Source patches for the custom build live in `patches/github/`. They are copied into the builder stage in `Dockerfile.github-mcp-server`. Add new `.go` files there and reference them in the Dockerfile.
+- **Documentation language**: Docs, Makefile help output, and user-facing messages are written in Japanese.
+- **MCP server key**: Always use `github-mcp-server-docker` as the server identifier in IDE configs.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/mcp-http-bridge.js` | stdio↔HTTP bridge for Claude Desktop |
+| `Dockerfile.github-mcp-server` | 3-stage build: OpenSSL refresh → Go builder (injects patches) → distroless runtime |
+| `patches/github/list_pr_review_threads.go` | Custom GraphQL tool: `list_pull_request_review_threads` |
+| `docker-compose.yml` | Primary compose (official image, resource limits, log rotation) |
+| `docker-compose.custom.yml` | Override file for custom patched builds |
+| `scripts/setup.sh` | First-run: creates `.env`, validates environment |
+| `scripts/generate-ide-config.sh` | Generates per-IDE MCP JSON/TOML configs |
+
+## Gotchas
+
+- **Frame size** (`mcp-http-bridge`): default max frame is 1 MB. Large GitHub responses need `--max-frame-size`.
+- **Timeout**: default HTTP timeout is 30 s. Complex operations may need `--timeout` tuning.
+- **GraphQL rate limits**: the custom `list_pull_request_review_threads` tool uses GraphQL (not REST), which has separate rate limits. Paginates at 100 threads/query.
+- **Stale config volume**: `./config/github-mcp` persists after `make clean`. Remove manually if reconfiguring from scratch.
+- **v2.1.0 breaking change**: transport changed from stdio to HTTP. Pre-2.1.0 IDE configs will fail.
+
+## Further Reading
+
+- [README.md](../README.md) — Quick start, token setup, per-IDE configuration steps
+- [SECURITY.md](../SECURITY.md) — Token scope requirements, fine-grained PAT guidance
+- [docs/SECURITY_PATCHES.md](../docs/SECURITY_PATCHES.md) — CVE mitigation, Trivy scanning, digest pinning
+- [docs/simplification/github-mcp-server-design.md](../docs/simplification/github-mcp-server-design.md) — Detailed system design
+- [CHANGELOG.md](../CHANGELOG.md) — Release history and breaking changes

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -31,7 +31,7 @@ IDE名:
   GITHUB_MCP_SERVER_URL         HTTP 接続先 URL（未設定時は GITHUB_MCP_HTTP_PORT から生成）
   GITHUB_MCP_HTTP_PORT          HTTP ポート番号（デフォルト: 8082）
   GITHUB_PERSONAL_ACCESS_TOKEN  GitHub API 用の個人アクセストークン（fine-grained PAT 推奨。生成される各 IDE 設定で使用）
-  MCP_HTTP_BRIDGE_PACKAGE       Claude Desktop 用 bridge の npx パッケージ名（デフォルト: mcp-http-bridge）
+  MCP_HTTP_BRIDGE_JS_PATH       Claude Desktop 用 bridge JS のパス（デフォルト: bin/mcp-http-bridge.js）
   MCP_HTTP_BRIDGE_TIMEOUT_MS    Claude Desktop 用 bridge の HTTP タイムアウト（デフォルト: 30000）
 EOF
     exit 1
@@ -88,7 +88,6 @@ resolve_server_url() {
 }
 
 SERVER_URL="$(resolve_server_url)"
-BRIDGE_PACKAGE="${MCP_HTTP_BRIDGE_PACKAGE:-mcp-http-bridge}"
 BRIDGE_TIMEOUT_MS="${MCP_HTTP_BRIDGE_TIMEOUT_MS:-30000}"
 OUTPUT_DIR="${PROJECT_ROOT}/config/ide-configs/${IDE}"
 mkdir -p "${OUTPUT_DIR}"
@@ -122,7 +121,7 @@ EOF
         ;;
 
     claude-desktop)
-        BRIDGE_JS_PATH="${PROJECT_ROOT}/bin/mcp-http-bridge.js"
+        BRIDGE_JS_PATH="${BRIDGE_JS_PATH:-${MCP_HTTP_BRIDGE_JS_PATH:-${PROJECT_ROOT}/bin/mcp-http-bridge.js}}"
 
         if command -v wslpath &>/dev/null; then
             # WSL環境: Windows用 .cmd ラッパーを生成し、node で直接起動する設定を出力
@@ -162,37 +161,38 @@ EOF
             echo "      Windows: %APPDATA%\\Claude\\claude_desktop_config.json"
             echo "   4. Claude Desktop を再起動"
         else
-            # macOS/Linux環境: node で直接起動する設定を出力
+            # macOS/Linux環境: start-bridge.sh を生成し、sh 経由で env 展開して起動する設定を出力
+            SH_FILE="${OUTPUT_DIR}/start-bridge.sh"
+            cat > "${SH_FILE}" <<EOF
+#!/bin/sh
+exec node "${BRIDGE_JS_PATH}" --url ${SERVER_URL} --timeout ${BRIDGE_TIMEOUT_MS} --header "Authorization: Bearer \${GITHUB_PERSONAL_ACCESS_TOKEN}"
+EOF
+            chmod +x "${SH_FILE}"
+
             cat > "${OUTPUT_DIR}/claude_desktop_config.json" <<EOF
 {
   "mcpServers": {
     "${MCP_SERVER_KEY}": {
-      "command": "node",
-      "args": [
-        "${BRIDGE_JS_PATH}",
-        "--url",
-        "${SERVER_URL}",
-        "--timeout",
-        "${BRIDGE_TIMEOUT_MS}",
-        "--header",
-        "Authorization: Bearer \${GITHUB_PERSONAL_ACCESS_TOKEN}"
-      ]
+      "command": "sh",
+      "args": ["${SH_FILE}"]
     }
   }
 }
 EOF
+            echo "✅ macOS/Linux用ブリッジラッパーを生成しました: ${SH_FILE}"
             echo "✅ Claude Desktop設定を生成しました: ${OUTPUT_DIR}/claude_desktop_config.json"
             echo ""
-            echo "ℹ️  Claude Desktop -> node bin/mcp-http-bridge.js -> ${SERVER_URL}"
+            echo "ℹ️  Claude Desktop -> sh start-bridge.sh -> node bin/mcp-http-bridge.js -> ${SERVER_URL}"
             echo "   PATは環境変数 GITHUB_PERSONAL_ACCESS_TOKEN から取得します"
             echo ""
             echo "📋 設定方法:"
             echo "   1. Dockerコンテナを起動: docker compose up -d github-mcp"
-            echo "   2. 生成された設定を Claude Desktop設定ファイルにマージする"
+            echo "   2. 環境変数 GITHUB_PERSONAL_ACCESS_TOKEN を設定"
+            echo "   3. 生成された設定を Claude Desktop設定ファイルにマージする"
             echo "      ${OUTPUT_DIR}/claude_desktop_config.json"
             echo "      macOS: ~/Library/Application Support/Claude/claude_desktop_config.json"
             echo "      Linux: ~/.config/Claude/claude_desktop_config.json"
-            echo "   3. Claude Desktop を再起動"
+            echo "   4. Claude Desktop を再起動"
         fi
         ;;
 

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -122,38 +122,78 @@ EOF
         ;;
 
     claude-desktop)
-        cat > "${OUTPUT_DIR}/claude_desktop_config.json" <<EOF
+        BRIDGE_JS_PATH="${PROJECT_ROOT}/bin/mcp-http-bridge.js"
+
+        if command -v wslpath &>/dev/null; then
+            # WSL環境: Windows用 .cmd ラッパーを生成し、node で直接起動する設定を出力
+            BRIDGE_JS_WIN="$(wslpath -w "${BRIDGE_JS_PATH}")"
+            CMD_FILE="${OUTPUT_DIR}/start-bridge.cmd"
+
+            cat > "${CMD_FILE}" <<EOF
+@echo off
+node "${BRIDGE_JS_WIN}" --url ${SERVER_URL} --timeout ${BRIDGE_TIMEOUT_MS} --header "Authorization: Bearer %GITHUB_PERSONAL_ACCESS_TOKEN%"
+EOF
+
+            CMD_WIN="$(wslpath -w "${CMD_FILE}")"
+            # JSON用にバックスラッシュをエスケープ
+            CMD_WIN_JSON="${CMD_WIN//\\/\\\\}"
+
+            cat > "${OUTPUT_DIR}/claude_desktop_config.json" <<EOF
 {
   "mcpServers": {
     "${MCP_SERVER_KEY}": {
-      "command": "npx",
+      "command": "cmd",
+      "args": ["/C", "${CMD_WIN_JSON}"]
+    }
+  }
+}
+EOF
+            echo "✅ Windows用ブリッジラッパーを生成しました: ${CMD_FILE}"
+            echo "✅ Claude Desktop設定を生成しました: ${OUTPUT_DIR}/claude_desktop_config.json"
+            echo ""
+            echo "ℹ️  Claude Desktop -> cmd /C start-bridge.cmd -> node bin/mcp-http-bridge.js -> ${SERVER_URL}"
+            echo "   PATは Windows環境変数 GITHUB_PERSONAL_ACCESS_TOKEN から取得します"
+            echo ""
+            echo "📋 設定方法:"
+            echo "   1. Dockerコンテナを起動"
+            echo "   2. Windows環境変数 GITHUB_PERSONAL_ACCESS_TOKEN を設定"
+            echo "   3. 生成された設定を Claude Desktop設定ファイルにマージする"
+            echo "      ${OUTPUT_DIR}/claude_desktop_config.json"
+            echo "      Windows: %APPDATA%\\Claude\\claude_desktop_config.json"
+            echo "   4. Claude Desktop を再起動"
+        else
+            # macOS/Linux環境: node で直接起動する設定を出力
+            cat > "${OUTPUT_DIR}/claude_desktop_config.json" <<EOF
+{
+  "mcpServers": {
+    "${MCP_SERVER_KEY}": {
+      "command": "node",
       "args": [
-        "-y",
-        "${BRIDGE_PACKAGE}",
+        "${BRIDGE_JS_PATH}",
         "--url",
         "${SERVER_URL}",
         "--timeout",
-        "${BRIDGE_TIMEOUT_MS}"
+        "${BRIDGE_TIMEOUT_MS}",
+        "--header",
+        "Authorization: Bearer \${GITHUB_PERSONAL_ACCESS_TOKEN}"
       ]
     }
   }
 }
 EOF
-        echo "✅ Claude Desktop設定を生成しました: ${OUTPUT_DIR}/claude_desktop_config.json"
-        echo ""
-        echo "ℹ️  Claude Desktop は HTTP transport 非対応のため stdio bridge を使用します"
-        echo "   Claude Desktop -> npx ${BRIDGE_PACKAGE} -> ${SERVER_URL}"
-        echo ""
-        echo "📋 設定方法:"
-        echo "   1. Dockerコンテナを起動: docker compose up -d github-mcp"
-        echo "   2. 生成された設定を Claude Desktop設定ファイルにマージする"
-        echo "      ${OUTPUT_DIR}/claude_desktop_config.json"
-        echo "      macOS: ~/Library/Application Support/Claude/claude_desktop_config.json"
-        echo "      Linux: ~/.config/Claude/claude_desktop_config.json"
-        echo "      Windows: %APPDATA%\\Claude\\claude_desktop_config.json"
-        echo "   3. Claude Desktop を再起動"
-        echo ""
-        echo "💡 追加ヘッダが必要な場合は args に --header \"Name: Value\" を追加してください"
+            echo "✅ Claude Desktop設定を生成しました: ${OUTPUT_DIR}/claude_desktop_config.json"
+            echo ""
+            echo "ℹ️  Claude Desktop -> node bin/mcp-http-bridge.js -> ${SERVER_URL}"
+            echo "   PATは環境変数 GITHUB_PERSONAL_ACCESS_TOKEN から取得します"
+            echo ""
+            echo "📋 設定方法:"
+            echo "   1. Dockerコンテナを起動: docker compose up -d github-mcp"
+            echo "   2. 生成された設定を Claude Desktop設定ファイルにマージする"
+            echo "      ${OUTPUT_DIR}/claude_desktop_config.json"
+            echo "      macOS: ~/Library/Application Support/Claude/claude_desktop_config.json"
+            echo "      Linux: ~/.config/Claude/claude_desktop_config.json"
+            echo "   3. Claude Desktop を再起動"
+        fi
         ;;
 
     kiro)

--- a/tests/shell/test_scripts.bats
+++ b/tests/shell/test_scripts.bats
@@ -79,11 +79,11 @@ setup() {
 }
 
 @test "generate-ide-config.sh: claude-desktop設定生成でbridge設定が反映される" {
-    run env MCP_HTTP_BRIDGE_PACKAGE=custom-bridge MCP_HTTP_BRIDGE_TIMEOUT_MS=12345 "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop
+    run env MCP_HTTP_BRIDGE_TIMEOUT_MS=12345 "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Claude Desktop設定を生成しました" ]]
     [ -f "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json" ]
-    grep -q '"custom-bridge"' "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json"
+    grep -q 'mcp-http-bridge.js' "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json"
     grep -q '"12345"' "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json"
 }
 

--- a/tests/shell/test_scripts.bats
+++ b/tests/shell/test_scripts.bats
@@ -83,8 +83,9 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Claude Desktop設定を生成しました" ]]
     [ -f "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json" ]
-    grep -q 'mcp-http-bridge.js' "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json"
-    grep -q '"12345"' "${PROJECT_ROOT}/config/ide-configs/claude-desktop/claude_desktop_config.json"
+    [ -f "${PROJECT_ROOT}/config/ide-configs/claude-desktop/start-bridge.sh" ]
+    grep -q 'mcp-http-bridge.js' "${PROJECT_ROOT}/config/ide-configs/claude-desktop/start-bridge.sh"
+    grep -q '12345' "${PROJECT_ROOT}/config/ide-configs/claude-desktop/start-bridge.sh"
 }
 
 @test "generate-ide-config.sh: amazonq設定生成が動作する" {


### PR DESCRIPTION
## 問題

Claude Desktop から MCP サーバーに接続できない問題が2つあった。

### 1. `npx -y mcp-http-bridge` が別パッケージを実行していた

npm に `mcp-http-bridge` という別パッケージが存在し、`npx -y mcp-http-bridge` がそちらを拾ってサイレント終了していた。このリポジトリのコードは一切実行されていなかった。

### 2. `Authorization` ヘッダーが付いていなかった

github-mcp-server の HTTP エンドポイントはクライアントリクエストにも `Authorization: Bearer <PAT>` を要求するが、claude-desktop 向けの設定にはヘッダー指定がなく、コンテナが常に 401 を返してタイムアウトしていた。

## 変更内容

`scripts/generate-ide-config.sh` の `claude-desktop` ケースを修正。

### WSL環境（Windows + Docker Desktop）

- `config/ide-configs/claude-desktop/start-bridge.cmd` を生成
  - Windows の `node` で `bin/mcp-http-bridge.js` を直接呼び出す
  - `%GITHUB_PERSONAL_ACCESS_TOKEN%` から PAT を取得して `Authorization` ヘッダーに設定
  - ローカルアドレス・パスは gitignore 対象の生成物にのみ含まれ、git には入らない
- `claude_desktop_config.json` は `cmd /C start-bridge.cmd` を起動する設定に変更

### macOS/Linux環境

- 従来の `npx` ではなく `node` + `bin/mcp-http-bridge.js` 直接指定に変更
- `Authorization` ヘッダーを引数に追加

## 接続の流れ（修正後）

```
Claude Desktop (Windows)
  ↓ stdio
cmd /C start-bridge.cmd
  ↓
node bin/mcp-http-bridge.js --header "Authorization: Bearer %GITHUB_PERSONAL_ACCESS_TOKEN%"
  ↓ HTTP POST + Authorization ヘッダー
http://127.0.0.1:8082 (Docker コンテナ)
  ↓
GitHub API
```

## 前提条件

- Windows ユーザー環境変数に `GITHUB_PERSONAL_ACCESS_TOKEN` が設定されていること
- `./scripts/generate-ide-config.sh --ide claude-desktop` を再実行して設定を再生成すること