### PR TITLE
chore: .gitattributesを追加してシェルスクリプトのLF改行を強制

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Force LF for all text files by default
+* text=auto eol=lf
+
+# Shell scripts must always use LF
+*.sh        text eol=lf
+*.bats      text eol=lf
+
+# Windows-specific scripts keep CRLF
+*.cmd       text eol=crlf
+*.bat       text eol=crlf
+*.ps1       text eol=crlf
+
+# Binary files
+*.png       binary
+*.jpg       binary
+*.gif       binary


### PR DESCRIPTION
## 問題

`core.autocrlf=true` のWindows環境では、`create_file` や VS Code のファイル編集でシェルスクリプトが CRLF 改行で保存される。その結果、WSL/Linux で実行すると `set: pipefail: invalid option name` エラーが発生して起動できない。

## 変更内容

`.gitattributes` を追加：

- `*.sh` / `*.bats` → `eol=lf`（強制LF）
- `*.cmd` / `*.bat` / `*.ps1` → `eol=crlf`（Windows用は維持）
- その他テキストファイル → `text=auto eol=lf`（自動判別、LF優先）

この設定により、`core.autocrlf=true` の環境でもチェックアウト時に `.gitattributes` が優先され、シェルスクリプトが常にLFで保存される。