### PR TITLE
Phase1: copilot-review-mcp OAuth Facade (ISSUE#28)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - SESSION_TTL_MIN=${SESSION_TTL_MIN:-10}
       - TOKEN_CACHE_TTL_MIN=${TOKEN_CACHE_TTL_MIN:-5}
     ports:
-      - "127.0.0.1:${COPILOT_REVIEW_MCP_PORT:-8083}:8083"
+      - "127.0.0.1:${COPILOT_REVIEW_MCP_PORT:-8083}:${COPILOT_REVIEW_MCP_PORT:-8083}"
 
     networks:
       - mcp-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,23 +61,15 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - SESSION_TTL_MIN=${SESSION_TTL_MIN:-10}
       - TOKEN_CACHE_TTL_MIN=${TOKEN_CACHE_TTL_MIN:-5}
-      - SQLITE_PATH=/data/copilot-review.db
-
-    volumes:
-      - copilot-review-data:/data
-
     ports:
       - "127.0.0.1:${COPILOT_REVIEW_MCP_PORT:-8083}:8083"
 
     networks:
       - mcp-network
 
+    # Note: distroless image has no shell/wget. Health is validated host-side.
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8083/health || exit 1"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
+      disable: true
 
     logging:
       driver: "json-file"
@@ -93,8 +85,6 @@ services:
 
 volumes:
   github-mcp-cache:
-    driver: local
-  copilot-review-data:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,57 @@ services:
           cpus: "0.5"
           memory: 256M
 
+  copilot-review-mcp:
+    build:
+      context: ./services/copilot-review-mcp
+      dockerfile: Dockerfile
+    image: copilot-review-mcp:local
+    container_name: copilot-review-mcp
+    restart: unless-stopped
+
+    environment:
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
+      - BASE_URL=${BASE_URL:-http://localhost:8083}
+      - GITHUB_OAUTH_SCOPES=${GITHUB_OAUTH_SCOPES:-repo,user}
+      - MCP_PORT=${COPILOT_REVIEW_MCP_PORT:-8083}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - SESSION_TTL_MIN=${SESSION_TTL_MIN:-10}
+      - TOKEN_CACHE_TTL_MIN=${TOKEN_CACHE_TTL_MIN:-5}
+      - SQLITE_PATH=/data/copilot-review.db
+
+    volumes:
+      - copilot-review-data:/data
+
+    ports:
+      - "127.0.0.1:${COPILOT_REVIEW_MCP_PORT:-8083}:8083"
+
+    networks:
+      - mcp-network
+
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8083/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+
 volumes:
   github-mcp-cache:
+    driver: local
+  copilot-review-data:
     driver: local
 
 networks:

--- a/services/copilot-review-mcp/Dockerfile
+++ b/services/copilot-review-mcp/Dockerfile
@@ -11,4 +11,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /out/copilot-review-mcp /copilot-review-mcp
 EXPOSE 8083
+# Trivy DS-0002: explicitly declare non-root user (distroless:nonroot UID=65532)
+USER nonroot:nonroot
 ENTRYPOINT ["/copilot-review-mcp"]

--- a/services/copilot-review-mcp/Dockerfile
+++ b/services/copilot-review-mcp/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.24-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
+    -o /out/copilot-review-mcp ./cmd/server
+
+# distroless: no shell, no package manager
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /out/copilot-review-mcp /copilot-review-mcp
+EXPOSE 8083
+ENTRYPOINT ["/copilot-review-mcp"]

--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/auth"
+	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
+)
+
+func main() {
+	cfg := loadConfig()
+
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: parseLogLevel(cfg.logLevel),
+	})))
+
+	oauthHandler := auth.NewHandler(auth.Config{
+		GitHubClientID:     cfg.githubClientID,
+		GitHubClientSecret: cfg.githubClientSecret,
+		BaseURL:            cfg.baseURL,
+		Scopes:             cfg.oauthScopes,
+		SessionTTL:         time.Duration(cfg.sessionTTLMin) * time.Minute,
+		CacheTTL:           time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
+	})
+
+	authMiddleware := middleware.Auth(oauthHandler)
+
+	mux := http.NewServeMux()
+
+	// OAuth façade endpoints (no auth required)
+	mux.HandleFunc("GET /.well-known/oauth-authorization-server", oauthHandler.Discovery)
+	mux.HandleFunc("GET /authorize", oauthHandler.Authorize)
+	mux.HandleFunc("GET /callback", oauthHandler.Callback)
+	mux.HandleFunc("POST /token", oauthHandler.Token)
+
+	// Health check (no auth required)
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"status":"ok"}`)
+	})
+
+	// MCP endpoints (auth required) — placeholder until Tools 1-3 are implemented
+	mcpMux := http.NewServeMux()
+	mcpMux.HandleFunc("GET /mcp", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"jsonrpc":"2.0","result":{"serverInfo":{"name":"copilot-review-mcp","version":"0.1.0"}}}`)
+	})
+	mux.Handle("/mcp", authMiddleware(mcpMux))
+	mux.Handle("/mcp/", authMiddleware(mcpMux))
+
+	addr := ":" + cfg.port
+	slog.Info("copilot-review-mcp starting", "addr", addr, "base_url", cfg.baseURL)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		slog.Error("server error", "err", err)
+		os.Exit(1)
+	}
+}
+
+type config struct {
+	githubClientID     string
+	githubClientSecret string
+	baseURL            string
+	oauthScopes        string
+	port               string
+	logLevel           string
+	sessionTTLMin      int
+	tokenCacheTTLMin   int
+}
+
+func loadConfig() config {
+	c := config{
+		githubClientID:     mustEnv("GITHUB_CLIENT_ID"),
+		githubClientSecret: mustEnv("GITHUB_CLIENT_SECRET"),
+		baseURL:            getEnv("BASE_URL", "http://localhost:8083"),
+		oauthScopes:        getEnv("GITHUB_OAUTH_SCOPES", "repo,user"),
+		port:               getEnv("MCP_PORT", "8083"),
+		logLevel:           getEnv("LOG_LEVEL", "info"),
+		sessionTTLMin:      getEnvInt("SESSION_TTL_MIN", 10),
+		tokenCacheTTLMin:   getEnvInt("TOKEN_CACHE_TTL_MIN", 5),
+	}
+	return c
+}
+
+func mustEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		slog.Error("required environment variable not set", "key", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func getEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func getEnvInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func parseLogLevel(level string) slog.Level {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -54,7 +54,15 @@ func main() {
 
 	addr := ":" + cfg.port
 	slog.Info("copilot-review-mcp starting", "addr", addr, "base_url", cfg.baseURL)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil {
 		slog.Error("server error", "err", err)
 		os.Exit(1)
 	}

--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -47,6 +47,7 @@ func main() {
 	// MCP endpoints (auth required) — placeholder until Tools 1-3 are implemented
 	mcpMux := http.NewServeMux()
 	mcpMux.HandleFunc("GET /mcp", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintln(w, `{"jsonrpc":"2.0","result":{"serverInfo":{"name":"copilot-review-mcp","version":"0.1.0"}}}`)
 	})
 	mux.Handle("/mcp", authMiddleware(mcpMux))

--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -40,6 +40,7 @@ func main() {
 
 	// Health check (no auth required)
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintln(w, `{"status":"ok"}`)
 	})
 

--- a/services/copilot-review-mcp/go.mod
+++ b/services/copilot-review-mcp/go.mod
@@ -1,0 +1,3 @@
+module github.com/scottlz0310/copilot-review-mcp
+
+go 1.26.1

--- a/services/copilot-review-mcp/go.mod
+++ b/services/copilot-review-mcp/go.mod
@@ -1,3 +1,3 @@
 module github.com/scottlz0310/copilot-review-mcp
 
-go 1.26.1
+go 1.24

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -13,6 +13,9 @@ import (
 	"log/slog"
 )
 
+// githubClient is a shared HTTP client with timeouts to avoid hanging requests.
+var githubClient = &http.Client{Timeout: 15 * time.Second}
+
 // Config holds OAuth façade configuration.
 type Config struct {
 	GitHubClientID     string
@@ -39,12 +42,12 @@ func NewHandler(cfg Config) *Handler {
 // Discovery returns RFC 8414 metadata.
 func (h *Handler) Discovery(w http.ResponseWriter, r *http.Request) {
 	doc := map[string]any{
-		"issuer":                                h.cfg.BaseURL,
-		"authorization_endpoint":               h.cfg.BaseURL + "/authorize",
-		"token_endpoint":                        h.cfg.BaseURL + "/token",
-		"response_types_supported":             []string{"code"},
-		"grant_types_supported":                []string{"authorization_code"},
-		"code_challenge_methods_supported":     []string{"S256"},
+		"issuer":                           h.cfg.BaseURL,
+		"authorization_endpoint":           h.cfg.BaseURL + "/authorize",
+		"token_endpoint":                   h.cfg.BaseURL + "/token",
+		"response_types_supported":         []string{"code"},
+		"grant_types_supported":            []string{"authorization_code"},
+		"code_challenge_methods_supported": []string{"S256"},
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(doc)
@@ -59,6 +62,13 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 
 	if state == "" || redirectURI == "" {
 		http.Error(w, "missing state or redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	// Validate redirect_uri: only http/https schemes to prevent open-redirect.
+	parsedRedirect, err := url.Parse(redirectURI)
+	if err != nil || (parsedRedirect.Scheme != "http" && parsedRedirect.Scheme != "https") {
+		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
 		return
 	}
 
@@ -83,6 +93,12 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	if code == "" || state == "" {
 		http.Error(w, "missing code or state", http.StatusBadRequest)
+		return
+	}
+
+	// Verify state maps to a live session BEFORE calling GitHub to avoid unnecessary outbound calls.
+	if !h.store.HasSession(state) {
+		http.Error(w, "invalid state", http.StatusBadRequest)
 		return
 	}
 
@@ -164,7 +180,7 @@ func (h *Handler) ValidateToken(ctx context.Context, token string) (string, erro
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := githubClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("GitHub API unreachable: %w", err)
 	}
@@ -174,7 +190,10 @@ func (h *Handler) ValidateToken(ctx context.Context, token string) (string, erro
 		return "", fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
 	}
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading GitHub user response: %w", err)
+	}
 	var user struct {
 		Login string `json:"login"`
 	}
@@ -201,18 +220,23 @@ func (h *Handler) exchangeGitHubCode(ctx context.Context, code string) (string, 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := githubClient.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return "", fmt.Errorf("GitHub OAuth returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
 
 	var result struct {
 		AccessToken string `json:"access_token"`
 		Error       string `json:"error"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", err
+		return "", fmt.Errorf("decoding GitHub OAuth response: %w", err)
 	}
 	if result.Error != "" {
 		return "", fmt.Errorf("GitHub OAuth error: %s", result.Error)

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -18,12 +18,13 @@ var githubClient = &http.Client{Timeout: 15 * time.Second}
 
 // Config holds OAuth façade configuration.
 type Config struct {
-	GitHubClientID     string
-	GitHubClientSecret string
-	BaseURL            string // e.g. http://localhost:8083
-	Scopes             string // e.g. "repo,user"
-	SessionTTL         time.Duration
-	CacheTTL           time.Duration
+	GitHubClientID       string
+	GitHubClientSecret   string
+	BaseURL              string // e.g. http://localhost:8083
+	Scopes               string // e.g. "repo,user"
+	SessionTTL           time.Duration
+	CacheTTL             time.Duration
+	AllowedRedirectHosts []string // allowlist of permitted redirect_uri hostnames; defaults to ["localhost","127.0.0.1"]
 }
 
 // UpstreamError represents a failure contacting an upstream service (e.g. GitHub API
@@ -45,6 +46,9 @@ type Handler struct {
 func NewHandler(cfg Config) *Handler {
 	// Normalize BaseURL: strip trailing slash to prevent double-slash in endpoint URLs.
 	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
+	if len(cfg.AllowedRedirectHosts) == 0 {
+		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1"}
+	}
 	return &Handler{
 		cfg:   cfg,
 		store: NewStore(cfg.SessionTTL, cfg.CacheTTL),
@@ -90,13 +94,17 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate redirect_uri: must be an absolute URL with http/https scheme,
-	// non-empty host, and no fragment (RFC 6749 §3.1.2).
+	// non-empty host, no fragment (RFC 6749 §3.1.2), and host in the allowlist.
 	parsedRedirect, err := url.Parse(redirectURI)
 	if err != nil ||
 		(parsedRedirect.Scheme != "http" && parsedRedirect.Scheme != "https") ||
 		parsedRedirect.Host == "" ||
 		parsedRedirect.Fragment != "" {
 		oauthError(w, "invalid_request", "invalid redirect_uri: must be absolute http/https URL without fragment", http.StatusBadRequest)
+		return
+	}
+	if !isAllowedRedirectHost(parsedRedirect.Hostname(), h.cfg.AllowedRedirectHosts) {
+		oauthError(w, "invalid_request", "redirect_uri host not permitted", http.StatusBadRequest)
 		return
 	}
 
@@ -130,14 +138,14 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	accessToken, err := h.exchangeGitHubCode(r.Context(), code)
+	accessToken, grantedScope, err := h.exchangeGitHubCode(r.Context(), code)
 	if err != nil {
 		slog.Error("GitHub token exchange failed", "err", err)
 		http.Error(w, "token exchange failed", http.StatusBadGateway)
 		return
 	}
 
-	internalCode, err := h.store.CompleteCallback(state, accessToken)
+	internalCode, err := h.store.CompleteCallback(state, accessToken, grantedScope)
 	if err != nil {
 		slog.Error("session completion failed", "err", err)
 		http.Error(w, "invalid state", http.StatusBadRequest)
@@ -182,22 +190,26 @@ func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 	redirectURI := r.FormValue("redirect_uri")
 	codeVerifier := r.FormValue("code_verifier")
 
-	token, err := h.store.ExchangeCode(code, redirectURI, codeVerifier)
+	token, grantedScope, err := h.store.ExchangeCode(code, redirectURI, codeVerifier)
 	if err != nil {
 		slog.Warn("token exchange rejected", "err", err)
 		oauthError(w, "invalid_grant", err.Error(), http.StatusBadRequest)
 		return
 	}
 
+	tokenResp := map[string]any{
+		"access_token": token,
+		"token_type":   "Bearer",
+	}
+	// RFC 6749 §5.1: include the scope actually granted by GitHub rather than the requested scope.
+	if grantedScope != "" {
+		tokenResp["scope"] = grantedScope
+	}
 	w.Header().Set("Content-Type", "application/json")
 	// RFC 6749 §5.1: token responses MUST NOT be cached.
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Pragma", "no-cache")
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"access_token": token,
-		"token_type":   "Bearer",
-		"scope":        h.cfg.Scopes,
-	})
+	_ = json.NewEncoder(w).Encode(tokenResp)
 }
 
 // ValidateToken checks the bearer token against GitHub API (with cache).
@@ -238,8 +250,8 @@ func (h *Handler) ValidateToken(ctx context.Context, token string) (string, erro
 	return user.Login, nil
 }
 
-// exchangeGitHubCode exchanges GitHub's authorization code for an access token.
-func (h *Handler) exchangeGitHubCode(ctx context.Context, code string) (string, error) {
+// exchangeGitHubCode exchanges GitHub's authorization code for an access token and scope.
+func (h *Handler) exchangeGitHubCode(ctx context.Context, code string) (string, string, error) {
 	form := url.Values{
 		"client_id":     {h.cfg.GitHubClientID},
 		"client_secret": {h.cfg.GitHubClientSecret},
@@ -255,29 +267,30 @@ func (h *Handler) exchangeGitHubCode(ctx context.Context, code string) (string, 
 
 	resp, err := githubClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		return "", fmt.Errorf("GitHub OAuth returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+		return "", "", fmt.Errorf("GitHub OAuth returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
 	}
 
 	var result struct {
 		AccessToken string `json:"access_token"`
+		Scope       string `json:"scope"`
 		Error       string `json:"error"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("decoding GitHub OAuth response: %w", err)
+		return "", "", fmt.Errorf("decoding GitHub OAuth response: %w", err)
 	}
 	if result.Error != "" {
-		return "", fmt.Errorf("GitHub OAuth error: %s", result.Error)
+		return "", "", fmt.Errorf("GitHub OAuth error: %s", result.Error)
 	}
 	if result.AccessToken == "" {
-		return "", fmt.Errorf("empty access_token from GitHub")
+		return "", "", fmt.Errorf("empty access_token from GitHub")
 	}
-	return result.AccessToken, nil
+	return result.AccessToken, result.Scope, nil
 }
 
 // lookupByCode is a helper for Callback to read redirect_uri without consuming the code.
@@ -285,6 +298,16 @@ func (s *Store) lookupByCode(code string) *Session {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.codes[code]
+}
+
+// isAllowedRedirectHost returns true when hostname is in the configured allowlist.
+func isAllowedRedirectHost(hostname string, allowed []string) bool {
+	for _, h := range allowed {
+		if h == hostname {
+			return true
+		}
+	}
+	return false
 }
 
 // oauthError writes an RFC 6749-compliant JSON error response.

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -33,6 +33,8 @@ type Handler struct {
 }
 
 func NewHandler(cfg Config) *Handler {
+	// Normalize BaseURL: strip trailing slash to prevent double-slash in endpoint URLs.
+	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
 	return &Handler{
 		cfg:   cfg,
 		store: NewStore(cfg.SessionTTL, cfg.CacheTTL),
@@ -77,10 +79,14 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate redirect_uri: only http/https schemes to prevent open-redirect.
+	// Validate redirect_uri: must be an absolute URL with http/https scheme,
+	// non-empty host, and no fragment (RFC 6749 §3.1.2).
 	parsedRedirect, err := url.Parse(redirectURI)
-	if err != nil || (parsedRedirect.Scheme != "http" && parsedRedirect.Scheme != "https") {
-		oauthError(w, "invalid_request", "invalid redirect_uri", http.StatusBadRequest)
+	if err != nil ||
+		(parsedRedirect.Scheme != "http" && parsedRedirect.Scheme != "https") ||
+		parsedRedirect.Host == "" ||
+		parsedRedirect.Fragment != "" {
+		oauthError(w, "invalid_request", "invalid redirect_uri: must be absolute http/https URL without fragment", http.StatusBadRequest)
 		return
 	}
 
@@ -153,12 +159,12 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 // registry is needed for phase 1. Multi-client support can be added in a future iteration.
 func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+		oauthError(w, "invalid_request", "malformed request body", http.StatusBadRequest)
 		return
 	}
 	grantType := r.FormValue("grant_type")
 	if grantType != "authorization_code" {
-		http.Error(w, "unsupported grant_type", http.StatusBadRequest)
+		oauthError(w, "unsupported_grant_type", "only authorization_code is supported", http.StatusBadRequest)
 		return
 	}
 
@@ -169,16 +175,14 @@ func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 	token, err := h.store.ExchangeCode(code, redirectURI, codeVerifier)
 	if err != nil {
 		slog.Warn("token exchange rejected", "err", err)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"error":             "invalid_grant",
-			"error_description": err.Error(),
-		})
+		oauthError(w, "invalid_grant", err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	// RFC 6749 §5.1: token responses MUST NOT be cached.
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"access_token": token,
 		"token_type":   "Bearer",
@@ -273,6 +277,8 @@ func (s *Store) lookupByCode(code string) *Session {
 // oauthError writes an RFC 6749-compliant JSON error response.
 func oauthError(w http.ResponseWriter, code, description string, status int) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]string{
 		"error":             code,

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -59,16 +59,28 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 	state := q.Get("state")
 	redirectURI := q.Get("redirect_uri")
 	codeChallenge := q.Get("code_challenge")
+	responseType := q.Get("response_type")
+	codeChallengeMethod := q.Get("code_challenge_method")
 
+	// Validate required OAuth 2.0 parameters.
+	if responseType != "code" {
+		oauthError(w, "unsupported_response_type", "response_type must be 'code'", http.StatusBadRequest)
+		return
+	}
 	if state == "" || redirectURI == "" {
-		http.Error(w, "missing state or redirect_uri", http.StatusBadRequest)
+		oauthError(w, "invalid_request", "missing state or redirect_uri", http.StatusBadRequest)
+		return
+	}
+	// If code_challenge is provided, enforce S256 method.
+	if codeChallenge != "" && codeChallengeMethod != "S256" {
+		oauthError(w, "invalid_request", "code_challenge_method must be S256", http.StatusBadRequest)
 		return
 	}
 
 	// Validate redirect_uri: only http/https schemes to prevent open-redirect.
 	parsedRedirect, err := url.Parse(redirectURI)
 	if err != nil || (parsedRedirect.Scheme != "http" && parsedRedirect.Scheme != "https") {
-		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+		oauthError(w, "invalid_request", "invalid redirect_uri", http.StatusBadRequest)
 		return
 	}
 
@@ -135,6 +147,10 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 }
 
 // Token handles the authorization_code grant and returns the access token.
+// Note on client_id: this façade authenticates exclusively via GitHub OAuth App (single-client).
+// The client_id presented by MCP clients is the GitHub OAuth App Client ID, which is
+// validated by GitHub during the code-exchange step. No separate façade-level client
+// registry is needed for phase 1. Multi-client support can be added in a future iteration.
 func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
@@ -252,4 +268,14 @@ func (s *Store) lookupByCode(code string) *Session {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.codes[code]
+}
+
+// oauthError writes an RFC 6749-compliant JSON error response.
+func oauthError(w http.ResponseWriter, code, description string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             code,
+		"error_description": description,
+	})
 }

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -26,6 +26,16 @@ type Config struct {
 	CacheTTL           time.Duration
 }
 
+// UpstreamError represents a failure contacting an upstream service (e.g. GitHub API
+// network error or 5xx response). The auth middleware uses this to return 503 instead of 401.
+type UpstreamError struct {
+	err error
+}
+
+func (e *UpstreamError) Error() string         { return e.err.Error() }
+func (e *UpstreamError) Unwrap() error         { return e.err }
+func (e *UpstreamError) IsUpstreamError() bool { return true }
+
 // Handler implements the OAuth façade endpoints.
 type Handler struct {
 	cfg   Config
@@ -202,17 +212,20 @@ func (h *Handler) ValidateToken(ctx context.Context, token string) (string, erro
 
 	resp, err := githubClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("GitHub API unreachable: %w", err)
+		return "", &UpstreamError{err: fmt.Errorf("GitHub API unreachable: %w", err)}
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode >= 500 {
+			return "", &UpstreamError{err: fmt.Errorf("GitHub API returned %d", resp.StatusCode)}
+		}
 		return "", fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("reading GitHub user response: %w", err)
+		return "", &UpstreamError{err: fmt.Errorf("reading GitHub user response: %w", err)}
 	}
 	var user struct {
 		Login string `json:"login"`

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -1,0 +1,231 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"log/slog"
+)
+
+// Config holds OAuth façade configuration.
+type Config struct {
+	GitHubClientID     string
+	GitHubClientSecret string
+	BaseURL            string // e.g. http://localhost:8083
+	Scopes             string // e.g. "repo,user"
+	SessionTTL         time.Duration
+	CacheTTL           time.Duration
+}
+
+// Handler implements the OAuth façade endpoints.
+type Handler struct {
+	cfg   Config
+	store *Store
+}
+
+func NewHandler(cfg Config) *Handler {
+	return &Handler{
+		cfg:   cfg,
+		store: NewStore(cfg.SessionTTL, cfg.CacheTTL),
+	}
+}
+
+// Discovery returns RFC 8414 metadata.
+func (h *Handler) Discovery(w http.ResponseWriter, r *http.Request) {
+	doc := map[string]any{
+		"issuer":                                h.cfg.BaseURL,
+		"authorization_endpoint":               h.cfg.BaseURL + "/authorize",
+		"token_endpoint":                        h.cfg.BaseURL + "/token",
+		"response_types_supported":             []string{"code"},
+		"grant_types_supported":                []string{"authorization_code"},
+		"code_challenge_methods_supported":     []string{"S256"},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// Authorize redirects the MCP client to GitHub OAuth.
+func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	state := q.Get("state")
+	redirectURI := q.Get("redirect_uri")
+	codeChallenge := q.Get("code_challenge")
+
+	if state == "" || redirectURI == "" {
+		http.Error(w, "missing state or redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	h.store.SaveSession(state, redirectURI, codeChallenge)
+
+	ghURL, _ := url.Parse("https://github.com/login/oauth/authorize")
+	ghq := ghURL.Query()
+	ghq.Set("client_id", h.cfg.GitHubClientID)
+	ghq.Set("redirect_uri", h.cfg.BaseURL+"/callback")
+	ghq.Set("state", state)
+	ghq.Set("scope", h.cfg.Scopes)
+	ghURL.RawQuery = ghq.Encode()
+
+	http.Redirect(w, r, ghURL.String(), http.StatusFound)
+}
+
+// Callback receives GitHub's authorization code and exchanges it for an access token.
+func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	code := q.Get("code")
+	state := q.Get("state")
+
+	if code == "" || state == "" {
+		http.Error(w, "missing code or state", http.StatusBadRequest)
+		return
+	}
+
+	accessToken, err := h.exchangeGitHubCode(r.Context(), code)
+	if err != nil {
+		slog.Error("GitHub token exchange failed", "err", err)
+		http.Error(w, "token exchange failed", http.StatusBadGateway)
+		return
+	}
+
+	internalCode, err := h.store.CompleteCallback(state, accessToken)
+	if err != nil {
+		slog.Error("session completion failed", "err", err)
+		http.Error(w, "invalid state", http.StatusBadRequest)
+		return
+	}
+
+	// Retrieve redirect_uri from session to redirect back to MCP client.
+	// We need to look it up before ExchangeCode consumes it.
+	// Re-read via a separate lookup (session still exists at this point).
+	sess := h.store.lookupByCode(internalCode)
+	if sess == nil {
+		http.Error(w, "session lost", http.StatusInternalServerError)
+		return
+	}
+
+	redirect, _ := url.Parse(sess.RedirectURI)
+	rq := redirect.Query()
+	rq.Set("code", internalCode)
+	rq.Set("state", state)
+	redirect.RawQuery = rq.Encode()
+
+	http.Redirect(w, r, redirect.String(), http.StatusFound)
+}
+
+// Token handles the authorization_code grant and returns the access token.
+func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	grantType := r.FormValue("grant_type")
+	if grantType != "authorization_code" {
+		http.Error(w, "unsupported grant_type", http.StatusBadRequest)
+		return
+	}
+
+	code := r.FormValue("code")
+	redirectURI := r.FormValue("redirect_uri")
+	codeVerifier := r.FormValue("code_verifier")
+
+	token, err := h.store.ExchangeCode(code, redirectURI, codeVerifier)
+	if err != nil {
+		slog.Warn("token exchange rejected", "err", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": err.Error(),
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"access_token": token,
+		"token_type":   "Bearer",
+		"scope":        h.cfg.Scopes,
+	})
+}
+
+// ValidateToken checks the bearer token against GitHub API (with cache).
+func (h *Handler) ValidateToken(ctx context.Context, token string) (string, error) {
+	if login, ok := h.store.LookupToken(token); ok {
+		return login, nil
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GitHub API unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var user struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal(body, &user); err != nil || user.Login == "" {
+		return "", fmt.Errorf("unexpected GitHub user response")
+	}
+
+	h.store.CacheToken(token, user.Login)
+	return user.Login, nil
+}
+
+// exchangeGitHubCode exchanges GitHub's authorization code for an access token.
+func (h *Handler) exchangeGitHubCode(ctx context.Context, code string) (string, error) {
+	form := url.Values{
+		"client_id":     {h.cfg.GitHubClientID},
+		"client_secret": {h.cfg.GitHubClientSecret},
+		"code":          {code},
+		"redirect_uri":  {h.cfg.BaseURL + "/callback"},
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://github.com/login/oauth/access_token",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if result.Error != "" {
+		return "", fmt.Errorf("GitHub OAuth error: %s", result.Error)
+	}
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("empty access_token from GitHub")
+	}
+	return result.AccessToken, nil
+}
+
+// lookupByCode is a helper for Callback to read redirect_uri without consuming the code.
+func (s *Store) lookupByCode(code string) *Session {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.codes[code]
+}

--- a/services/copilot-review-mcp/internal/auth/session.go
+++ b/services/copilot-review-mcp/internal/auth/session.go
@@ -14,7 +14,7 @@ type Session struct {
 	State         string
 	RedirectURI   string
 	CodeChallenge string
-	InternalCode  string // UUID issued at /callback
+	InternalCode  string // base64url-encoded 32-byte random string, issued at /callback
 	AccessToken   string // GitHub access_token stored at /callback
 	ExpiresAt     time.Time
 }

--- a/services/copilot-review-mcp/internal/auth/session.go
+++ b/services/copilot-review-mcp/internal/auth/session.go
@@ -1,0 +1,169 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Session holds OAuth flow state between /authorize and /token.
+type Session struct {
+	State         string
+	RedirectURI   string
+	CodeChallenge string
+	InternalCode  string // UUID issued at /callback
+	AccessToken   string // GitHub access_token stored at /callback
+	ExpiresAt     time.Time
+}
+
+// TokenCache caches validated GitHub tokens to reduce API calls.
+type TokenCache struct {
+	mu      sync.RWMutex
+	entries map[string]tokenEntry
+}
+
+type tokenEntry struct {
+	login     string
+	expiresAt time.Time
+}
+
+type Store struct {
+	mu       sync.RWMutex
+	sessions map[string]*Session // keyed by state
+	codes    map[string]*Session // keyed by internal code
+	ttl      time.Duration
+
+	cache    *TokenCache
+	cacheTTL time.Duration
+}
+
+func NewStore(sessionTTL, cacheTTL time.Duration) *Store {
+	s := &Store{
+		sessions: make(map[string]*Session),
+		codes:    make(map[string]*Session),
+		ttl:      sessionTTL,
+		cache:    &TokenCache{entries: make(map[string]tokenEntry)},
+		cacheTTL: cacheTTL,
+	}
+	go s.janitor()
+	return s
+}
+
+// SaveSession stores a new OAuth session keyed by state.
+func (s *Store) SaveSession(state, redirectURI, codeChallenge string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions[state] = &Session{
+		State:         state,
+		RedirectURI:   redirectURI,
+		CodeChallenge: codeChallenge,
+		ExpiresAt:     time.Now().Add(s.ttl),
+	}
+}
+
+// CompleteCallback attaches an internal code + access token to the session.
+func (s *Store) CompleteCallback(state, accessToken string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[state]
+	if !ok || time.Now().After(sess.ExpiresAt) {
+		delete(s.sessions, state)
+		return "", fmt.Errorf("session not found or expired for state %q", state)
+	}
+
+	code := generateCode()
+	sess.InternalCode = code
+	sess.AccessToken = accessToken
+	s.codes[code] = sess
+	return code, nil
+}
+
+// ExchangeCode validates PKCE and returns the access token for the given code.
+func (s *Store) ExchangeCode(code, redirectURI, codeVerifier string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.codes[code]
+	if !ok || time.Now().After(sess.ExpiresAt) {
+		delete(s.codes, code)
+		return "", fmt.Errorf("code not found or expired")
+	}
+	if sess.RedirectURI != redirectURI {
+		return "", fmt.Errorf("redirect_uri mismatch")
+	}
+	if sess.CodeChallenge != "" {
+		if err := verifyPKCE(codeVerifier, sess.CodeChallenge); err != nil {
+			return "", err
+		}
+	}
+
+	token := sess.AccessToken
+	// one-time use
+	delete(s.codes, code)
+	delete(s.sessions, sess.State)
+	return token, nil
+}
+
+// CacheToken stores a validated login for a token.
+func (s *Store) CacheToken(token, login string) {
+	s.cache.mu.Lock()
+	defer s.cache.mu.Unlock()
+	s.cache.entries[token] = tokenEntry{login: login, expiresAt: time.Now().Add(s.cacheTTL)}
+}
+
+// LookupToken returns (login, true) if token is cached and not expired.
+func (s *Store) LookupToken(token string) (string, bool) {
+	s.cache.mu.RLock()
+	defer s.cache.mu.RUnlock()
+	e, ok := s.cache.entries[token]
+	if !ok || time.Now().After(e.expiresAt) {
+		return "", false
+	}
+	return e.login, true
+}
+
+func (s *Store) janitor() {
+	ticker := time.NewTicker(time.Minute)
+	for range ticker.C {
+		now := time.Now()
+		s.mu.Lock()
+		for k, v := range s.sessions {
+			if now.After(v.ExpiresAt) {
+				delete(s.sessions, k)
+			}
+		}
+		for k, v := range s.codes {
+			if now.After(v.ExpiresAt) {
+				delete(s.codes, k)
+			}
+		}
+		s.mu.Unlock()
+
+		s.cache.mu.Lock()
+		for k, v := range s.cache.entries {
+			if now.After(v.expiresAt) {
+				delete(s.cache.entries, k)
+			}
+		}
+		s.cache.mu.Unlock()
+	}
+}
+
+func generateCode() string {
+	b := make([]byte, 32)
+	_, _ = rand.Read(b)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func verifyPKCE(verifier, challenge string) error {
+	h := sha256.Sum256([]byte(verifier))
+	got := base64.RawURLEncoding.EncodeToString(h[:])
+	if got != challenge {
+		return fmt.Errorf("PKCE verification failed")
+	}
+	return nil
+}

--- a/services/copilot-review-mcp/internal/auth/session.go
+++ b/services/copilot-review-mcp/internal/auth/session.go
@@ -16,6 +16,7 @@ type Session struct {
 	CodeChallenge string
 	InternalCode  string // base64url-encoded 32-byte random string, issued at /callback
 	AccessToken   string // GitHub access_token stored at /callback
+	Scope         string // OAuth scope actually granted by GitHub
 	ExpiresAt     time.Time
 }
 
@@ -73,7 +74,7 @@ func (s *Store) HasSession(state string) bool {
 }
 
 // CompleteCallback attaches an internal code + access token to the session.
-func (s *Store) CompleteCallback(state, accessToken string) (string, error) {
+func (s *Store) CompleteCallback(state, accessToken, scope string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -89,34 +90,36 @@ func (s *Store) CompleteCallback(state, accessToken string) (string, error) {
 	}
 	sess.InternalCode = code
 	sess.AccessToken = accessToken
+	sess.Scope = scope
 	s.codes[code] = sess
 	return code, nil
 }
 
-// ExchangeCode validates PKCE and returns the access token for the given code.
-func (s *Store) ExchangeCode(code, redirectURI, codeVerifier string) (string, error) {
+// ExchangeCode validates PKCE and returns the access token and granted scope for the given code.
+func (s *Store) ExchangeCode(code, redirectURI, codeVerifier string) (string, string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	sess, ok := s.codes[code]
 	if !ok || time.Now().After(sess.ExpiresAt) {
 		delete(s.codes, code)
-		return "", fmt.Errorf("code not found or expired")
+		return "", "", fmt.Errorf("code not found or expired")
 	}
 	if sess.RedirectURI != redirectURI {
-		return "", fmt.Errorf("redirect_uri mismatch")
+		return "", "", fmt.Errorf("redirect_uri mismatch")
 	}
 	if sess.CodeChallenge != "" {
 		if err := verifyPKCE(codeVerifier, sess.CodeChallenge); err != nil {
-			return "", err
+			return "", "", err
 		}
 	}
 
 	token := sess.AccessToken
+	scope := sess.Scope
 	// one-time use
 	delete(s.codes, code)
 	delete(s.sessions, sess.State)
-	return token, nil
+	return token, scope, nil
 }
 
 // CacheToken stores a validated login for a token.
@@ -172,7 +175,28 @@ func generateCode() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
+// isValidPKCEVerifier checks RFC 7636 requirements: 43-128 chars, unreserved charset only.
+func isValidPKCEVerifier(verifier string) bool {
+	if len(verifier) < 43 || len(verifier) > 128 {
+		return false
+	}
+	for i := 0; i < len(verifier); i++ {
+		c := verifier[i]
+		if (c >= 'A' && c <= 'Z') ||
+			(c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') ||
+			c == '-' || c == '.' || c == '_' || c == '~' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 func verifyPKCE(verifier, challenge string) error {
+	if !isValidPKCEVerifier(verifier) {
+		return fmt.Errorf("invalid_grant")
+	}
 	h := sha256.Sum256([]byte(verifier))
 	got := base64.RawURLEncoding.EncodeToString(h[:])
 	if got != challenge {

--- a/services/copilot-review-mcp/internal/auth/session.go
+++ b/services/copilot-review-mcp/internal/auth/session.go
@@ -64,6 +64,14 @@ func (s *Store) SaveSession(state, redirectURI, codeChallenge string) {
 	}
 }
 
+// HasSession returns true if state maps to a live (non-expired) session.
+func (s *Store) HasSession(state string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[state]
+	return ok && !time.Now().After(sess.ExpiresAt)
+}
+
 // CompleteCallback attaches an internal code + access token to the session.
 func (s *Store) CompleteCallback(state, accessToken string) (string, error) {
 	s.mu.Lock()
@@ -75,7 +83,10 @@ func (s *Store) CompleteCallback(state, accessToken string) (string, error) {
 		return "", fmt.Errorf("session not found or expired for state %q", state)
 	}
 
-	code := generateCode()
+	code, err := generateCode()
+	if err != nil {
+		return "", err
+	}
 	sess.InternalCode = code
 	sess.AccessToken = accessToken
 	s.codes[code] = sess
@@ -153,10 +164,12 @@ func (s *Store) janitor() {
 	}
 }
 
-func generateCode() string {
+func generateCode() (string, error) {
 	b := make([]byte, 32)
-	_, _ = rand.Read(b)
-	return base64.RawURLEncoding.EncodeToString(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating code: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 func verifyPKCE(verifier, challenge string) error {

--- a/services/copilot-review-mcp/internal/middleware/auth.go
+++ b/services/copilot-review-mcp/internal/middleware/auth.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"log/slog"
+)
+
+type contextKey string
+
+const ContextKeyLogin contextKey = "github_login"
+const ContextKeyToken contextKey = "github_token"
+
+// TokenValidator is implemented by auth.Handler.
+type TokenValidator interface {
+	ValidateToken(ctx context.Context, token string) (string, error)
+}
+
+// Auth returns a middleware that validates Bearer tokens via the GitHub API.
+func Auth(v TokenValidator) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := extractBearer(r)
+			if token == "" {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+
+			login, err := v.ValidateToken(r.Context(), token)
+			if err != nil {
+				slog.Warn("auth failed", "err", err, "path", r.URL.Path)
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), ContextKeyLogin, login)
+			ctx = context.WithValue(ctx, ContextKeyToken, token)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func extractBearer(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	if strings.HasPrefix(h, "Bearer ") {
+		return strings.TrimPrefix(h, "Bearer ")
+	}
+	return ""
+}
+
+// TokenFromContext retrieves the GitHub token injected by Auth middleware.
+func TokenFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ContextKeyToken).(string)
+	return v
+}

--- a/services/copilot-review-mcp/internal/middleware/auth.go
+++ b/services/copilot-review-mcp/internal/middleware/auth.go
@@ -24,14 +24,14 @@ func Auth(v TokenValidator) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := extractBearer(r)
 			if token == "" {
-				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				writeUnauthorized(w, "missing_token")
 				return
 			}
 
 			login, err := v.ValidateToken(r.Context(), token)
 			if err != nil {
 				slog.Warn("auth failed", "err", err, "path", r.URL.Path)
-				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				writeUnauthorized(w, "invalid_token")
 				return
 			}
 
@@ -42,10 +42,18 @@ func Auth(v TokenValidator) func(http.Handler) http.Handler {
 	}
 }
 
+func writeUnauthorized(w http.ResponseWriter, errCode string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("WWW-Authenticate", `Bearer realm="copilot-review-mcp"`)
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = w.Write([]byte(`{"error":"` + errCode + `"}`))
+}
+
 func extractBearer(r *http.Request) string {
 	h := r.Header.Get("Authorization")
-	if strings.HasPrefix(h, "Bearer ") {
-		return strings.TrimPrefix(h, "Bearer ")
+	fields := strings.Fields(h)
+	if len(fields) == 2 && strings.EqualFold(fields[0], "bearer") {
+		return fields[1]
 	}
 	return ""
 }

--- a/services/copilot-review-mcp/internal/middleware/auth.go
+++ b/services/copilot-review-mcp/internal/middleware/auth.go
@@ -2,6 +2,8 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -18,6 +20,12 @@ type TokenValidator interface {
 	ValidateToken(ctx context.Context, token string) (string, error)
 }
 
+// upstreamErrorer is satisfied by errors that represent upstream service failures
+// (network errors, GitHub 5xx), allowing the middleware to return 503 instead of 401.
+type upstreamErrorer interface {
+	IsUpstreamError() bool
+}
+
 // Auth returns a middleware that validates Bearer tokens via the GitHub API.
 func Auth(v TokenValidator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -30,6 +38,14 @@ func Auth(v TokenValidator) func(http.Handler) http.Handler {
 
 			login, err := v.ValidateToken(r.Context(), token)
 			if err != nil {
+				var ue upstreamErrorer
+				if errors.As(err, &ue) {
+					slog.Error("upstream error during auth", "err", err, "path", r.URL.Path)
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "upstream_error"})
+					return
+				}
 				slog.Warn("auth failed", "err", err, "path", r.URL.Path)
 				writeUnauthorized(w, "invalid_token")
 				return
@@ -46,7 +62,7 @@ func writeUnauthorized(w http.ResponseWriter, errCode string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("WWW-Authenticate", `Bearer realm="copilot-review-mcp"`)
 	w.WriteHeader(http.StatusUnauthorized)
-	_, _ = w.Write([]byte(`{"error":"` + errCode + `"}`))
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": errCode})
 }
 
 func extractBearer(r *http.Request) string {


### PR DESCRIPTION
## 概要

services/copilot-review-mcp/ を新規作成。ISSUE#28 の OAuth Facade 実装（フェーズ1）。

## 変更内容

- /.well-known/oauth-authorization-server Discovery エンドポイント（RFC 8414）
- /authorize → GitHub OAuth 認可リダイレクト
- /callback → GitHub code 受領 → 内部 code 発行
- /token → authorization_code grant + PKCE S256 検証
- Bearer token 検証ミドルウェア（GitHub API + インメモリキャッシュ）
- セッションストア（TTL 付き、janitor goroutine）
- distroless Dockerfile（CGO_ENABLED=0）
- docker-compose.yml に copilot-review-mcp サービス追加

## テスト方法

`ash
# .env に GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET を設定後
docker compose build copilot-review-mcp
docker compose up copilot-review-mcp
curl http://localhost:8083/health
curl http://localhost:8083/.well-known/oauth-authorization-server
`

Closes #28（一部。DoD 全項目は後続 PR で完了）

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>