### PR TITLE
feat(copilot-review-mcp): implement ISSUE#27 Tool 8 get_pr_review_cycle_status

### DIFF
--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -70,7 +70,7 @@ type CycleClassificationSummary struct {
 
 // CycleStatusOutput is the output schema for get_pr_review_cycle_status.
 type CycleStatusOutput struct {
-	CycleStatus           string                     `json:"cycle_status"`       // CONTINUE | TERMINATE
+	CycleStatus           string                     `json:"cycle_status"`       // CONTINUE | TERMINATE  ※TERMINATE は推奨アクションが終端アクション(READY_TO_MERGE/ESCALATE)の場合のみ
 	RecommendedAction     string                     `json:"recommended_action"` // WAIT | APPLY_FIXES | REPLY_RESOLVE | REQUEST_REREVIEW | READY_TO_MERGE | ESCALATE
 	RereviewRequired      bool                       `json:"rereview_required"`
 	RereviewReason        *string                    `json:"rereview_reason"`
@@ -87,7 +87,12 @@ var cycleTool = &mcp.Tool{
 	Name: "get_pr_review_cycle_status",
 	Description: "PR レビューサイクルの現在状態を評価し、次の推奨アクション " +
 		"(WAIT / APPLY_FIXES / REPLY_RESOLVE / REQUEST_REREVIEW / READY_TO_MERGE / ESCALATE) を返す。" +
-		"ISSUE#25・ISSUE#26 のツール群を組み合わせた PR レビューサイクルのオーケストレーション用。",
+		"ISSUE#25・ISSUE#26 のツール群を組み合わせた PR レビューサイクルのオーケストレーション用。\n\n" +
+		"【cycle_status の定義】\n" +
+		"  TERMINATE = recommended_action が READY_TO_MERGE または ESCALATE の場合のみ。\n" +
+		"  これらは \"次のサイクル不要\" を意味する終端アクション。\n" +
+		"  終了条件 (terminateCond) が満たされても rereview_required=true 等の理由で\n" +
+		"  recommended_action が READY_TO_MERGE でない場合は CONTINUE になることがある。",
 }
 
 func cycleStatusHandler(
@@ -287,10 +292,14 @@ func cycleStatusHandler(
 		}
 
 		// ── Derive cycle_status from recommended_action ───────────────────────
-		// Only READY_TO_MERGE implies cycle termination; all other actions continue the cycle.
-		// This ensures cycle_status and recommended_action are always consistent.
+		// cycle_status=TERMINATE は「終端アクション」の場合のみ。
+		// 終端アクション = READY_TO_MERGE または ESCALATE（次のサイクル不要）。
+		// terminateCond1/2 は READY_TO_MERGE 到達のための入力条件であり、
+		// 直接 cycle_status を制御しない。これにより cycle_status と
+		// recommended_action が常に整合する（e.g. rereview 必要な場合は
+		// terminateCond が満たされても CONTINUE のまま）。
 		cycleStatus := "CONTINUE"
-		if recommendedAction == "READY_TO_MERGE" {
+		if recommendedAction == "READY_TO_MERGE" || recommendedAction == "ESCALATE" {
 			cycleStatus = "TERMINATE"
 		}
 

--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -142,7 +142,10 @@ func cycleStatusHandler(
 				RereviewReason:    rereviewReason,
 				CyclesDone:        in.CyclesDone,
 				MaxCycles:         maxCycles,
-				Notes:             notes,
+				// Reflect at least the caller-provided CI status; thread counts are unavailable
+				// at this early-exit point (threads not yet fetched).
+				MergeConditions: MergeConditions{CIOK: in.CIAllSuccess},
+				Notes:           notes,
 			}, nil
 		}
 
@@ -205,9 +208,9 @@ func cycleStatusHandler(
 		}
 		if reviewData.RateLimitRemaining < 10 {
 			return nil, CycleStatusOutput{}, fmt.Errorf(
-				"insufficient GitHub API rate limit remaining to safely derive review status: remaining=%d, retry-after=%v",
+				"insufficient GitHub API rate limit remaining to safely derive review status: remaining=%d, retry-after=%s",
 				reviewData.RateLimitRemaining,
-				reviewData.RateLimitReset,
+				reviewData.RateLimitReset.UTC().Format(time.RFC3339),
 			)
 		}
 
@@ -226,9 +229,10 @@ func cycleStatusHandler(
 		elapsedMinutes := 0
 		if in.LastCommentAt != nil && *in.LastCommentAt != "" {
 			lastAt, parseErr := time.Parse(time.RFC3339, *in.LastCommentAt)
-			if parseErr == nil {
-				elapsedMinutes = int(time.Since(lastAt).Minutes())
+			if parseErr != nil {
+				return nil, CycleStatusOutput{}, fmt.Errorf("invalid last_comment_at: must be RFC3339: %w", parseErr)
 			}
+			elapsedMinutes = int(time.Since(lastAt).Minutes())
 		}
 
 		// ── Termination condition checks (used for action and notes) ─────────
@@ -306,17 +310,31 @@ func cycleStatusHandler(
 			}
 		} else {
 			var reasons []string
-			if blockingCount > 0 {
-				reasons = append(reasons, fmt.Sprintf("blocking=%d残存", blockingCount))
-			}
-			if unresolvedCount > 0 {
-				reasons = append(reasons, fmt.Sprintf("unresolved=%d残存", unresolvedCount))
-			}
-			if !in.CIAllSuccess {
-				reasons = append(reasons, "CI未達成")
-			}
-			if len(reasons) == 0 {
-				reasons = append(reasons, "条件評価中")
+			if terminateCond1 || terminateCond2 {
+				// Termination conditions are already met, but the cycle continues
+				// due to a higher-priority action (e.g. rereview required, PENDING status).
+				reasons = append(reasons, "終了条件は達成済み")
+				switch {
+				case rereviewRequired && rereviewReason != nil:
+					reasons = append(reasons, fmt.Sprintf("継続理由: 再レビュー必須（%s）", *rereviewReason))
+				case rereviewRequired:
+					reasons = append(reasons, "継続理由: 再レビュー必須")
+				default:
+					reasons = append(reasons, fmt.Sprintf("継続理由: 推奨アクション=%s", recommendedAction))
+				}
+			} else {
+				if blockingCount > 0 {
+					reasons = append(reasons, fmt.Sprintf("blocking=%d残存", blockingCount))
+				}
+				if unresolvedCount > 0 {
+					reasons = append(reasons, fmt.Sprintf("unresolved=%d残存", unresolvedCount))
+				}
+				if !in.CIAllSuccess {
+					reasons = append(reasons, "CI未達成")
+				}
+				if len(reasons) == 0 {
+					reasons = append(reasons, "条件評価中")
+				}
 			}
 			notes = append(notes, fmt.Sprintf("■ サイクル終了条件: 未達成（%s）", strings.Join(reasons, ", ")))
 		}

--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -1,0 +1,319 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
+	"github.com/scottlz0310/copilot-review-mcp/internal/store"
+)
+
+// ─── Environment helpers ──────────────────────────────────────────────────────
+
+const (
+	defaultMaxCycles           = 3
+	defaultNoCommentThresholdMin = 6
+)
+
+func envMaxCycles() int {
+	if s := os.Getenv("MAX_REVIEW_CYCLES"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil && v > 0 {
+			return v
+		}
+	}
+	return defaultMaxCycles
+}
+
+func envNoCommentThreshold() int {
+	if s := os.Getenv("NO_COMMENT_THRESHOLD_MIN"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil && v > 0 {
+			return v
+		}
+	}
+	return defaultNoCommentThresholdMin
+}
+
+// ─── Tool 8 Types ─────────────────────────────────────────────────────────────
+
+// CycleStatusInput is the input schema for get_pr_review_cycle_status.
+type CycleStatusInput struct {
+	Owner         string  `json:"owner"`
+	Repo          string  `json:"repo"`
+	PR            int     `json:"pr"`
+	CIAllSuccess  bool    `json:"ci_all_success"`
+	LastCommentAt *string `json:"last_comment_at"` // ISO8601 | null
+	CyclesDone    int     `json:"cycles_done"`
+	MaxCycles     int     `json:"max_cycles"` // 0 → use env/default
+	FixType       string  `json:"fix_type"`   // logic | spec_change | trivial | none
+}
+
+// MergeConditions holds the per-condition merge readiness check.
+type MergeConditions struct {
+	CIOK            bool `json:"ci_ok"`
+	BlockingCount   int  `json:"blocking_count"`
+	UnresolvedCount int  `json:"unresolved_count"`
+	AllReplied      bool `json:"all_replied"`
+}
+
+// CycleClassificationSummary holds aggregate thread classification counts.
+type CycleClassificationSummary struct {
+	Blocking    int `json:"blocking"`
+	NonBlocking int `json:"nonBlocking"`
+	Suggestion  int `json:"suggestion"`
+}
+
+// CycleStatusOutput is the output schema for get_pr_review_cycle_status.
+type CycleStatusOutput struct {
+	CycleStatus           string                     `json:"cycle_status"`       // CONTINUE | TERMINATE
+	RecommendedAction     string                     `json:"recommended_action"` // WAIT | APPLY_FIXES | REPLY_RESOLVE | REQUEST_REREVIEW | READY_TO_MERGE | ESCALATE
+	RereviewRequired      bool                       `json:"rereview_required"`
+	RereviewReason        *string                    `json:"rereview_reason"`
+	CyclesDone            int                        `json:"cycles_done"`
+	MaxCycles             int                        `json:"max_cycles"`
+	MergeConditions       MergeConditions            `json:"merge_conditions"`
+	ClassificationSummary CycleClassificationSummary `json:"classification_summary"`
+	Notes                 []string                   `json:"notes"`
+}
+
+// ─── Tool 8: get_pr_review_cycle_status ──────────────────────────────────────
+
+var cycleTool = &mcp.Tool{
+	Name: "get_pr_review_cycle_status",
+	Description: "PR レビューサイクルの現在状態を評価し、次の推奨アクション " +
+		"(WAIT / APPLY_FIXES / REPLY_RESOLVE / REQUEST_REREVIEW / READY_TO_MERGE / ESCALATE) を返す。" +
+		"ISSUE#25・ISSUE#26 のツール群を組み合わせた PR レビューサイクルのオーケストレーション用。",
+}
+
+func cycleStatusHandler(
+	gh *ghclient.Client,
+	db *store.DB,
+) func(context.Context, *mcp.CallToolRequest, CycleStatusInput) (*mcp.CallToolResult, CycleStatusOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, in CycleStatusInput) (*mcp.CallToolResult, CycleStatusOutput, error) {
+		// Input validation
+		if in.Owner == "" || in.Repo == "" || in.PR <= 0 {
+			return nil, CycleStatusOutput{}, fmt.Errorf("owner, repo, and pr are required")
+		}
+		validFixTypes := map[string]bool{
+			"logic": true, "spec_change": true, "trivial": true, "none": true,
+		}
+		if in.FixType != "" && !validFixTypes[in.FixType] {
+			return nil, CycleStatusOutput{}, fmt.Errorf(
+				"fix_type must be one of: logic, spec_change, trivial, none (got %q)", in.FixType,
+			)
+		}
+
+		// Resolve max_cycles (input → env → default)
+		maxCycles := in.MaxCycles
+		if maxCycles <= 0 {
+			maxCycles = envMaxCycles()
+		}
+		noCommentThreshold := envNoCommentThreshold()
+
+		// Determine rereview_required from fix_type
+		rereviewRequired := in.FixType == "logic" || in.FixType == "spec_change"
+		var rereviewReason *string
+		if rereviewRequired {
+			reason := fmt.Sprintf("fix_type=%q は再レビューが必要です", in.FixType)
+			rereviewReason = &reason
+		}
+
+		// ── Early exit: max cycles exceeded ────────────────────────────────
+		if in.CyclesDone >= maxCycles {
+			notes := []string{
+				fmt.Sprintf("■ 最大サイクル数 %d 回に達しました。", maxCycles),
+				fmt.Sprintf("■ PR: https://github.com/%s/%s/pull/%d", in.Owner, in.Repo, in.PR),
+				"■ 人間によるレビューと判断が必要です。",
+			}
+			return nil, CycleStatusOutput{
+				CycleStatus:       "TERMINATE",
+				RecommendedAction: "ESCALATE",
+				RereviewRequired:  rereviewRequired,
+				RereviewReason:    rereviewReason,
+				CyclesDone:        in.CyclesDone,
+				MaxCycles:         maxCycles,
+				Notes:             notes,
+			}, nil
+		}
+
+		// ── Fetch review threads and classify ────────────────────────────────
+		rawThreads, err := gh.GetReviewThreads(ctx, in.Owner, in.Repo, in.PR)
+		if err != nil {
+			return nil, CycleStatusOutput{}, fmt.Errorf("failed to fetch review threads: %w", err)
+		}
+
+		blockingCount := 0
+		nonBlockingCount := 0
+		suggestionCount := 0
+		unresolvedCount := 0
+		allReplied := true // vacuously true when there are no threads
+
+		for _, t := range rawThreads {
+			cls, _ := classifyThread(t.Comments)
+			switch cls {
+			case "blocking":
+				blockingCount++
+			case "non-blocking":
+				nonBlockingCount++
+			default:
+				suggestionCount++
+			}
+			if !t.IsResolved {
+				unresolvedCount++
+			}
+			// A thread is "replied" when it has more than 1 comment
+			// (original Copilot comment + at least one user reply).
+			if len(t.Comments) <= 1 {
+				allReplied = false
+			}
+		}
+
+		classSummary := CycleClassificationSummary{
+			Blocking:    blockingCount,
+			NonBlocking: nonBlockingCount,
+			Suggestion:  suggestionCount,
+		}
+		mergeConditions := MergeConditions{
+			CIOK:            in.CIAllSuccess,
+			BlockingCount:   blockingCount,
+			UnresolvedCount: unresolvedCount,
+			AllReplied:      allReplied,
+		}
+
+		// ── Fetch current review status ──────────────────────────────────────
+		reviewData, err := gh.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
+		if err != nil {
+			return nil, CycleStatusOutput{}, fmt.Errorf("failed to fetch review data: %w", err)
+		}
+
+		entry, err := db.GetLatest(in.Owner, in.Repo, in.PR)
+		if err != nil {
+			return nil, CycleStatusOutput{}, fmt.Errorf("failed to fetch trigger log: %w", err)
+		}
+
+		var requestedAt *time.Time
+		if entry != nil {
+			requestedAt = &entry.RequestedAt
+		}
+		reviewStatus := gh.DeriveStatus(reviewData, requestedAt)
+
+		// ── Elapsed time since last Copilot comment ───────────────────────────
+		elapsedMinutes := 0
+		if in.LastCommentAt != nil && *in.LastCommentAt != "" {
+			lastAt, parseErr := time.Parse(time.RFC3339, *in.LastCommentAt)
+			if parseErr == nil {
+				elapsedMinutes = int(time.Since(lastAt).Minutes())
+			}
+		}
+
+		// ── Determine cycle_status ────────────────────────────────────────────
+		// Condition 1: all comments resolved, no blocking, CI OK.
+		terminateCond1 := blockingCount == 0 && unresolvedCount == 0 && in.CIAllSuccess
+		// Condition 2: no new Copilot comment for ≥ threshold minutes, CI OK, no blocking.
+		terminateCond2 := elapsedMinutes >= noCommentThreshold && in.CIAllSuccess && blockingCount == 0
+
+		cycleStatus := "CONTINUE"
+		if terminateCond1 || terminateCond2 {
+			cycleStatus = "TERMINATE"
+		}
+
+		// ── Determine recommended_action ──────────────────────────────────────
+		var recommendedAction string
+
+		switch {
+		case reviewStatus == ghclient.StatusPending || reviewStatus == ghclient.StatusInProgress:
+			recommendedAction = "WAIT"
+
+		case blockingCount > 0:
+			recommendedAction = "APPLY_FIXES"
+
+		case unresolvedCount > 0:
+			recommendedAction = "REPLY_RESOLVE"
+
+		case rereviewRequired:
+			// Guard: previous review must be COMPLETED or BLOCKED, and all threads replied.
+			reviewDone := reviewStatus == ghclient.StatusCompleted || reviewStatus == ghclient.StatusBlocked
+			if reviewDone && allReplied {
+				recommendedAction = "REQUEST_REREVIEW"
+			} else {
+				// Guards not met; reply/resolve remaining threads first.
+				recommendedAction = "REPLY_RESOLVE"
+			}
+
+		case cycleStatus == "TERMINATE":
+			recommendedAction = "READY_TO_MERGE"
+
+		default:
+			// Remaining case: blocking==0, unresolved==0, rereview not required,
+			// but cycle is still CONTINUE (e.g. CI not yet green).
+			// WAIT is the most conservative choice until the next cycle.
+			recommendedAction = "WAIT"
+		}
+
+		// ── Build notes ───────────────────────────────────────────────────────
+		notes := []string{
+			fmt.Sprintf("■ サイクル: %d/%d回目", in.CyclesDone+1, maxCycles),
+			fmt.Sprintf("■ コメント分類: blocking=%d, non-blocking=%d, suggestion=%d",
+				blockingCount, nonBlockingCount, suggestionCount),
+		}
+		if in.FixType != "" {
+			fixNote := fmt.Sprintf("■ 修正種別: %s", in.FixType)
+			if rereviewRequired {
+				fixNote += " → 再レビュー必須"
+			} else {
+				fixNote += " → 再レビュー不要"
+			}
+			notes = append(notes, fixNote)
+		}
+
+		if cycleStatus == "TERMINATE" {
+			switch {
+			case terminateCond1:
+				notes = append(notes, "■ サイクル終了条件: 達成（blocking=0, unresolved=0, CI=OK）")
+			default:
+				notes = append(notes, fmt.Sprintf(
+					"■ サイクル終了条件: 達成（コメントなし %d分経過 ≥ %d分閾値 & CI=OK）",
+					elapsedMinutes, noCommentThreshold,
+				))
+			}
+		} else {
+			var reasons []string
+			if blockingCount > 0 {
+				reasons = append(reasons, fmt.Sprintf("blocking=%d残存", blockingCount))
+			}
+			if unresolvedCount > 0 {
+				reasons = append(reasons, fmt.Sprintf("unresolved=%d残存", unresolvedCount))
+			}
+			if !in.CIAllSuccess {
+				reasons = append(reasons, "CI未達成")
+			}
+			if len(reasons) == 0 {
+				reasons = append(reasons, "条件評価中")
+			}
+			notes = append(notes, fmt.Sprintf("■ サイクル終了条件: 未達成（%s）", strings.Join(reasons, ", ")))
+		}
+		notes = append(notes, fmt.Sprintf("■ 推奨アクション: %s", recommendedAction))
+
+		return nil, CycleStatusOutput{
+			CycleStatus:           cycleStatus,
+			RecommendedAction:     recommendedAction,
+			RereviewRequired:      rereviewRequired,
+			RereviewReason:        rereviewReason,
+			CyclesDone:            in.CyclesDone,
+			MaxCycles:             maxCycles,
+			MergeConditions:       mergeConditions,
+			ClassificationSummary: classSummary,
+			Notes:                 notes,
+		}, nil
+	}
+}
+
+// RegisterCycleTool adds get_pr_review_cycle_status to the MCP server.
+func RegisterCycleTool(server *mcp.Server, gh *ghclient.Client, db *store.DB) {
+	mcp.AddTool(server, cycleTool, cycleStatusHandler(gh, db))
+}

--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -17,7 +17,7 @@ import (
 // ─── Environment helpers ──────────────────────────────────────────────────────
 
 const (
-	defaultMaxCycles           = 3
+	defaultMaxCycles             = 3
 	defaultNoCommentThresholdMin = 6
 )
 
@@ -99,6 +99,12 @@ func cycleStatusHandler(
 		if in.Owner == "" || in.Repo == "" || in.PR <= 0 {
 			return nil, CycleStatusOutput{}, fmt.Errorf("owner, repo, and pr are required")
 		}
+		if in.CyclesDone < 0 {
+			return nil, CycleStatusOutput{}, fmt.Errorf("cycles_done must be >= 0 (got %d)", in.CyclesDone)
+		}
+		if in.MaxCycles < 0 {
+			return nil, CycleStatusOutput{}, fmt.Errorf("max_cycles must be >= 0 when specified (got %d)", in.MaxCycles)
+		}
 		validFixTypes := map[string]bool{
 			"logic": true, "spec_change": true, "trivial": true, "none": true,
 		}
@@ -163,16 +169,18 @@ func cycleStatusHandler(
 
 		for _, t := range rawThreads {
 			cls, _ := classifyThread(t.Comments)
-			switch cls {
-			case "blocking":
-				blockingCount++
-			case "non-blocking":
-				nonBlockingCount++
-			default:
-				suggestionCount++
-			}
+			// Count classifications only for unresolved threads so that
+			// resolved/fixed issues do not keep the cycle stuck.
 			if !t.IsResolved {
 				unresolvedCount++
+				switch cls {
+				case "blocking":
+					blockingCount++
+				case "non-blocking":
+					nonBlockingCount++
+				default:
+					suggestionCount++
+				}
 			}
 			// A thread is "replied" only when there are comments from
 			// at least two distinct authors (for example, Copilot and a user).
@@ -245,6 +253,10 @@ func cycleStatusHandler(
 		var recommendedAction string
 
 		switch {
+		case reviewStatus == ghclient.StatusNotRequested:
+			// Guard: never mark an unreviewed PR as ready to merge.
+			recommendedAction = "WAIT"
+
 		case reviewStatus == ghclient.StatusPending || reviewStatus == ghclient.StatusInProgress:
 			recommendedAction = "WAIT"
 

--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -102,7 +102,12 @@ func cycleStatusHandler(
 		validFixTypes := map[string]bool{
 			"logic": true, "spec_change": true, "trivial": true, "none": true,
 		}
-		if in.FixType != "" && !validFixTypes[in.FixType] {
+		if in.FixType == "" {
+			return nil, CycleStatusOutput{}, fmt.Errorf(
+				`fix_type is required and must be one of: "logic", "spec_change", "trivial", "none"`,
+			)
+		}
+		if !validFixTypes[in.FixType] {
 			return nil, CycleStatusOutput{}, fmt.Errorf(
 				"fix_type must be one of: logic, spec_change, trivial, none (got %q)", in.FixType,
 			)
@@ -166,9 +171,17 @@ func cycleStatusHandler(
 			if !t.IsResolved {
 				unresolvedCount++
 			}
-			// A thread is "replied" when it has more than 1 comment
-			// (original Copilot comment + at least one user reply).
-			if len(t.Comments) <= 1 {
+			// A thread is "replied" only when there are comments from
+			// at least two distinct authors (for example, Copilot and a user).
+			uniqueAuthors := make(map[string]struct{})
+			for _, c := range t.Comments {
+				authorKey := strings.TrimSpace(c.Author)
+				if authorKey == "" {
+					continue
+				}
+				uniqueAuthors[authorKey] = struct{}{}
+			}
+			if len(uniqueAuthors) < 2 {
 				allReplied = false
 			}
 		}
@@ -189,6 +202,13 @@ func cycleStatusHandler(
 		reviewData, err := gh.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
 		if err != nil {
 			return nil, CycleStatusOutput{}, fmt.Errorf("failed to fetch review data: %w", err)
+		}
+		if reviewData.RateLimitRemaining < 10 {
+			return nil, CycleStatusOutput{}, fmt.Errorf(
+				"insufficient GitHub API rate limit remaining to safely derive review status: remaining=%d, retry-after=%v",
+				reviewData.RateLimitRemaining,
+				reviewData.RateLimitReset,
+			)
 		}
 
 		entry, err := db.GetLatest(in.Owner, in.Repo, in.PR)
@@ -211,16 +231,11 @@ func cycleStatusHandler(
 			}
 		}
 
-		// ── Determine cycle_status ────────────────────────────────────────────
+		// ── Termination condition checks (used for action and notes) ─────────
 		// Condition 1: all comments resolved, no blocking, CI OK.
 		terminateCond1 := blockingCount == 0 && unresolvedCount == 0 && in.CIAllSuccess
 		// Condition 2: no new Copilot comment for ≥ threshold minutes, CI OK, no blocking.
 		terminateCond2 := elapsedMinutes >= noCommentThreshold && in.CIAllSuccess && blockingCount == 0
-
-		cycleStatus := "CONTINUE"
-		if terminateCond1 || terminateCond2 {
-			cycleStatus = "TERMINATE"
-		}
 
 		// ── Determine recommended_action ──────────────────────────────────────
 		var recommendedAction string
@@ -245,14 +260,22 @@ func cycleStatusHandler(
 				recommendedAction = "REPLY_RESOLVE"
 			}
 
-		case cycleStatus == "TERMINATE":
+		case terminateCond1 || terminateCond2:
 			recommendedAction = "READY_TO_MERGE"
 
 		default:
 			// Remaining case: blocking==0, unresolved==0, rereview not required,
-			// but cycle is still CONTINUE (e.g. CI not yet green).
+			// but termination conditions not met (e.g. CI not yet green).
 			// WAIT is the most conservative choice until the next cycle.
 			recommendedAction = "WAIT"
+		}
+
+		// ── Derive cycle_status from recommended_action ───────────────────────
+		// Only READY_TO_MERGE implies cycle termination; all other actions continue the cycle.
+		// This ensures cycle_status and recommended_action are always consistent.
+		cycleStatus := "CONTINUE"
+		if recommendedAction == "READY_TO_MERGE" {
+			cycleStatus = "TERMINATE"
 		}
 
 		// ── Build notes ───────────────────────────────────────────────────────

--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -32,6 +32,7 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration) http.Handler 
 		RegisterWaitTool(srv, gh, db)
 		RegisterRequestTool(srv, gh, db)
 		RegisterThreadTools(srv, gh)
+		RegisterCycleTool(srv, gh, db)
 		return srv
 	}
 	return mcp.NewStreamableHTTPHandler(getServer, &mcp.StreamableHTTPOptions{


### PR DESCRIPTION
## 概要

ISSUE#27 の実装。Tool 8 `get_pr_review_cycle_status` を追加し、PR レビューサイクルのオーケストレーションを実現する。

Closes #27

---

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/tools/cycle.go` | Tool 8 新規実装 |
| `internal/tools/server.go` | `RegisterCycleTool` を登録 |

---

## 実装内容

### Tool 8: `get_pr_review_cycle_status`

PR レビューサイクルの現在状態を評価し、次の推奨アクションを返す。

**Input**
```json
{
  "owner": "string",
  "repo": "string",
  "pr": number,
  "ci_all_success": boolean,
  "last_comment_at": "string | null",
  "cycles_done": number,
  "max_cycles": number,
  "fix_type": "logic" | "spec_change" | "trivial" | "none"
}
```

**Output**
```json
{
  "cycle_status": "CONTINUE" | "TERMINATE",
  "recommended_action": "WAIT" | "APPLY_FIXES" | "REPLY_RESOLVE" | "REQUEST_REREVIEW" | "READY_TO_MERGE" | "ESCALATE",
  "rereview_required": boolean,
  "rereview_reason": "string | null",
  "cycles_done": number,
  "max_cycles": number,
  "merge_conditions": { "ci_ok", "blocking_count", "unresolved_count", "all_replied" },
  "classification_summary": { "blocking", "nonBlocking", "suggestion" },
  "notes": ["string"]
}
```

### 判断ロジック

1. **ESCALATE**: `cycles_done >= max_cycles` → 即時 TERMINATE + ESCALATE（無限ループ防止）
2. **WAIT**: review_status が PENDING / IN_PROGRESS
3. **APPLY_FIXES**: `blocking_count > 0`
4. **REPLY_RESOLVE**: `unresolved_count > 0`
5. **REQUEST_REREVIEW**: `rereview_required` かつ guard 通過（review COMPLETED/BLOCKED & all_replied）
6. **READY_TO_MERGE**: `cycle_status == TERMINATE`（終了条件達成）

### サイクル終了条件

- 条件1: `blocking == 0 && unresolved == 0 && ci_ok`
- 条件2: `elapsed_since_last_comment >= NO_COMMENT_THRESHOLD_MIN && ci_ok && blocking == 0`

### 環境変数

| 変数名 | デフォルト | 説明 |
|---|---|---|
| `MAX_REVIEW_CYCLES` | `3` | 最大サイクル数 |
| `NO_COMMENT_THRESHOLD_MIN` | `6` | コメントなし終了判定閾値（分） |

### 再レビュー必須条件

| `fix_type` | `rereview_required` |
|---|---|
| `logic` | `true` |
| `spec_change` | `true` |
| `trivial` | `false` |
| `none` | `false` |

### REQUEST_REREVIEW ガード

以下を全て満たす場合のみ `REQUEST_REREVIEW` を推奨:
1. 前回レビューが `COMPLETED` または `BLOCKED`
2. `unresolved_count == 0`（elif チェーンで保証）
3. `all_replied == true`（全スレッドに返信済み）

> ⚠️ READY_TO_MERGE はマージ操作を一切含まない。人間への判断委譲シグナルのみ。
