### PR TITLE
feat(copilot-review-mcp): RFC 7591 動的クライアント登録と .env 自動読み込みを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,33 @@
 # ========================================
 
 # 環境変数優先、.env フォールバック
-# 既に export 済みの変数は上書きしない (override しない)
+# $(origin ...) で環境由来の値を退避 → .env を include → 退避値を復元することで
+# シェルで export 済みの変数が .env より優先されることを保証する。
+ifeq ($(origin GITHUB_CLIENT_ID),environment)
+  ENV_GITHUB_CLIENT_ID := $(GITHUB_CLIENT_ID)
+endif
+ifeq ($(origin GITHUB_CLIENT_ID),environment override)
+  ENV_GITHUB_CLIENT_ID := $(GITHUB_CLIENT_ID)
+endif
+ifeq ($(origin GITHUB_CLIENT_SECRET),environment)
+  ENV_GITHUB_CLIENT_SECRET := $(GITHUB_CLIENT_SECRET)
+endif
+ifeq ($(origin GITHUB_CLIENT_SECRET),environment override)
+  ENV_GITHUB_CLIENT_SECRET := $(GITHUB_CLIENT_SECRET)
+endif
 ifneq (,$(wildcard .env))
   include .env
   export
 endif
-# .env のシェルスタイル引用符 ("value" → value) を除去
+# .env のシェルスタイル引用符 ("value" → value) を除去してから環境由来の値で上書き
 GITHUB_CLIENT_ID     := $(patsubst "%",%,$(GITHUB_CLIENT_ID))
 GITHUB_CLIENT_SECRET := $(patsubst "%",%,$(GITHUB_CLIENT_SECRET))
+ifdef ENV_GITHUB_CLIENT_ID
+  GITHUB_CLIENT_ID := $(ENV_GITHUB_CLIENT_ID)
+endif
+ifdef ENV_GITHUB_CLIENT_SECRET
+  GITHUB_CLIENT_SECRET := $(ENV_GITHUB_CLIENT_SECRET)
+endif
 
 .DEFAULT_GOAL := help
 

--- a/Makefile
+++ b/Makefile
@@ -2,34 +2,19 @@
 # GitHub MCP Server - サービス管理
 # ========================================
 
-# 環境変数優先、.env フォールバック
-# $(origin ...) で環境由来の値を退避 → .env を include → 退避値を復元することで
-# シェルで export 済みの変数が .env より優先されることを保証する。
-ifeq ($(origin GITHUB_CLIENT_ID),environment)
-  ENV_GITHUB_CLIENT_ID := $(GITHUB_CLIENT_ID)
-endif
-ifeq ($(origin GITHUB_CLIENT_ID),environment override)
-  ENV_GITHUB_CLIENT_ID := $(GITHUB_CLIENT_ID)
-endif
-ifeq ($(origin GITHUB_CLIENT_SECRET),environment)
-  ENV_GITHUB_CLIENT_SECRET := $(GITHUB_CLIENT_SECRET)
-endif
-ifeq ($(origin GITHUB_CLIENT_SECRET),environment override)
-  ENV_GITHUB_CLIENT_SECRET := $(GITHUB_CLIENT_SECRET)
-endif
+# 環境変数優先、.env フォールバック（安全な shell ベース読み込み）
+# include .env は .env を Makefile として解釈するため $(shell ...) 等が実行される危険がある。
+# 代わりに shell でソースして既知変数のみ抽出することで Make 関数インジェクションを防ぐ。
+# ?= は変数が未定義の場合のみ代入するため、シェルの export 済み変数が自動的に優先される。
 ifneq (,$(wildcard .env))
-  include .env
-  export
+  GITHUB_CLIENT_ID             ?= $(shell . ./.env 2>/dev/null && printf '%s' "$$GITHUB_CLIENT_ID")
+  GITHUB_CLIENT_SECRET         ?= $(shell . ./.env 2>/dev/null && printf '%s' "$$GITHUB_CLIENT_SECRET")
+  GITHUB_PERSONAL_ACCESS_TOKEN ?= $(shell . ./.env 2>/dev/null && printf '%s' "$$GITHUB_PERSONAL_ACCESS_TOKEN")
+  BASE_URL                     ?= $(shell . ./.env 2>/dev/null && printf '%s' "$$BASE_URL")
+  GITHUB_OAUTH_SCOPES          ?= $(shell . ./.env 2>/dev/null && printf '%s' "$$GITHUB_OAUTH_SCOPES")
 endif
-# .env のシェルスタイル引用符 ("value" → value) を除去してから環境由来の値で上書き
-GITHUB_CLIENT_ID     := $(patsubst "%",%,$(GITHUB_CLIENT_ID))
-GITHUB_CLIENT_SECRET := $(patsubst "%",%,$(GITHUB_CLIENT_SECRET))
-ifdef ENV_GITHUB_CLIENT_ID
-  GITHUB_CLIENT_ID := $(ENV_GITHUB_CLIENT_ID)
-endif
-ifdef ENV_GITHUB_CLIENT_SECRET
-  GITHUB_CLIENT_SECRET := $(ENV_GITHUB_CLIENT_SECRET)
-endif
+# 子プロセス（docker compose / docker run）に確実に渡す
+export GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET GITHUB_PERSONAL_ACCESS_TOKEN BASE_URL GITHUB_OAUTH_SCOPES
 
 .DEFAULT_GOAL := help
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,16 @@
 # GitHub MCP Server - サービス管理
 # ========================================
 
+# 環境変数優先、.env フォールバック
+# 既に export 済みの変数は上書きしない (override しない)
+ifneq (,$(wildcard .env))
+  include .env
+  export
+endif
+# .env のシェルスタイル引用符 ("value" → value) を除去
+GITHUB_CLIENT_ID     := $(patsubst "%",%,$(GITHUB_CLIENT_ID))
+GITHUB_CLIENT_SECRET := $(patsubst "%",%,$(GITHUB_CLIENT_SECRET))
+
 .DEFAULT_GOAL := help
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,18 @@
 # GitHub MCP Server - サービス管理
 # ========================================
 
-# 環境変数優先、.env フォールバック（安全な shell ベース読み込み）
-# include .env は .env を Makefile として解釈するため $(shell ...) 等が実行される危険がある。
-# 代わりに shell でソースして既知変数のみ抽出することで Make 関数インジェクションを防ぐ。
-# ?= は変数が未定義の場合のみ代入するため、シェルの export 済み変数が自動的に優先される。
+# 環境変数優先、.env フォールバック（安全な awk テキスト抽出）
+# include .env は Makefile として解釈される危険があり、
+# . ./.env (shell source) は .env 内の任意コマンドを実行する危険がある。
+# awk でテキスト解析のみ行い KEY=VALUE 行から値を取り出す（コマンド実行なし）。
+# ?= はシェルの export 済み変数を優先するので、環境変数が設定済みの場合は .env を無視する。
+ENV_GET = $(strip $(shell awk -v key='$(1)' '/^[[:space:]]*#/{next} $$0 ~ ("^[[:space:]]*" key "[[:space:]]*=") {val=substr($$0,index($$0,"=")+1); gsub(/^[[:space:]"'"'"']+|[[:space:]"'"'"']+$$/,"",val); print val; exit}' .env 2>/dev/null))
 ifneq (,$(wildcard .env))
-  GITHUB_CLIENT_ID             ?= $(shell . ./.env 2>/dev/null && printf '%s' "$$GITHUB_CLIENT_ID")
-  GITHUB_CLIENT_SECRET         ?= $(shell . ./.env 2>/dev/null && printf '%s' "$$GITHUB_CLIENT_SECRET")
-  GITHUB_PERSONAL_ACCESS_TOKEN ?= $(shell . ./.env 2>/dev/null && printf '%s' "$$GITHUB_PERSONAL_ACCESS_TOKEN")
-  BASE_URL                     ?= $(shell . ./.env 2>/dev/null && printf '%s' "$$BASE_URL")
-  GITHUB_OAUTH_SCOPES          ?= $(shell . ./.env 2>/dev/null && printf '%s' "$$GITHUB_OAUTH_SCOPES")
+  GITHUB_CLIENT_ID             ?= $(call ENV_GET,GITHUB_CLIENT_ID)
+  GITHUB_CLIENT_SECRET         ?= $(call ENV_GET,GITHUB_CLIENT_SECRET)
+  GITHUB_PERSONAL_ACCESS_TOKEN ?= $(call ENV_GET,GITHUB_PERSONAL_ACCESS_TOKEN)
+  BASE_URL                     ?= $(call ENV_GET,BASE_URL)
+  GITHUB_OAUTH_SCOPES          ?= $(call ENV_GET,GITHUB_OAUTH_SCOPES)
 endif
 # 子プロセス（docker compose / docker run）に確実に渡す
 export GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET GITHUB_PERSONAL_ACCESS_TOKEN BASE_URL GITHUB_OAUTH_SCOPES

--- a/services/copilot-review-mcp/Dockerfile
+++ b/services/copilot-review-mcp/Dockerfile
@@ -6,10 +6,13 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
     -o /out/copilot-review-mcp ./cmd/server
+# Create /data directory owned by nonroot (UID=65532) for SQLite volume mount
+RUN mkdir -p /data && chown 65532:65532 /data
 
 # distroless: no shell, no package manager
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /out/copilot-review-mcp /copilot-review-mcp
+COPY --from=builder --chown=nonroot:nonroot /data /data
 EXPOSE 8083
 # Trivy DS-0002: explicitly declare non-root user (distroless:nonroot UID=65532)
 USER nonroot:nonroot

--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/scottlz0310/copilot-review-mcp/internal/auth"
@@ -47,6 +48,7 @@ func main() {
 	mux.HandleFunc("GET /authorize", oauthHandler.Authorize)
 	mux.HandleFunc("GET /callback", oauthHandler.Callback)
 	mux.HandleFunc("POST /token", oauthHandler.Token)
+	mux.HandleFunc("POST /register", oauthHandler.Register)
 
 	// Health check (no auth required)
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
@@ -108,7 +110,7 @@ func loadConfig() config {
 }
 
 func mustEnv(key string) string {
-	v := os.Getenv(key)
+	v := strings.TrimSpace(os.Getenv(key))
 	if v == "" {
 		slog.Error("required environment variable not set", "key", key)
 		os.Exit(1)
@@ -117,7 +119,7 @@ func mustEnv(key string) string {
 }
 
 func getEnv(key, fallback string) string {
-	if v := os.Getenv(key); v != "" {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
 		return v
 	}
 	return fallback

--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -126,7 +126,7 @@ func getEnv(key, fallback string) string {
 }
 
 func getEnvInt(key string, fallback int) int {
-	if v := os.Getenv(key); v != "" {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
 		}

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -75,9 +75,33 @@ func (h *Handler) Discovery(w http.ResponseWriter, r *http.Request) {
 // is created. This allows MCP clients (e.g. VS Code) to proceed automatically
 // without requiring the user to enter a client_id manually.
 func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
-	var meta map[string]json.RawMessage
-	// Ignore decode errors — metadata fields are all optional per RFC 7591.
-	_ = json.NewDecoder(r.Body).Decode(&meta)
+	// Limit body to 64 KB to prevent memory exhaustion from oversized requests.
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+
+	meta := map[string]json.RawMessage{}
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&meta); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_client_metadata",
+			"error_description": "request body must be valid JSON client metadata",
+		})
+		return
+	}
+	// Reject payloads that contain more than a single JSON object (RFC 7591).
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); err != io.EOF {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_client_metadata",
+			"error_description": "request body must contain a single JSON object",
+		})
+		return
+	}
 
 	resp := map[string]any{
 		"client_id":                  h.cfg.GitHubClientID,
@@ -95,6 +119,7 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -47,7 +47,7 @@ func NewHandler(cfg Config) *Handler {
 	// Normalize BaseURL: strip trailing slash to prevent double-slash in endpoint URLs.
 	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
 	if len(cfg.AllowedRedirectHosts) == 0 {
-		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1"}
+		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1", "vscode.dev"}
 	}
 	return &Handler{
 		cfg:   cfg,
@@ -61,12 +61,42 @@ func (h *Handler) Discovery(w http.ResponseWriter, r *http.Request) {
 		"issuer":                           h.cfg.BaseURL,
 		"authorization_endpoint":           h.cfg.BaseURL + "/authorize",
 		"token_endpoint":                   h.cfg.BaseURL + "/token",
+		"registration_endpoint":            h.cfg.BaseURL + "/register",
 		"response_types_supported":         []string{"code"},
 		"grant_types_supported":            []string{"authorization_code"},
 		"code_challenge_methods_supported": []string{"S256"},
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// Register implements RFC 7591 Dynamic Client Registration (pseudo).
+// Always returns the pre-configured GitHub OAuth App client_id; no new client
+// is created. This allows MCP clients (e.g. VS Code) to proceed automatically
+// without requiring the user to enter a client_id manually.
+func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
+	var meta map[string]json.RawMessage
+	// Ignore decode errors — metadata fields are all optional per RFC 7591.
+	_ = json.NewDecoder(r.Body).Decode(&meta)
+
+	resp := map[string]any{
+		"client_id":                  h.cfg.GitHubClientID,
+		"client_id_issued_at":        time.Now().Unix(),
+		"client_secret_expires_at":   0,
+		"token_endpoint_auth_method": "none",
+		"grant_types":                []string{"authorization_code"},
+		"response_types":             []string{"code"},
+	}
+	// Echo back optional metadata fields if provided by the client.
+	for _, field := range []string{"redirect_uris", "client_name", "scope"} {
+		if v, ok := meta[field]; ok {
+			resp[field] = v
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // Authorize redirects the MCP client to GitHub OAuth.

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -24,7 +24,7 @@ type Config struct {
 	Scopes               string // e.g. "repo,user"
 	SessionTTL           time.Duration
 	CacheTTL             time.Duration
-	AllowedRedirectHosts []string // allowlist of permitted redirect_uri hostnames; defaults to ["localhost","127.0.0.1"]
+	AllowedRedirectHosts []string // allowlist of permitted redirect_uri hostnames; defaults to ["localhost","127.0.0.1","vscode.dev"]
 }
 
 // UpstreamError represents a failure contacting an upstream service (e.g. GitHub API

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 	"time"
 
 	"github.com/google/go-github/v72/github"
@@ -208,21 +209,27 @@ type threadNodeQuery struct {
 	} `graphql:"node(id: $id)"`
 }
 
-// addReplyMutation is the GraphQL mutation for adding a reply to a review thread.
-type addReplyMutation struct {
-	AddPullRequestReviewCommentReply struct {
-		Comment struct {
-			ID        githubv4.ID
-			CreatedAt githubv4.DateTime
-		}
-	} `graphql:"addPullRequestReviewCommentReply(input: $input)"`
-}
-
-// AddPullRequestReviewCommentReplyInput is the input for addReplyMutation.
-// Must be PascalCase so shurcooL/githubv4 sends the correct GraphQL type name.
-type AddPullRequestReviewCommentReplyInput struct {
-	PullRequestReviewThreadID githubv4.ID     `json:"pullRequestReviewThreadId"`
-	Body                      githubv4.String `json:"body"`
+// threadMetadataQuery fetches owner, repo, PR number, and first comment database ID
+// from a review thread node ID. Used to reply via REST API.
+type threadMetadataQuery struct {
+	Node struct {
+		PullRequestReviewThread struct {
+			PullRequest struct {
+				Number     githubv4.Int
+				Repository struct {
+					Name  githubv4.String
+					Owner struct {
+						Login githubv4.String
+					}
+				}
+			}
+			Comments struct {
+				Nodes []struct {
+					DatabaseId githubv4.Int
+				}
+			} `graphql:"comments(first: 1)"`
+		} `graphql:"... on PullRequestReviewThread"`
+	} `graphql:"node(id: $id)"`
 }
 
 // resolveThreadMutation is the GraphQL mutation for resolving a review thread.
@@ -335,20 +342,33 @@ func (c *Client) IsThreadResolved(ctx context.Context, threadID string) (bool, e
 	return bool(q.Node.PullRequestReviewThread.IsResolved), nil
 }
 
-// ReplyToThread adds a reply comment to a review thread.
-// Returns the new comment's ID and creation timestamp.
+// ReplyToThread adds a reply to a review thread via the REST API.
+// It first queries the thread node to resolve owner/repo/PR/commentID,
+// then calls CreateCommentInReplyTo. This avoids the deprecated
+// addPullRequestReviewCommentReply GraphQL mutation.
 func (c *Client) ReplyToThread(ctx context.Context, threadID, body string) (ReplyResult, error) {
-	var m addReplyMutation
-	input := AddPullRequestReviewCommentReplyInput{
-		PullRequestReviewThreadID: githubv4.ID(threadID),
-		Body:                      githubv4.String(body),
+	// Resolve thread metadata via GraphQL.
+	var q threadMetadataQuery
+	if err := c.v4.Query(ctx, &q, map[string]interface{}{"id": githubv4.ID(threadID)}); err != nil {
+		return ReplyResult{}, fmt.Errorf("graphql query failed: %w", err)
 	}
-	if err := c.v4.Mutate(ctx, &m, input, nil); err != nil {
-		return ReplyResult{}, fmt.Errorf("graphql mutation failed: %w", err)
+	meta := q.Node.PullRequestReviewThread
+	if len(meta.Comments.Nodes) == 0 {
+		return ReplyResult{}, fmt.Errorf("thread has no comments")
+	}
+	owner := string(meta.PullRequest.Repository.Owner.Login)
+	repo := string(meta.PullRequest.Repository.Name)
+	prNum := int(meta.PullRequest.Number)
+	commentID := int64(meta.Comments.Nodes[0].DatabaseId)
+
+	// Post reply via REST API.
+	comment, _, err := c.gh.PullRequests.CreateCommentInReplyTo(ctx, owner, repo, prNum, body, commentID)
+	if err != nil {
+		return ReplyResult{}, fmt.Errorf("REST API reply failed: %w", err)
 	}
 	return ReplyResult{
-		CommentID: fmt.Sprintf("%v", m.AddPullRequestReviewCommentReply.Comment.ID),
-		CreatedAt: m.AddPullRequestReviewCommentReply.Comment.CreatedAt.Format(time.RFC3339),
+		CommentID: strconv.FormatInt(comment.GetID(), 10),
+		CreatedAt: comment.GetCreatedAt().Format(time.RFC3339),
 	}, nil
 }
 

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -218,8 +218,9 @@ type addReplyMutation struct {
 	} `graphql:"addPullRequestReviewCommentReply(input: $input)"`
 }
 
-// addPullRequestReviewCommentReplyInput is the input for addReplyMutation.
-type addPullRequestReviewCommentReplyInput struct {
+// AddPullRequestReviewCommentReplyInput is the input for addReplyMutation.
+// Must be PascalCase so shurcooL/githubv4 sends the correct GraphQL type name.
+type AddPullRequestReviewCommentReplyInput struct {
 	PullRequestReviewThreadID githubv4.ID     `json:"pullRequestReviewThreadId"`
 	Body                      githubv4.String `json:"body"`
 }
@@ -233,8 +234,9 @@ type resolveThreadMutation struct {
 	} `graphql:"resolveReviewThread(input: $input)"`
 }
 
-// resolveReviewThreadInput is the input for resolveThreadMutation.
-type resolveReviewThreadInput struct {
+// ResolveReviewThreadInput is the input for resolveThreadMutation.
+// Must be PascalCase so shurcooL/githubv4 sends the correct GraphQL type name.
+type ResolveReviewThreadInput struct {
 	ThreadID githubv4.ID `json:"threadId"`
 }
 
@@ -337,7 +339,7 @@ func (c *Client) IsThreadResolved(ctx context.Context, threadID string) (bool, e
 // Returns the new comment's ID and creation timestamp.
 func (c *Client) ReplyToThread(ctx context.Context, threadID, body string) (ReplyResult, error) {
 	var m addReplyMutation
-	input := addPullRequestReviewCommentReplyInput{
+	input := AddPullRequestReviewCommentReplyInput{
 		PullRequestReviewThreadID: githubv4.ID(threadID),
 		Body:                      githubv4.String(body),
 	}
@@ -360,7 +362,7 @@ func (c *Client) ResolveThread(ctx context.Context, threadID string) (alreadyRes
 		return true, nil
 	}
 	var m resolveThreadMutation
-	input := resolveReviewThreadInput{ThreadID: githubv4.ID(threadID)}
+	input := ResolveReviewThreadInput{ThreadID: githubv4.ID(threadID)}
 	if err := c.v4.Mutate(ctx, &m, input, nil); err != nil {
 		return false, fmt.Errorf("graphql mutation failed: %w", err)
 	}

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -225,7 +225,7 @@ type threadMetadataQuery struct {
 			}
 			Comments struct {
 				Nodes []struct {
-					DatabaseId githubv4.Int
+					DatabaseId int64 // githubv4.Int (int32) overflows for large comment IDs
 				}
 			} `graphql:"comments(first: 1)"`
 		} `graphql:"... on PullRequestReviewThread"`


### PR DESCRIPTION
## 概要

VS Code が `copilot-review-mcp` に接続する際に表示されていた「動的クライアント登録はサポートされていません。クライアント登録（クライアント ID）を手動で指定して続行しますか？」ダイアログを解消するための修正。

## 変更内容

### 1. OAuth 動的クライアント登録 (RFC 7591) — `internal/auth/handler.go`

- Discovery ドキュメント (`/.well-known/oauth-authorization-server`) に `registration_endpoint` を追加
- `POST /register` エンドポイントを実装（疑似動的登録）
  - 事前設定済みの `GITHUB_CLIENT_ID` を返すことで VS Code が自動的にクライアント登録を完了
  - クライアントのメタデータ（`redirect_uris`, `client_name`, `scope`）をエコーバック（RFC 7591 準拠）
- デフォルトのリダイレクト許可ホストに `vscode.dev` を追加

### 2. `POST /register` ルート追加 — `cmd/server/main.go`

```go
mux.HandleFunc("POST /register", oauthHandler.Register)
```

### 3. Makefile: `.env` 自動読み込み

- `make crm-start` 等で環境変数未設定時に `.env` をフォールバック参照
- シェルで既に `export` 済みの環境変数を優先（上書きしない）
- `.env` 内のシェルスタイルクォート (`"value"`) を自動除去
  - これを修正しないと `client_id=%22...%22` とクォートがURLエンコードされ GitHub OAuth が失敗していた

### 4. Dockerfile: SQLite ボリューム用 `/data` ディレクトリ — `Dockerfile`

- ビルドステージで `/data` を作成し nonroot UID=65532 でオーナー設定
- distroless ランタイムへコピーし、ボリュームマウント時のパーミションエラーを解消

## 動作確認

- `POST /register` が `{"client_id": "Ov23li3TX2UdWVyyft43", ...}` をクォートなしで返すことを確認
- VS Code から OAuth フローが自動完了し、ダイアログが表示されないことを確認
- `make crm-start` が `.env` から認証情報を読み込んで起動することを確認