### PR TITLE
fix(copilot-review-mcp): DeriveStatus でstaleレビューによる誤完了を修正 (#39)

### DIFF
--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -130,10 +130,23 @@ func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber
 // requestedAt is nil when no trigger_log entry exists (AUTO trigger or not yet recorded).
 func (c *Client) DeriveStatus(data *ReviewData, requestedAt *time.Time) ReviewStatus {
 	if data.LatestCopilotReview != nil {
-		if data.LatestCopilotReview.GetState() == "CHANGES_REQUESTED" {
-			return StatusBlocked
+		// When requestedAt is known, only treat this review as relevant if it was submitted
+		// at or after the request time. This prevents a stale pre-existing review from being
+		// mistaken for the result of the current request.
+		// - Use !Before (≥) instead of After (>) to include same-second events.
+		// - nil submittedAt means the review has no timestamp → treat as stale.
+		relevant := true
+		if requestedAt != nil {
+			sat := data.LatestCopilotReview.GetSubmittedAt()
+			// IsZero means no timestamp recorded → treat as stale.
+			relevant = !sat.IsZero() && !sat.Before(*requestedAt)
 		}
-		return StatusCompleted
+		if relevant {
+			if data.LatestCopilotReview.GetState() == "CHANGES_REQUESTED" {
+				return StatusBlocked
+			}
+			return StatusCompleted
+		}
 	}
 	if data.IsCopilotInReviewers {
 		if requestedAt != nil {

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -19,12 +19,15 @@ func newReview(state string, submittedAt *time.Time) *github.PullRequestReview {
 }
 
 func TestDeriveStatus(t *testing.T) {
-	// threshold=30s: requestedAt=now → PENDING, requestedAt=2min ago → IN_PROGRESS
+	// threshold=30s.
+	// recentRequest: 1s elapsed → PENDING (29s slack vs threshold, safe on slow CI).
+	// longAgoRequest: 2min elapsed → IN_PROGRESS.
 	c := &Client{threshold: 30 * time.Second}
 
 	now := time.Now()
+	recentRequest := now.Add(-time.Second)   // 1s ago — safely within 30s threshold
+	longAgoRequest := now.Add(-2 * time.Minute) // 2min ago — safely past threshold
 	threeMinAgo := now.Add(-3 * time.Minute)
-	twoMinAgo := now.Add(-2 * time.Minute)
 	oneMinAgo := now.Add(-1 * time.Minute)
 	oneMinLater := now.Add(1 * time.Minute)
 
@@ -43,13 +46,13 @@ func TestDeriveStatus(t *testing.T) {
 		{
 			name:        "no review, copilot in reviewers, within threshold → PENDING",
 			data:        &ReviewData{IsCopilotInReviewers: true},
-			requestedAt: &now,
+			requestedAt: &recentRequest,
 			want:        StatusPending,
 		},
 		{
 			name:        "no review, copilot in reviewers, threshold elapsed → IN_PROGRESS",
 			data:        &ReviewData{IsCopilotInReviewers: true},
-			requestedAt: &twoMinAgo,
+			requestedAt: &longAgoRequest,
 			want:        StatusInProgress,
 		},
 		{
@@ -94,29 +97,31 @@ func TestDeriveStatus(t *testing.T) {
 
 		// ── stale review (submitted BEFORE requestedAt) ───────────────────────────
 		{
+			// review (1min ago) is older than recentRequest (1s ago) → stale,
+			// then elapsed since request = 1s < 30s threshold → PENDING.
 			name:        "stale APPROVED review, copilot in reviewers, within threshold → PENDING",
 			data:        &ReviewData{IsCopilotInReviewers: true, LatestCopilotReview: newReview("APPROVED", &oneMinAgo)},
-			requestedAt: &now,
+			requestedAt: &recentRequest,
 			want:        StatusPending,
 		},
 		{
 			name:        "stale CHANGES_REQUESTED review, copilot in reviewers, within threshold → PENDING (not BLOCKED)",
 			data:        &ReviewData{IsCopilotInReviewers: true, LatestCopilotReview: newReview("CHANGES_REQUESTED", &oneMinAgo)},
-			requestedAt: &now,
+			requestedAt: &recentRequest,
 			want:        StatusPending,
 		},
 		{
 			name:        "stale review, copilot NOT in reviewers → NOT_REQUESTED",
 			data:        &ReviewData{LatestCopilotReview: newReview("APPROVED", &oneMinAgo)},
-			requestedAt: &now,
+			requestedAt: &recentRequest,
 			want:        StatusNotRequested,
 		},
 		{
-			// review (3min ago) is older than requestedAt (2min ago) → stale,
+			// review (3min ago) is older than longAgoRequest (2min ago) → stale,
 			// then elapsed since request = 2min > 30s threshold → IN_PROGRESS.
 			name:        "stale review, copilot in reviewers, threshold elapsed → IN_PROGRESS",
 			data:        &ReviewData{IsCopilotInReviewers: true, LatestCopilotReview: newReview("APPROVED", &threeMinAgo)},
-			requestedAt: &twoMinAgo,
+			requestedAt: &longAgoRequest,
 			want:        StatusInProgress,
 		},
 

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -1,0 +1,145 @@
+package ghclient
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v72/github"
+)
+
+// newReview creates a PullRequestReview with the given state and optional submittedAt.
+func newReview(state string, submittedAt *time.Time) *github.PullRequestReview {
+	r := &github.PullRequestReview{
+		State: github.Ptr(state),
+	}
+	if submittedAt != nil {
+		r.SubmittedAt = &github.Timestamp{Time: *submittedAt}
+	}
+	return r
+}
+
+func TestDeriveStatus(t *testing.T) {
+	// threshold=30s: requestedAt=now → PENDING, requestedAt=2min ago → IN_PROGRESS
+	c := &Client{threshold: 30 * time.Second}
+
+	now := time.Now()
+	threeMinAgo := now.Add(-3 * time.Minute)
+	twoMinAgo := now.Add(-2 * time.Minute)
+	oneMinAgo := now.Add(-1 * time.Minute)
+	oneMinLater := now.Add(1 * time.Minute)
+
+	tests := []struct {
+		name        string
+		data        *ReviewData
+		requestedAt *time.Time
+		want        ReviewStatus
+	}{
+		// ── no review ────────────────────────────────────────────────────────────
+		{
+			name: "no review, no reviewers → NOT_REQUESTED",
+			data: &ReviewData{},
+			want: StatusNotRequested,
+		},
+		{
+			name:        "no review, copilot in reviewers, within threshold → PENDING",
+			data:        &ReviewData{IsCopilotInReviewers: true},
+			requestedAt: &now,
+			want:        StatusPending,
+		},
+		{
+			name:        "no review, copilot in reviewers, threshold elapsed → IN_PROGRESS",
+			data:        &ReviewData{IsCopilotInReviewers: true},
+			requestedAt: &twoMinAgo,
+			want:        StatusInProgress,
+		},
+		{
+			name: "no review, copilot in reviewers, no requestedAt → IN_PROGRESS (AUTO)",
+			data: &ReviewData{IsCopilotInReviewers: true},
+			want: StatusInProgress,
+		},
+
+		// ── review exists, requestedAt nil (backward compat) ─────────────────────
+		{
+			name: "APPROVED review, no requestedAt → COMPLETED",
+			data: &ReviewData{LatestCopilotReview: newReview("APPROVED", &oneMinAgo)},
+			want: StatusCompleted,
+		},
+		{
+			name: "CHANGES_REQUESTED review, no requestedAt → BLOCKED",
+			data: &ReviewData{LatestCopilotReview: newReview("CHANGES_REQUESTED", &oneMinAgo)},
+			want: StatusBlocked,
+		},
+
+		// ── review submitted AFTER requestedAt ───────────────────────────────────
+		{
+			name:        "APPROVED review after requestedAt → COMPLETED",
+			data:        &ReviewData{LatestCopilotReview: newReview("APPROVED", &oneMinLater)},
+			requestedAt: &now,
+			want:        StatusCompleted,
+		},
+		{
+			name:        "CHANGES_REQUESTED review after requestedAt → BLOCKED",
+			data:        &ReviewData{LatestCopilotReview: newReview("CHANGES_REQUESTED", &oneMinLater)},
+			requestedAt: &now,
+			want:        StatusBlocked,
+		},
+
+		// ── review submitted at EXACTLY requestedAt (same-second inclusive) ───────
+		{
+			name:        "APPROVED review at exact requestedAt → COMPLETED (same-second inclusive)",
+			data:        &ReviewData{LatestCopilotReview: newReview("APPROVED", &now)},
+			requestedAt: &now,
+			want:        StatusCompleted,
+		},
+
+		// ── stale review (submitted BEFORE requestedAt) ───────────────────────────
+		{
+			name:        "stale APPROVED review, copilot in reviewers, within threshold → PENDING",
+			data:        &ReviewData{IsCopilotInReviewers: true, LatestCopilotReview: newReview("APPROVED", &oneMinAgo)},
+			requestedAt: &now,
+			want:        StatusPending,
+		},
+		{
+			name:        "stale CHANGES_REQUESTED review, copilot in reviewers, within threshold → PENDING (not BLOCKED)",
+			data:        &ReviewData{IsCopilotInReviewers: true, LatestCopilotReview: newReview("CHANGES_REQUESTED", &oneMinAgo)},
+			requestedAt: &now,
+			want:        StatusPending,
+		},
+		{
+			name:        "stale review, copilot NOT in reviewers → NOT_REQUESTED",
+			data:        &ReviewData{LatestCopilotReview: newReview("APPROVED", &oneMinAgo)},
+			requestedAt: &now,
+			want:        StatusNotRequested,
+		},
+		{
+			// review (3min ago) is older than requestedAt (2min ago) → stale,
+			// then elapsed since request = 2min > 30s threshold → IN_PROGRESS.
+			name:        "stale review, copilot in reviewers, threshold elapsed → IN_PROGRESS",
+			data:        &ReviewData{IsCopilotInReviewers: true, LatestCopilotReview: newReview("APPROVED", &threeMinAgo)},
+			requestedAt: &twoMinAgo,
+			want:        StatusInProgress,
+		},
+
+		// ── nil submittedAt on review ─────────────────────────────────────────────
+		{
+			name:        "review with nil submittedAt, requestedAt set → treat as stale → NOT_REQUESTED",
+			data:        &ReviewData{LatestCopilotReview: newReview("APPROVED", nil)},
+			requestedAt: &now,
+			want:        StatusNotRequested,
+		},
+		{
+			name: "review with nil submittedAt, no requestedAt → COMPLETED (backward compat)",
+			data: &ReviewData{LatestCopilotReview: newReview("APPROVED", nil)},
+			want: StatusCompleted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.DeriveStatus(tt.data, tt.requestedAt)
+			if got != tt.want {
+				t.Errorf("DeriveStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `DeriveStatus` が `requestedAt` より前に提出された既存レビューを誤って COMPLETED/BLOCKED と判定していたバグを修正
- `!Before` (≥) による同一秒イベントの包含、`IsZero()` による nil submittedAt の stale 扱いを実装
- `DeriveStatus` の全シナリオをカバーするユニットテスト 15 件を新規追加

## Changes

### `internal/github/client.go` — `DeriveStatus` 修正

`requestedAt` が設定されている場合、`LatestCopilotReview.GetSubmittedAt()` が `requestedAt` 以降かを検証してから COMPLETED/BLOCKED を返すよう変更。

```go
relevant := true
if requestedAt != nil {
    sat := data.LatestCopilotReview.GetSubmittedAt()
    relevant = !sat.IsZero() && !sat.Before(*requestedAt)
}
```

| 対処点 | 内容 |
|---|---|
| `After` だと同一秒が除外 | `!Before` (≥) を使用 |
| nil submittedAt で誤判定 | `IsZero()` で stale 扱い |
| stale レビューによる誤完了 | `requestedAt` 以降のみ有効と判定 |

### `internal/github/client_test.go` — 新規追加

レビューなし・stale レビュー・同一秒・nil タイムスタンプ・後方互換性 (requestedAt=nil) など全シナリオをテスト。

## Test plan

- [x] `go test ./internal/github/...` — 15件全 PASS
- [x] `go build ./...` — ビルドエラーなし

Closes #39