### PR TITLE
fix(copilot-review-mcp): Token レスポンスに expires_in を追加して認証切れを防ぐ

### DIFF
--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -37,6 +37,7 @@ func main() {
 		Scopes:             cfg.oauthScopes,
 		SessionTTL:         time.Duration(cfg.sessionTTLMin) * time.Minute,
 		CacheTTL:           time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
+		ExpiresIn:          time.Duration(cfg.tokenExpiresInSec) * time.Second,
 	})
 
 	authMiddleware := middleware.Auth(oauthHandler)
@@ -89,6 +90,7 @@ type config struct {
 	logLevel               string
 	sessionTTLMin          int
 	tokenCacheTTLMin       int
+	tokenExpiresInSec      int
 	sqlitePath             string
 	inProgressThresholdSec int
 }
@@ -103,6 +105,7 @@ func loadConfig() config {
 		logLevel:               getEnv("LOG_LEVEL", "info"),
 		sessionTTLMin:          getEnvInt("SESSION_TTL_MIN", 10),
 		tokenCacheTTLMin:       getEnvInt("TOKEN_CACHE_TTL_MIN", 5),
+		tokenExpiresInSec:      getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
 		sqlitePath:             getEnv("SQLITE_PATH", "/data/copilot-review.db"),
 		inProgressThresholdSec: getEnvInt("IN_PROGRESS_THRESHOLD_SEC", 30),
 	}

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -260,13 +260,19 @@ func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Use integer division to avoid float64 precision issues from Duration.Seconds().
+	// Clamp to at least 1 so expires_in is always a positive integer per RFC 6749 §5.1.
+	expiresInSeconds := int64(h.cfg.ExpiresIn / time.Second)
+	if expiresInSeconds < 1 {
+		expiresInSeconds = 1
+	}
 	tokenResp := map[string]any{
 		"access_token": token,
 		"token_type":   "Bearer",
 		// RFC 6749 §5.1: expires_in tells MCP clients how long to trust the cached token.
 		// GitHub classic OAuth tokens do not expire server-side; this value controls
 		// client-side re-authentication frequency only.
-		"expires_in": int64(h.cfg.ExpiresIn.Seconds()),
+		"expires_in": expiresInSeconds,
 	}
 	// RFC 6749 §5.1: include the scope actually granted by GitHub rather than the requested scope.
 	if grantedScope != "" {

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -25,6 +25,11 @@ type Config struct {
 	SessionTTL           time.Duration
 	CacheTTL             time.Duration
 	AllowedRedirectHosts []string // allowlist of permitted redirect_uri hostnames; defaults to ["localhost","127.0.0.1","vscode.dev"]
+	// ExpiresIn is the lifetime advertised to MCP clients via the token response
+	// expires_in field (RFC 6749 §5.1). GitHub classic OAuth tokens do not expire
+	// on GitHub's side, so this value only controls how long the MCP client trusts
+	// its cached copy before re-authenticating. Defaults to 7776000 s (90 days).
+	ExpiresIn time.Duration
 }
 
 // UpstreamError represents a failure contacting an upstream service (e.g. GitHub API
@@ -48,6 +53,9 @@ func NewHandler(cfg Config) *Handler {
 	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
 	if len(cfg.AllowedRedirectHosts) == 0 {
 		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1", "vscode.dev"}
+	}
+	if cfg.ExpiresIn <= 0 {
+		cfg.ExpiresIn = 90 * 24 * time.Hour // 90 days default
 	}
 	return &Handler{
 		cfg:   cfg,
@@ -255,6 +263,10 @@ func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 	tokenResp := map[string]any{
 		"access_token": token,
 		"token_type":   "Bearer",
+		// RFC 6749 §5.1: expires_in tells MCP clients how long to trust the cached token.
+		// GitHub classic OAuth tokens do not expire server-side; this value controls
+		// client-side re-authentication frequency only.
+		"expires_in": int64(h.cfg.ExpiresIn.Seconds()),
 	}
 	// RFC 6749 §5.1: include the scope actually granted by GitHub rather than the requested scope.
 	if grantedScope != "" {


### PR DESCRIPTION
## Summary

- Token エンドポイントが `expires_in` を返していなかったため、MCP クライアント（Claude Code）が内部デフォルト値でトークン有効期限を判断し、早期に再認証を要求していた問題を修正
- GitHub classic OAuth トークンはサーバー側で失効しないため、`expires_in` はクライアント側の再認証頻度を制御するためだけに使用
- デフォルト 90 日（7,776,000 秒）。`TOKEN_EXPIRES_IN_SEC` 環境変数でカスタマイズ可能

## Changes

### `internal/auth/handler.go`

- `Config.ExpiresIn` フィールドを追加（コメント付き）
- `NewHandler` でゼロ値の場合に 90 日をデフォルト設定
- `Token` レスポンスに `expires_in` を追加（RFC 6749 §5.1 準拠）

### `cmd/server/main.go`

- `config.tokenExpiresInSec` フィールドを追加
- `TOKEN_EXPIRES_IN_SEC` 環境変数を追加（デフォルト: `7776000`）
- `auth.Config.ExpiresIn` に渡す

## Test plan

- [x] `go build ./...` — ビルドエラーなし
- [x] `go test ./...` — 既存テスト全 PASS