### PR TITLE
feat(github-oauth-proxy): mcp-remote経由Claude Desktop接続用OAuthプロキシを新設

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -34,3 +34,36 @@ GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # ログレベル (debug, info, warn, error)
 LOG_LEVEL=info
+
+# =============================================================================
+# github-oauth-proxy (ISSUE #41) — mcp-remote経由でClaude Desktopから接続する場合
+# =============================================================================
+#
+# GitHub OAuth App の作成手順:
+#   1. https://github.com/settings/applications/new にアクセス
+#   2. Application name: 任意 (例: "GitHub MCP Proxy")
+#   3. Homepage URL: http://localhost:8084
+#   4. Authorization callback URL: http://localhost:8084/callback
+#   5. 作成後に Client ID と Client Secret を取得
+#
+# 補足: copilot-review-mcp 用の GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET と
+#       同一の GitHub OAuth App を共有することも可能
+#
+# GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
+# GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# github-oauth-proxy の外部 URL（OAuth callback URL に使用）
+# デフォルト: http://localhost:8084
+# GITHUB_OAUTH_PROXY_BASE_URL=http://localhost:8084
+
+# github-oauth-proxy のリッスンポート
+# デフォルト: 8084
+# GITHUB_OAUTH_PROXY_PORT=8084
+
+# 転送先 github-mcp-server の URL（Docker ネットワーク内部）
+# デフォルト: http://github-mcp:8082
+# GITHUB_MCP_UPSTREAM_URL=http://github-mcp:8082
+
+# GitHub OAuth スコープ
+# デフォルト: repo,user
+# GITHUB_MCP_OAUTH_SCOPES=repo,user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-04-06
+
+### ✨ 新機能
+
+- `github-oauth-proxy` サービスを新設（`services/github-oauth-proxy/`）
+  - mcp-remote 経由で Claude Desktop から github-mcp-server へ OAuth 認証付き接続が可能に（ISSUE #41）
+  - RFC 8414 discovery / RFC 7591 Dynamic Client Registration (疑似) / Authorization Code + PKCE フローを実装
+  - Bearer トークンを GitHub API（`GET /user`）で検証しキャッシュ。upstream (github-mcp-server) が HTTP 401 を返した際はキャッシュを即時無効化
+  - `httputil.ReverseProxy.Rewrite` による厳格なヘッダーサニタイズ（`X-Forwarded-For` 等除去・`X-GitHub-Login` 注入）
+  - 監査ログ: login / path / upstream_status / token_hash (SHA-256 前 8 桁) を `slog` で出力
+  - `distroless/static-debian12:nonroot` ベースの最小イメージ。外部依存ライブラリなし（標準ライブラリのみ）
+
+- `docker-compose.yml` に `github-oauth-proxy` サービスを追加
+  - `github-mcp` のホスト公開ポートを廃止し Docker ネットワーク内に閉じ込め（セキュリティ向上）
+  - `github-oauth-proxy` はポート 8084 でホスト公開
+
+- `config/ide-configs/github-oauth-proxy/` に各クライアント向け設定を追加
+  - `claude-desktop/`: mcp-remote 経由 stdio ブリッジ設定
+  - `vscode/`: HTTP 直接接続設定
+  - `codex/`: TOML 形式設定
+
 ## [2.2.0] - 2026-03-17
 
 ### ✨ 新機能

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,10 @@ services:
       - ./config/github-mcp:/app/config
       - github-mcp-cache:/app/cache
 
-    ports:
-      - "127.0.0.1:${GITHUB_MCP_HTTP_PORT:-8082}:${GITHUB_MCP_HTTP_PORT:-8082}"
+    # Exposed only within the Docker network. Direct host access is intentionally
+    # removed; use github-oauth-proxy (:8084) for authenticated external access.
+    expose:
+      - "${GITHUB_MCP_HTTP_PORT:-8082}"
 
     networks:
       - mcp-network
@@ -41,6 +43,50 @@ services:
           cpus: "1.0"
           memory: 512M
         reservations:
+          cpus: "0.5"
+          memory: 256M
+
+  github-oauth-proxy:
+    build:
+      context: ./services/github-oauth-proxy
+      dockerfile: Dockerfile
+    image: github-oauth-proxy:local
+    container_name: github-oauth-proxy
+    restart: unless-stopped
+    depends_on:
+      - github-mcp
+
+    environment:
+      - GITHUB_MCP_CLIENT_ID=${GITHUB_MCP_CLIENT_ID}
+      - GITHUB_MCP_CLIENT_SECRET=${GITHUB_MCP_CLIENT_SECRET}
+      - GITHUB_OAUTH_PROXY_BASE_URL=${GITHUB_OAUTH_PROXY_BASE_URL:-http://localhost:8084}
+      - GITHUB_OAUTH_PROXY_PORT=${GITHUB_OAUTH_PROXY_PORT:-8084}
+      - GITHUB_MCP_UPSTREAM_URL=${GITHUB_MCP_UPSTREAM_URL:-http://github-mcp:8082}
+      - GITHUB_MCP_OAUTH_SCOPES=${GITHUB_MCP_OAUTH_SCOPES:-repo,user}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - SESSION_TTL_MIN=${SESSION_TTL_MIN:-10}
+      - TOKEN_CACHE_TTL_MIN=${TOKEN_CACHE_TTL_MIN:-5}
+      - TOKEN_EXPIRES_IN_SEC=${TOKEN_EXPIRES_IN_SEC:-7776000}
+
+    ports:
+      - "127.0.0.1:${GITHUB_OAUTH_PROXY_PORT:-8084}:${GITHUB_OAUTH_PROXY_PORT:-8084}"
+
+    networks:
+      - mcp-network
+
+    # Note: distroless image has no shell/wget. Health is validated host-side.
+    healthcheck:
+      disable: true
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+    deploy:
+      resources:
+        limits:
           cpus: "0.5"
           memory: 256M
 

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -466,6 +466,21 @@ EOF
 fi
 
 # ── github-mcp サービス（既存ロジック）─────────────────────────────────────────
+#
+# ⚠️  注意: docker-compose.yml の変更により github-mcp はホスト非公開（Docker ネットワーク内部のみ）
+# になっています。GITHUB_MCP_SERVER_URL を明示的に設定していない場合、生成される設定の接続先
+# (http://127.0.0.1:8082) には接続できません。
+#
+# ホストから github-mcp-server に接続するには github-oauth-proxy 経由を推奨:
+#   $0 --ide ${IDE} --service github-oauth-proxy
+#
+if [[ -z "${GITHUB_MCP_SERVER_URL:-}" ]] && [[ -z "$(extract_env_value "GITHUB_MCP_SERVER_URL")" ]]; then
+    echo "⚠️  警告: github-mcp はホスト非公開（Docker ネットワーク内部のみ）です。"
+    echo "   生成された設定の接続先 (${SERVER_URL}) には接続できない可能性があります。"
+    echo "   代わりに github-oauth-proxy 経由を使用することを推奨します:"
+    echo "   $0 --ide ${IDE} --service github-oauth-proxy"
+    echo ""
+fi
 
 OUTPUT_DIR="${PROJECT_ROOT}/config/ide-configs/${IDE}"
 mkdir -p "${OUTPUT_DIR}"

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -21,9 +21,11 @@ IDE名:
   copilot-cli     GitHub Copilot CLI
 
 サービス名 (--service):
-  github-mcp          GitHub MCP Server（デフォルト、Docker HTTP ブリッジ port 8082）
+  github-mcp          GitHub MCP Server（Docker ネットワーク内部のみ port 8082、ホストからは直接アクセス不可）
+                      ※ ホストから接続するには github-oauth-proxy 経由を推奨
   copilot-review-mcp  Copilot Review MCP Server（OAuth 付き HTTP、port 8083）
   github-oauth-proxy  GitHub OAuth Proxy（mcp-remote 経由 Claude Desktop 対応、port 8084）
+                      ※ Claude Desktop から github-mcp-server に接続する場合はこちらを使用
 
 例:
   $0 --ide vscode

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -23,11 +23,13 @@ IDE名:
 サービス名 (--service):
   github-mcp          GitHub MCP Server（デフォルト、Docker HTTP ブリッジ port 8082）
   copilot-review-mcp  Copilot Review MCP Server（OAuth 付き HTTP、port 8083）
+  github-oauth-proxy  GitHub OAuth Proxy（mcp-remote 経由 Claude Desktop 対応、port 8084）
 
 例:
   $0 --ide vscode
   $0 --ide vscode --service copilot-review-mcp
   $0 --ide claude-desktop
+  $0 --ide claude-desktop --service github-oauth-proxy
   $0 --ide amazonq --service copilot-review-mcp
   $0 --ide codex
   $0 --ide copilot-cli
@@ -42,6 +44,11 @@ IDE名:
   COPILOT_REVIEW_MCP_URL        HTTP 接続先 URL（未設定時は COPILOT_REVIEW_MCP_PORT から生成）
   COPILOT_REVIEW_MCP_PORT       HTTP ポート番号（デフォルト: 8083）
   GITHUB_PERSONAL_ACCESS_TOKEN  Bearer トークン（GitHub PAT, fine-grained 推奨）
+
+環境変数 (github-oauth-proxy):
+  GITHUB_OAUTH_PROXY_URL        HTTP 接続先 URL（未設定時は GITHUB_OAUTH_PROXY_PORT から生成）
+  GITHUB_OAUTH_PROXY_PORT       HTTP ポート番号（デフォルト: 8084）
+  GITHUB_PERSONAL_ACCESS_TOKEN  Bearer トークン（GitHub PAT または OAuth トークン）
 EOF
     exit 1
 }
@@ -69,7 +76,7 @@ if [[ -z "$IDE" ]]; then
 fi
 
 case "$SERVICE" in
-    github-mcp|copilot-review-mcp) ;;
+    github-mcp|copilot-review-mcp|github-oauth-proxy) ;;
     *) echo "❌ 未対応のサービス: $SERVICE"; usage ;;
 esac
 
@@ -126,9 +133,28 @@ resolve_copilot_review_url() {
     echo "${url}"
 }
 
+resolve_oauth_proxy_url() {
+    local url="${GITHUB_OAUTH_PROXY_URL:-}"
+    if [[ -z "${url}" ]]; then
+        url="$(extract_env_value "GITHUB_OAUTH_PROXY_URL")"
+    fi
+    if [[ -z "${url}" ]]; then
+        local port="${GITHUB_OAUTH_PROXY_PORT:-}"
+        if [[ -z "${port}" ]]; then
+            port="$(extract_env_value "GITHUB_OAUTH_PROXY_PORT")"
+        fi
+        port="${port:-8084}"
+        url="http://127.0.0.1:${port}"
+    fi
+    url="${url%/}"
+    url="${url%/mcp}"
+    echo "${url}"
+}
+
 SERVER_URL="$(resolve_server_url)"
 BRIDGE_TIMEOUT_MS="${MCP_HTTP_BRIDGE_TIMEOUT_MS:-30000}"
 COPILOT_REVIEW_URL="$(resolve_copilot_review_url)"
+OAUTH_PROXY_URL="$(resolve_oauth_proxy_url)"
 
 # ── 出力先・サービス別ディスパッチ ───────────────────────────────────────────
 
@@ -288,6 +314,150 @@ EOF
         *)
             echo "❌ 未対応のIDE: $IDE"
             usage
+            ;;
+    esac
+    exit 0
+fi
+
+# ── github-oauth-proxy サービス ──────────────────────────────────────────────
+
+if [[ "$SERVICE" == "github-oauth-proxy" ]]; then
+    GOP_SERVER_KEY="github-mcp-server-docker"
+    GOP_MCP_URL="${OAUTH_PROXY_URL}/mcp"
+
+    case "$IDE" in
+        vscode|claude-desktop|kiro|amazonq|codex|copilot-cli)
+            ;;
+        *)
+            echo "❌ 未対応のIDEです: $IDE"
+            echo "対応IDE: vscode, claude-desktop, kiro, amazonq, codex, copilot-cli"
+            exit 1
+            ;;
+    esac
+
+    GOP_OUTPUT_DIR="${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/${IDE}"
+    mkdir -p "${GOP_OUTPUT_DIR}"
+
+    case "$IDE" in
+        claude-desktop)
+            cat > "${GOP_OUTPUT_DIR}/claude_desktop_config.json" <<EOF
+{
+  "mcpServers": {
+    "${GOP_SERVER_KEY}": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "${GOP_MCP_URL}"
+      ]
+    }
+  }
+}
+EOF
+            echo "✅ Claude Desktop設定を生成しました: ${GOP_OUTPUT_DIR}/claude_desktop_config.json"
+            echo ""
+            echo "📋 設定方法:"
+            echo "   1. github-oauth-proxy / github-mcp サービスを起動:"
+            echo "      docker compose up -d github-mcp github-oauth-proxy"
+            echo "   2. 生成された設定を Claude Desktop設定ファイルにマージ:"
+            echo "      Windows: %APPDATA%\\Claude\\claude_desktop_config.json"
+            echo "      macOS:   ~/Library/Application Support/Claude/claude_desktop_config.json"
+            echo "   3. Claude Desktop を再起動"
+            echo "   4. ブラウザで GitHub OAuth 認証フロー（初回のみ）"
+            echo ""
+            echo "ℹ️  mcp-remote が OAuth フローを自動的に処理します（ブラウザが開きます）"
+            echo "   接続先: ${GOP_MCP_URL}"
+            ;;
+
+        vscode)
+            cat > "${GOP_OUTPUT_DIR}/settings.json" <<EOF
+{
+  "mcpServers": {
+    "${GOP_SERVER_KEY}": {
+      "type": "http",
+      "url": "${GOP_MCP_URL}",
+      "headers": {
+        "Authorization": "Bearer \${env:GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+EOF
+            echo "✅ VS Code設定を生成しました: ${GOP_OUTPUT_DIR}/settings.json"
+            echo ""
+            echo "📋 設定方法:"
+            echo "   1. github-oauth-proxy / github-mcp サービスを起動"
+            echo "   2. VS Code設定 (.vscode/settings.json) に追加"
+            echo "   3. 接続先URL: ${GOP_MCP_URL}"
+            echo ""
+            echo "💡 Bearer トークンの設定:"
+            echo "   export GITHUB_PERSONAL_ACCESS_TOKEN=your_pat_here"
+            ;;
+
+        kiro)
+            cat > "${GOP_OUTPUT_DIR}/mcp.json" <<EOF
+{
+  "mcp": {
+    "servers": {
+      "${GOP_SERVER_KEY}": {
+        "type": "http",
+        "url": "${GOP_MCP_URL}",
+        "headers": {
+          "Authorization": "Bearer \${GITHUB_PERSONAL_ACCESS_TOKEN}"
+        }
+      }
+    }
+  }
+}
+EOF
+            echo "✅ Kiro設定を生成しました: ${GOP_OUTPUT_DIR}/mcp.json"
+            echo "   接続先URL: ${GOP_MCP_URL}"
+            ;;
+
+        amazonq)
+            cat > "${GOP_OUTPUT_DIR}/mcp.json" <<EOF
+{
+  "mcpServers": {
+    "${GOP_SERVER_KEY}": {
+      "type": "http",
+      "url": "${GOP_MCP_URL}",
+      "headers": {
+        "Authorization": "Bearer \${env:GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+EOF
+            echo "✅ Amazon Q設定を生成しました: ${GOP_OUTPUT_DIR}/mcp.json"
+            echo "   接続先URL: ${GOP_MCP_URL}"
+            ;;
+
+        codex)
+            cat > "${GOP_OUTPUT_DIR}/config.toml" <<EOF
+[mcp_servers.${GOP_SERVER_KEY}]
+url = "${GOP_MCP_URL}"
+bearer_token_env_var = "GITHUB_PERSONAL_ACCESS_TOKEN"
+EOF
+            echo "✅ Codex設定を生成しました: ${GOP_OUTPUT_DIR}/config.toml"
+            echo "   接続先URL: ${GOP_MCP_URL}"
+            ;;
+
+        copilot-cli)
+            cat > "${GOP_OUTPUT_DIR}/mcp-config.json" <<EOF
+{
+  "mcpServers": {
+    "${GOP_SERVER_KEY}": {
+      "type": "http",
+      "url": "${GOP_MCP_URL}",
+      "headers": {
+        "Authorization": "Bearer \${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+EOF
+            echo "✅ Copilot CLI設定を生成しました: ${GOP_OUTPUT_DIR}/mcp-config.json"
+            echo "   接続先URL: ${GOP_MCP_URL}"
             ;;
     esac
     exit 0

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -5,20 +5,28 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 ENV_FILE="${PROJECT_ROOT}/.env"
 WITH_API_CHECK="auto"
+SERVICE="github-oauth-proxy"
 
 usage() {
     cat <<EOF
 使用方法: $0 [オプション]
 
 オプション:
-  --with-api    GitHub API接続確認を必ず実行
-  --no-api      GitHub API接続確認をスキップ
-  -h, --help    ヘルプを表示
+  --service <サービス名>  ヘルスチェック対象サービス (デフォルト: github-oauth-proxy)
+                          github-oauth-proxy : OAuth プロキシ経由のエンドポイントを確認 (port 8084)
+                          github-mcp         : github-mcp コンテナ状態のみ確認 (ホスト非公開のため HTTP 疎通不可)
+  --with-api              GitHub API接続確認を必ず実行
+  --no-api                GitHub API接続確認をスキップ
+  -h, --help              ヘルプを表示
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --service)
+            SERVICE="$2"
+            shift 2
+            ;;
         --with-api)
             WITH_API_CHECK="always"
             shift
@@ -39,6 +47,15 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+case "$SERVICE" in
+    github-mcp|github-oauth-proxy) ;;
+    *)
+        echo "❌ 未対応のサービス: $SERVICE"
+        echo "対応サービス: github-mcp, github-oauth-proxy"
+        exit 1
+        ;;
+esac
 
 require_command() {
     local cmd="$1"
@@ -88,25 +105,20 @@ extract_api_url_from_env_file() {
     extract_env_value "GITHUB_API_URL"
 }
 
-resolve_server_url() {
-    local server_url="${GITHUB_MCP_SERVER_URL:-}"
-    if [[ -z "${server_url}" ]]; then
-        server_url="$(extract_env_value "GITHUB_MCP_SERVER_URL")"
+resolve_oauth_proxy_url() {
+    local url="${GITHUB_OAUTH_PROXY_URL:-}"
+    if [[ -z "${url}" ]]; then
+        url="$(extract_env_value "GITHUB_OAUTH_PROXY_URL")"
     fi
-
-    if [[ -z "${server_url}" ]]; then
-        local http_port="${GITHUB_MCP_HTTP_PORT:-}"
-        if [[ -z "${http_port}" ]]; then
-            http_port="$(extract_env_value "GITHUB_MCP_HTTP_PORT")"
+    if [[ -z "${url}" ]]; then
+        local port="${GITHUB_OAUTH_PROXY_PORT:-}"
+        if [[ -z "${port}" ]]; then
+            port="$(extract_env_value "GITHUB_OAUTH_PROXY_PORT")"
         fi
-        if [[ -z "${http_port}" ]]; then
-            http_port="8082"
-        fi
-        server_url="http://127.0.0.1:${http_port}"
+        port="${port:-8084}"
+        url="http://127.0.0.1:${port}"
     fi
-
-    server_url="${server_url%/}"
-    echo "${server_url}"
+    echo "${url%/}"
 }
 
 is_placeholder_token() {
@@ -136,52 +148,74 @@ is_token_prefix_valid() {
     [[ "${token}" =~ ^(github_pat_|ghp_) ]]
 }
 
-echo "🏥 GitHub MCP Server ヘルスチェック"
+check_container_state() {
+    local service_name="$1"
+    local container_id
+    container_id="$(docker compose ps -q "${service_name}")"
+    if [[ -z "${container_id}" ]]; then
+        echo "❌ コンテナが見つかりません (${service_name})"
+        echo "   起動: docker compose up -d ${service_name}"
+        return 1
+    fi
+
+    local running_state
+    running_state="$(docker inspect -f '{{.State.Running}}' "${container_id}")"
+    if [[ "${running_state}" != "true" ]]; then
+        echo "❌ コンテナは停止状態です (${service_name})"
+        echo "   ログ確認: docker compose logs ${service_name}"
+        return 1
+    fi
+    echo "✅ コンテナは起動しています (${service_name})"
+
+    local restart_count
+    restart_count="$(docker inspect -f '{{.RestartCount}}' "${container_id}")"
+    if [[ "${restart_count}" != "0" ]]; then
+        echo "⚠️  コンテナの再起動回数: ${restart_count} (${service_name})"
+        echo "   不安定な可能性があるためログ確認を推奨: docker compose logs --tail=200 ${service_name}"
+    else
+        echo "✅ 再起動は発生していません (${service_name})"
+    fi
+}
+
+echo "🏥 GitHub MCP Server ヘルスチェック (--service ${SERVICE})"
 echo ""
 
 ensure_docker_ready
 
-# コンテナ状態確認
-container_id="$(docker compose ps -q github-mcp)"
-if [[ -z "${container_id}" ]]; then
-    echo "❌ コンテナが見つかりません"
-    echo "   起動: docker compose up -d github-mcp"
-    exit 1
+if [[ "${SERVICE}" == "github-mcp" ]]; then
+    # github-mcp はホスト非公開（Docker ネットワーク内部のみ）のため、
+    # コンテナ状態確認のみ実施。HTTP 疎通は github-oauth-proxy 経由で確認してください。
+    echo "ℹ️  github-mcp はホスト非公開です。HTTP 疎通確認はスキップします。"
+    echo "   HTTP エンドポイントを確認する場合: $0 --service github-oauth-proxy"
+    echo ""
+    check_container_state "github-mcp"
+    echo ""
+    echo "🎉 コンテナ状態チェックに合格しました"
+    exit 0
 fi
 
-running_state="$(docker inspect -f '{{.State.Running}}' "${container_id}")"
-if [[ "${running_state}" != "true" ]]; then
-    echo "❌ コンテナは停止状態です"
-    echo "   ログ確認: docker compose logs github-mcp"
-    exit 1
-fi
-echo "✅ コンテナは起動しています"
+# github-oauth-proxy のヘルスチェック
+# github-mcp コンテナ状態も確認
+check_container_state "github-mcp"
+check_container_state "github-oauth-proxy"
 
-restart_count="$(docker inspect -f '{{.RestartCount}}' "${container_id}")"
-if [[ "${restart_count}" != "0" ]]; then
-    echo "⚠️  コンテナの再起動回数: ${restart_count}"
-    echo "   不安定な可能性があるためログ確認を推奨: docker compose logs --tail=200 github-mcp"
-else
-    echo "✅ 再起動は発生していません"
-fi
-
-# HTTPエンドポイント確認
-server_url="$(resolve_server_url)"
+# HTTP エンドポイント確認 (github-oauth-proxy 経由)
+proxy_url="$(resolve_oauth_proxy_url)"
 if command -v curl > /dev/null 2>&1; then
     # curl failures should not abort the script, so we use || true and check the result
-    http_status="$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "${server_url}/" || true)"
+    http_status="$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "${proxy_url}/health" || true)"
     # 正常な3桁のHTTPステータスコードでない場合は "000" をデフォルトとする
     if [[ ! "${http_status}" =~ ^[0-9]{3}$ ]]; then
         http_status="000"
     fi
-    if [[ "${http_status}" == "200" ]] || [[ "${http_status}" == "401" ]]; then
-        echo "✅ MCP HTTPエンドポイント疎通成功 (${server_url}, status=${http_status})"
+    if [[ "${http_status}" == "200" ]]; then
+        echo "✅ github-oauth-proxy ヘルスエンドポイント疎通成功 (${proxy_url}/health, status=${http_status})"
     else
-        echo "❌ MCP HTTPエンドポイント疎通失敗 (${server_url}, status=${http_status})"
+        echo "❌ github-oauth-proxy ヘルスエンドポイント疎通失敗 (${proxy_url}/health, status=${http_status})"
         exit 1
     fi
 else
-    echo "⚠️  curl が未インストールのため、MCP HTTPエンドポイント確認をスキップします"
+    echo "⚠️  curl が未インストールのため、HTTP エンドポイント確認をスキップします"
 fi
 
 # GitHub API接続確認

--- a/services/github-oauth-proxy/Dockerfile
+++ b/services/github-oauth-proxy/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.26-alpine AS builder
+WORKDIR /src
+COPY go.mod ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
+    -o /out/github-oauth-proxy ./cmd/server
+
+# distroless: no shell, no package manager
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /out/github-oauth-proxy /github-oauth-proxy
+EXPOSE 8084
+# Trivy DS-0002: explicitly declare non-root user (distroless:nonroot UID=65532)
+USER nonroot:nonroot
+ENTRYPOINT ["/github-oauth-proxy"]

--- a/services/github-oauth-proxy/cmd/server/main.go
+++ b/services/github-oauth-proxy/cmd/server/main.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/scottlz0310/github-oauth-proxy/internal/auth"
+	"github.com/scottlz0310/github-oauth-proxy/internal/middleware"
+	"github.com/scottlz0310/github-oauth-proxy/internal/proxy"
+)
+
+func main() {
+	cfg := loadConfig()
+
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: parseLogLevel(cfg.logLevel),
+	})))
+
+	oauthHandler := auth.NewHandler(auth.Config{
+		GitHubClientID:     cfg.githubClientID,
+		GitHubClientSecret: cfg.githubClientSecret,
+		BaseURL:            cfg.baseURL,
+		Scopes:             cfg.oauthScopes,
+		SessionTTL:         time.Duration(cfg.sessionTTLMin) * time.Minute,
+		CacheTTL:           time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
+		ExpiresIn:          time.Duration(cfg.tokenExpiresInSec) * time.Second,
+	})
+
+	authMiddleware := middleware.Auth(oauthHandler)
+
+	upstreamURL, err := url.Parse(cfg.upstreamURL)
+	if err != nil {
+		slog.Error("invalid upstream URL", "url", cfg.upstreamURL, "err", err)
+		os.Exit(1)
+	}
+
+	mcpProxy := proxy.NewHandler(upstreamURL, oauthHandler)
+
+	mux := http.NewServeMux()
+
+	// OAuth façade endpoints (no auth required)
+	mux.HandleFunc("GET /.well-known/oauth-authorization-server", oauthHandler.Discovery)
+	mux.HandleFunc("GET /authorize", oauthHandler.Authorize)
+	mux.HandleFunc("GET /callback", oauthHandler.Callback)
+	mux.HandleFunc("POST /token", oauthHandler.Token)
+	mux.HandleFunc("POST /register", oauthHandler.Register)
+
+	// Health check (no auth required)
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"status":"ok"}`)
+	})
+
+	// MCP endpoint: Bearer validation → reverse proxy to github-mcp-server
+	mux.Handle("/mcp", authMiddleware(mcpProxy))
+	mux.Handle("/mcp/", authMiddleware(mcpProxy))
+
+	addr := ":" + cfg.port
+	slog.Info("github-oauth-proxy starting",
+		"addr", addr,
+		"base_url", cfg.baseURL,
+		"upstream", cfg.upstreamURL,
+	)
+
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      0, // unlimited: MCP streaming responses may be long-lived
+		IdleTimeout:       120 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil {
+		slog.Error("server error", "err", err)
+		os.Exit(1)
+	}
+}
+
+type config struct {
+	githubClientID     string
+	githubClientSecret string
+	baseURL            string
+	oauthScopes        string
+	port               string
+	logLevel           string
+	upstreamURL        string
+	sessionTTLMin      int
+	tokenCacheTTLMin   int
+	tokenExpiresInSec  int
+}
+
+func loadConfig() config {
+	return config{
+		githubClientID:     mustEnv("GITHUB_MCP_CLIENT_ID"),
+		githubClientSecret: mustEnv("GITHUB_MCP_CLIENT_SECRET"),
+		baseURL:            getEnv("GITHUB_OAUTH_PROXY_BASE_URL", "http://localhost:8084"),
+		oauthScopes:        getEnv("GITHUB_MCP_OAUTH_SCOPES", "repo,user"),
+		port:               getEnv("GITHUB_OAUTH_PROXY_PORT", "8084"),
+		logLevel:           getEnv("LOG_LEVEL", "info"),
+		upstreamURL:        getEnv("GITHUB_MCP_UPSTREAM_URL", "http://github-mcp:8082"),
+		sessionTTLMin:      getEnvInt("SESSION_TTL_MIN", 10),
+		tokenCacheTTLMin:   getEnvInt("TOKEN_CACHE_TTL_MIN", 5),
+		tokenExpiresInSec:  getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
+	}
+}
+
+func mustEnv(key string) string {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		slog.Error("required environment variable not set", "key", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func getEnv(key, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func getEnvInt(key string, fallback int) int {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func parseLogLevel(level string) slog.Level {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/services/github-oauth-proxy/cmd/server/main.go
+++ b/services/github-oauth-proxy/cmd/server/main.go
@@ -76,10 +76,11 @@ func main() {
 		WriteTimeout:      0, // unlimited: MCP streaming responses may be long-lived
 		IdleTimeout:       120 * time.Second,
 	}
-	if err := server.ListenAndServe(); err != nil {
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		slog.Error("server error", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("server stopped")
 }
 
 type config struct {

--- a/services/github-oauth-proxy/go.mod
+++ b/services/github-oauth-proxy/go.mod
@@ -1,0 +1,3 @@
+module github.com/scottlz0310/github-oauth-proxy
+
+go 1.26.1

--- a/services/github-oauth-proxy/internal/auth/handler.go
+++ b/services/github-oauth-proxy/internal/auth/handler.go
@@ -1,0 +1,364 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"log/slog"
+)
+
+// githubClient is a shared HTTP client with timeouts to avoid hanging requests.
+var githubClient = &http.Client{Timeout: 15 * time.Second}
+
+// Config holds OAuth façade configuration.
+type Config struct {
+	GitHubClientID       string
+	GitHubClientSecret   string
+	BaseURL              string // e.g. http://localhost:8084
+	Scopes               string // e.g. "repo,user"
+	SessionTTL           time.Duration
+	CacheTTL             time.Duration
+	AllowedRedirectHosts []string // allowlist of permitted redirect_uri hostnames
+	// ExpiresIn is the lifetime advertised to MCP clients via the token response
+	// expires_in field (RFC 6749 §5.1). GitHub classic OAuth tokens do not expire
+	// on GitHub's side, so this value only controls how long the MCP client trusts
+	// its cached copy before re-authenticating. Defaults to 7776000 s (90 days).
+	ExpiresIn time.Duration
+}
+
+// UpstreamError represents a failure contacting an upstream service.
+type UpstreamError struct {
+	err error
+}
+
+func (e *UpstreamError) Error() string         { return e.err.Error() }
+func (e *UpstreamError) Unwrap() error         { return e.err }
+func (e *UpstreamError) IsUpstreamError() bool { return true }
+
+// Handler implements the OAuth façade endpoints.
+type Handler struct {
+	cfg   Config
+	store *Store
+}
+
+func NewHandler(cfg Config) *Handler {
+	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
+	if len(cfg.AllowedRedirectHosts) == 0 {
+		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1", "vscode.dev"}
+	}
+	if cfg.ExpiresIn <= 0 {
+		cfg.ExpiresIn = 90 * 24 * time.Hour // 90 days default
+	}
+	return &Handler{
+		cfg:   cfg,
+		store: NewStore(cfg.SessionTTL, cfg.CacheTTL),
+	}
+}
+
+// Discovery returns RFC 8414 metadata.
+func (h *Handler) Discovery(w http.ResponseWriter, r *http.Request) {
+	doc := map[string]any{
+		"issuer":                           h.cfg.BaseURL,
+		"authorization_endpoint":           h.cfg.BaseURL + "/authorize",
+		"token_endpoint":                   h.cfg.BaseURL + "/token",
+		"registration_endpoint":            h.cfg.BaseURL + "/register",
+		"response_types_supported":         []string{"code"},
+		"grant_types_supported":            []string{"authorization_code"},
+		"code_challenge_methods_supported": []string{"S256"},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// Register implements RFC 7591 Dynamic Client Registration (pseudo).
+// Always returns the pre-configured GitHub OAuth App client_id; no new client
+// is created. This allows MCP clients (e.g. mcp-remote) to proceed automatically
+// without requiring the user to enter a client_id manually.
+func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+
+	meta := map[string]json.RawMessage{}
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&meta); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_client_metadata",
+			"error_description": "request body must be valid JSON client metadata",
+		})
+		return
+	}
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); err != io.EOF {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_client_metadata",
+			"error_description": "request body must contain a single JSON object",
+		})
+		return
+	}
+
+	resp := map[string]any{
+		"client_id":                  h.cfg.GitHubClientID,
+		"client_id_issued_at":        time.Now().Unix(),
+		"client_secret_expires_at":   0,
+		"token_endpoint_auth_method": "none",
+		"grant_types":                []string{"authorization_code"},
+		"response_types":             []string{"code"},
+	}
+	for _, field := range []string{"redirect_uris", "client_name", "scope"} {
+		if v, ok := meta[field]; ok {
+			resp[field] = v
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// Authorize redirects the MCP client to GitHub OAuth.
+func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	state := q.Get("state")
+	redirectURI := q.Get("redirect_uri")
+	codeChallenge := q.Get("code_challenge")
+	responseType := q.Get("response_type")
+	codeChallengeMethod := q.Get("code_challenge_method")
+
+	if responseType != "code" {
+		oauthError(w, "unsupported_response_type", "response_type must be 'code'", http.StatusBadRequest)
+		return
+	}
+	if state == "" || redirectURI == "" {
+		oauthError(w, "invalid_request", "missing state or redirect_uri", http.StatusBadRequest)
+		return
+	}
+	if codeChallenge != "" && codeChallengeMethod != "S256" {
+		oauthError(w, "invalid_request", "code_challenge_method must be S256", http.StatusBadRequest)
+		return
+	}
+
+	parsedRedirect, err := url.Parse(redirectURI)
+	if err != nil ||
+		(parsedRedirect.Scheme != "http" && parsedRedirect.Scheme != "https") ||
+		parsedRedirect.Host == "" ||
+		parsedRedirect.Fragment != "" {
+		oauthError(w, "invalid_request", "invalid redirect_uri: must be absolute http/https URL without fragment", http.StatusBadRequest)
+		return
+	}
+	if !isAllowedRedirectHost(parsedRedirect.Hostname(), h.cfg.AllowedRedirectHosts) {
+		oauthError(w, "invalid_request", "redirect_uri host not permitted", http.StatusBadRequest)
+		return
+	}
+
+	h.store.SaveSession(state, redirectURI, codeChallenge)
+
+	ghURL, _ := url.Parse("https://github.com/login/oauth/authorize")
+	ghq := ghURL.Query()
+	ghq.Set("client_id", h.cfg.GitHubClientID)
+	ghq.Set("redirect_uri", h.cfg.BaseURL+"/callback")
+	ghq.Set("state", state)
+	ghq.Set("scope", h.cfg.Scopes)
+	ghURL.RawQuery = ghq.Encode()
+
+	http.Redirect(w, r, ghURL.String(), http.StatusFound)
+}
+
+// Callback receives GitHub's authorization code and exchanges it for an access token.
+func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	code := q.Get("code")
+	state := q.Get("state")
+
+	if code == "" || state == "" {
+		http.Error(w, "missing code or state", http.StatusBadRequest)
+		return
+	}
+
+	if !h.store.HasSession(state) {
+		http.Error(w, "invalid state", http.StatusBadRequest)
+		return
+	}
+
+	accessToken, grantedScope, err := h.exchangeGitHubCode(r.Context(), code)
+	if err != nil {
+		slog.Error("GitHub token exchange failed", "err", err)
+		http.Error(w, "token exchange failed", http.StatusBadGateway)
+		return
+	}
+
+	internalCode, err := h.store.CompleteCallback(state, accessToken, grantedScope)
+	if err != nil {
+		slog.Error("session completion failed", "err", err)
+		http.Error(w, "invalid state", http.StatusBadRequest)
+		return
+	}
+
+	sess := h.store.lookupByCode(internalCode)
+	if sess == nil {
+		http.Error(w, "session lost", http.StatusInternalServerError)
+		return
+	}
+
+	redirect, _ := url.Parse(sess.RedirectURI)
+	rq := redirect.Query()
+	rq.Set("code", internalCode)
+	rq.Set("state", state)
+	redirect.RawQuery = rq.Encode()
+
+	http.Redirect(w, r, redirect.String(), http.StatusFound)
+}
+
+// Token handles the authorization_code grant and returns the access token.
+func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		oauthError(w, "invalid_request", "malformed request body", http.StatusBadRequest)
+		return
+	}
+	grantType := r.FormValue("grant_type")
+	if grantType != "authorization_code" {
+		oauthError(w, "unsupported_grant_type", "only authorization_code is supported", http.StatusBadRequest)
+		return
+	}
+
+	code := r.FormValue("code")
+	redirectURI := r.FormValue("redirect_uri")
+	codeVerifier := r.FormValue("code_verifier")
+
+	token, grantedScope, err := h.store.ExchangeCode(code, redirectURI, codeVerifier)
+	if err != nil {
+		slog.Warn("token exchange rejected", "err", err)
+		oauthError(w, "invalid_grant", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	expiresInSeconds := max(int64(h.cfg.ExpiresIn/time.Second), 1)
+	tokenResp := map[string]any{
+		"access_token": token,
+		"token_type":   "Bearer",
+		"expires_in":   expiresInSeconds,
+	}
+	if grantedScope != "" {
+		tokenResp["scope"] = grantedScope
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	_ = json.NewEncoder(w).Encode(tokenResp)
+}
+
+// ValidateToken checks the bearer token against GitHub API (with cache).
+func (h *Handler) ValidateToken(ctx context.Context, token string) (string, error) {
+	if login, ok := h.store.LookupToken(token); ok {
+		return login, nil
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := githubClient.Do(req)
+	if err != nil {
+		return "", &UpstreamError{err: fmt.Errorf("GitHub API unreachable: %w", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode >= 500 {
+			return "", &UpstreamError{err: fmt.Errorf("GitHub API returned %d", resp.StatusCode)}
+		}
+		return "", fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", &UpstreamError{err: fmt.Errorf("reading GitHub user response: %w", err)}
+	}
+	var user struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal(body, &user); err != nil || user.Login == "" {
+		return "", fmt.Errorf("unexpected GitHub user response")
+	}
+
+	h.store.CacheToken(token, user.Login)
+	return user.Login, nil
+}
+
+// InvalidateCachedToken delegates cache invalidation to the underlying store.
+// Call when the upstream MCP server returns HTTP 401.
+func (h *Handler) InvalidateCachedToken(token string) {
+	h.store.InvalidateCachedToken(token)
+}
+
+// exchangeGitHubCode exchanges GitHub's authorization code for an access token and scope.
+func (h *Handler) exchangeGitHubCode(ctx context.Context, code string) (string, string, error) {
+	form := url.Values{
+		"client_id":     {h.cfg.GitHubClientID},
+		"client_secret": {h.cfg.GitHubClientSecret},
+		"code":          {code},
+		"redirect_uri":  {h.cfg.BaseURL + "/callback"},
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://github.com/login/oauth/access_token",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := githubClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return "", "", fmt.Errorf("GitHub OAuth returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		Scope       string `json:"scope"`
+		Error       string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", "", fmt.Errorf("decoding GitHub OAuth response: %w", err)
+	}
+	if result.Error != "" {
+		return "", "", fmt.Errorf("GitHub OAuth error: %s", result.Error)
+	}
+	if result.AccessToken == "" {
+		return "", "", fmt.Errorf("empty access_token from GitHub")
+	}
+	return result.AccessToken, result.Scope, nil
+}
+
+// isAllowedRedirectHost returns true when hostname is in the configured allowlist.
+func isAllowedRedirectHost(hostname string, allowed []string) bool {
+	return slices.Contains(allowed, hostname)
+}
+
+// oauthError writes an RFC 6749-compliant JSON error response.
+func oauthError(w http.ResponseWriter, code, description string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             code,
+		"error_description": description,
+	})
+}

--- a/services/github-oauth-proxy/internal/auth/session.go
+++ b/services/github-oauth-proxy/internal/auth/session.go
@@ -1,0 +1,221 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Session holds OAuth flow state between /authorize and /token.
+type Session struct {
+	State         string
+	RedirectURI   string
+	CodeChallenge string
+	InternalCode  string // base64url-encoded 32-byte random string, issued at /callback
+	AccessToken   string // GitHub access_token stored at /callback
+	Scope         string // OAuth scope actually granted by GitHub
+	ExpiresAt     time.Time
+}
+
+// TokenCache caches validated GitHub tokens to reduce API calls.
+type TokenCache struct {
+	mu      sync.RWMutex
+	entries map[string]tokenEntry
+}
+
+type tokenEntry struct {
+	login     string
+	expiresAt time.Time
+}
+
+type Store struct {
+	mu       sync.RWMutex
+	sessions map[string]*Session // keyed by state
+	codes    map[string]*Session // keyed by internal code
+	ttl      time.Duration
+
+	cache    *TokenCache
+	cacheTTL time.Duration
+}
+
+func NewStore(sessionTTL, cacheTTL time.Duration) *Store {
+	s := &Store{
+		sessions: make(map[string]*Session),
+		codes:    make(map[string]*Session),
+		ttl:      sessionTTL,
+		cache:    &TokenCache{entries: make(map[string]tokenEntry)},
+		cacheTTL: cacheTTL,
+	}
+	go s.janitor()
+	return s
+}
+
+// SaveSession stores a new OAuth session keyed by state.
+func (s *Store) SaveSession(state, redirectURI, codeChallenge string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions[state] = &Session{
+		State:         state,
+		RedirectURI:   redirectURI,
+		CodeChallenge: codeChallenge,
+		ExpiresAt:     time.Now().Add(s.ttl),
+	}
+}
+
+// HasSession returns true if state maps to a live (non-expired) session.
+func (s *Store) HasSession(state string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[state]
+	return ok && !time.Now().After(sess.ExpiresAt)
+}
+
+// CompleteCallback attaches an internal code + access token to the session.
+func (s *Store) CompleteCallback(state, accessToken, scope string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[state]
+	if !ok || time.Now().After(sess.ExpiresAt) {
+		delete(s.sessions, state)
+		return "", fmt.Errorf("session not found or expired for state %q", state)
+	}
+
+	code, err := generateCode()
+	if err != nil {
+		return "", err
+	}
+	sess.InternalCode = code
+	sess.AccessToken = accessToken
+	sess.Scope = scope
+	s.codes[code] = sess
+	return code, nil
+}
+
+// ExchangeCode validates PKCE and returns the access token and granted scope for the given code.
+func (s *Store) ExchangeCode(code, redirectURI, codeVerifier string) (string, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.codes[code]
+	if !ok || time.Now().After(sess.ExpiresAt) {
+		delete(s.codes, code)
+		return "", "", fmt.Errorf("code not found or expired")
+	}
+	if sess.RedirectURI != redirectURI {
+		return "", "", fmt.Errorf("redirect_uri mismatch")
+	}
+	if sess.CodeChallenge != "" {
+		if err := verifyPKCE(codeVerifier, sess.CodeChallenge); err != nil {
+			return "", "", err
+		}
+	}
+
+	token := sess.AccessToken
+	scope := sess.Scope
+	// one-time use
+	delete(s.codes, code)
+	delete(s.sessions, sess.State)
+	return token, scope, nil
+}
+
+// CacheToken stores a validated login for a token.
+func (s *Store) CacheToken(token, login string) {
+	s.cache.mu.Lock()
+	defer s.cache.mu.Unlock()
+	s.cache.entries[token] = tokenEntry{login: login, expiresAt: time.Now().Add(s.cacheTTL)}
+}
+
+// LookupToken returns (login, true) if token is cached and not expired.
+func (s *Store) LookupToken(token string) (string, bool) {
+	s.cache.mu.RLock()
+	defer s.cache.mu.RUnlock()
+	e, ok := s.cache.entries[token]
+	if !ok || time.Now().After(e.expiresAt) {
+		return "", false
+	}
+	return e.login, true
+}
+
+// InvalidateCachedToken removes a token from the cache immediately.
+// Call this when the upstream returns HTTP 401 to force re-validation on the next request.
+func (s *Store) InvalidateCachedToken(token string) {
+	s.cache.mu.Lock()
+	defer s.cache.mu.Unlock()
+	delete(s.cache.entries, token)
+}
+
+func (s *Store) janitor() {
+	ticker := time.NewTicker(time.Minute)
+	for range ticker.C {
+		now := time.Now()
+		s.mu.Lock()
+		for k, v := range s.sessions {
+			if now.After(v.ExpiresAt) {
+				delete(s.sessions, k)
+			}
+		}
+		for k, v := range s.codes {
+			if now.After(v.ExpiresAt) {
+				delete(s.codes, k)
+			}
+		}
+		s.mu.Unlock()
+
+		s.cache.mu.Lock()
+		for k, v := range s.cache.entries {
+			if now.After(v.expiresAt) {
+				delete(s.cache.entries, k)
+			}
+		}
+		s.cache.mu.Unlock()
+	}
+}
+
+func generateCode() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating code: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// isValidPKCEVerifier checks RFC 7636 requirements: 43-128 chars, unreserved charset only.
+func isValidPKCEVerifier(verifier string) bool {
+	if len(verifier) < 43 || len(verifier) > 128 {
+		return false
+	}
+	for i := 0; i < len(verifier); i++ {
+		c := verifier[i]
+		if (c >= 'A' && c <= 'Z') ||
+			(c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') ||
+			c == '-' || c == '.' || c == '_' || c == '~' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func verifyPKCE(verifier, challenge string) error {
+	if !isValidPKCEVerifier(verifier) {
+		return fmt.Errorf("invalid_grant")
+	}
+	h := sha256.Sum256([]byte(verifier))
+	got := base64.RawURLEncoding.EncodeToString(h[:])
+	if got != challenge {
+		return fmt.Errorf("PKCE verification failed")
+	}
+	return nil
+}
+
+// lookupByCode is a helper for Callback to read redirect_uri without consuming the code.
+func (s *Store) lookupByCode(code string) *Session {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.codes[code]
+}

--- a/services/github-oauth-proxy/internal/middleware/auth.go
+++ b/services/github-oauth-proxy/internal/middleware/auth.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"log/slog"
+)
+
+type contextKey string
+
+const ContextKeyLogin contextKey = "github_login"
+const ContextKeyToken contextKey = "github_token"
+
+// TokenValidator is implemented by auth.Handler.
+type TokenValidator interface {
+	ValidateToken(ctx context.Context, token string) (string, error)
+}
+
+// upstreamErrorer is satisfied by errors that represent upstream service failures.
+type upstreamErrorer interface {
+	IsUpstreamError() bool
+}
+
+// Auth returns a middleware that validates Bearer tokens via the GitHub API.
+func Auth(v TokenValidator) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := extractBearer(r)
+			if token == "" {
+				writeUnauthorized(w, "missing_token")
+				return
+			}
+
+			login, err := v.ValidateToken(r.Context(), token)
+			if err != nil {
+				var ue upstreamErrorer
+				if errors.As(err, &ue) {
+					slog.Error("upstream error during auth", "err", err, "path", r.URL.Path)
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "upstream_error"})
+					return
+				}
+				slog.Warn("auth failed", "err", err, "path", r.URL.Path)
+				writeUnauthorized(w, "invalid_token")
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), ContextKeyLogin, login)
+			ctx = context.WithValue(ctx, ContextKeyToken, token)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func writeUnauthorized(w http.ResponseWriter, errCode string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("WWW-Authenticate", `Bearer realm="github-oauth-proxy"`)
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": errCode})
+}
+
+func extractBearer(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	fields := strings.Fields(h)
+	if len(fields) == 2 && strings.EqualFold(fields[0], "bearer") {
+		return fields[1]
+	}
+	return ""
+}
+
+// LoginFromContext retrieves the GitHub login injected by Auth middleware.
+func LoginFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ContextKeyLogin).(string)
+	return v
+}
+
+// TokenFromContext retrieves the GitHub token injected by Auth middleware.
+func TokenFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ContextKeyToken).(string)
+	return v
+}

--- a/services/github-oauth-proxy/internal/proxy/handler.go
+++ b/services/github-oauth-proxy/internal/proxy/handler.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/scottlz0310/github-oauth-proxy/internal/middleware"
+)
+
+// TokenInvalidator is implemented by auth.Handler.
+type TokenInvalidator interface {
+	InvalidateCachedToken(token string)
+}
+
+// NewHandler returns an HTTP handler that reverse-proxies authenticated requests
+// to the upstream MCP server. It performs header sanitization, injects the
+// verified GitHub login as X-GitHub-Login, and invalidates the token cache
+// when the upstream returns HTTP 401.
+func NewHandler(upstream *url.URL, inv TokenInvalidator) http.Handler {
+	rp := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(upstream)
+
+			// Remove headers that clients must not be able to spoof.
+			// With Rewrite, X-Forwarded-For is not added automatically,
+			// but we delete it in case the client sends it directly.
+			pr.Out.Header.Del("X-Forwarded-For")
+			pr.Out.Header.Del("X-Real-Ip")
+			pr.Out.Header.Del("X-GitHub-Login") // delete before setting to prevent spoofing
+			pr.Out.Header.Del("X-Forwarded-Host")
+			pr.Out.Header.Del("X-Forwarded-Proto")
+
+			// Inject verified user context from auth middleware.
+			if login := middleware.LoginFromContext(pr.In.Context()); login != "" {
+				pr.Out.Header.Set("X-GitHub-Login", login)
+			}
+
+			// Log the outbound request for audit purposes.
+			// Never log the raw token value — only a short hash for correlation.
+			slog.Info("proxy request",
+				"login", middleware.LoginFromContext(pr.In.Context()),
+				"method", pr.Out.Method,
+				"path", pr.Out.URL.Path,
+				"token_hash", tokenHash(middleware.TokenFromContext(pr.In.Context())),
+			)
+		},
+
+		ModifyResponse: func(resp *http.Response) error {
+			// If the upstream rejected the token, invalidate the cache immediately
+			// so the next request triggers a fresh GitHub API validation.
+			if resp.StatusCode == http.StatusUnauthorized {
+				if token := extractBearer(resp.Request); token != "" {
+					inv.InvalidateCachedToken(token)
+					slog.Warn("upstream rejected token; cache invalidated",
+						"path", resp.Request.URL.Path,
+						"token_hash", tokenHash(token),
+					)
+				}
+			}
+			slog.Info("proxy response",
+				"upstream_status", resp.StatusCode,
+				"path", resp.Request.URL.Path,
+			)
+			return nil
+		},
+	}
+
+	return rp
+}
+
+func extractBearer(req *http.Request) string {
+	h := req.Header.Get("Authorization")
+	if strings.HasPrefix(h, "Bearer ") {
+		return strings.TrimPrefix(h, "Bearer ")
+	}
+	return ""
+}
+
+// tokenHash returns the first 8 hex characters of SHA-256(token) for log
+// correlation. The raw token value must never appear in logs.
+func tokenHash(token string) string {
+	if token == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(token))
+	return fmt.Sprintf("%x", sum[:4])
+}

--- a/services/github-oauth-proxy/internal/proxy/handler.go
+++ b/services/github-oauth-proxy/internal/proxy/handler.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 
 	"github.com/scottlz0310/github-oauth-proxy/internal/middleware"
 )
@@ -35,6 +34,15 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator) http.Handler {
 			pr.Out.Header.Del("X-Forwarded-Host")
 			pr.Out.Header.Del("X-Forwarded-Proto")
 
+			// Normalize Authorization: delete any client-supplied values and set
+			// exactly one "Bearer <token>" from the validated context. This makes
+			// the proxy the single trust anchor and ensures ModifyResponse can
+			// reliably extract the token regardless of original header formatting.
+			pr.Out.Header.Del("Authorization")
+			if token := middleware.TokenFromContext(pr.In.Context()); token != "" {
+				pr.Out.Header.Set("Authorization", "Bearer "+token)
+			}
+
 			// Inject verified user context from auth middleware.
 			if login := middleware.LoginFromContext(pr.In.Context()); login != "" {
 				pr.Out.Header.Set("X-GitHub-Login", login)
@@ -53,6 +61,7 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator) http.Handler {
 		ModifyResponse: func(resp *http.Response) error {
 			// If the upstream rejected the token, invalidate the cache immediately
 			// so the next request triggers a fresh GitHub API validation.
+			// extractBearer is now reliable because Rewrite normalizes the header.
 			if resp.StatusCode == http.StatusUnauthorized {
 				if token := extractBearer(resp.Request); token != "" {
 					inv.InvalidateCachedToken(token)
@@ -73,10 +82,13 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator) http.Handler {
 	return rp
 }
 
+// extractBearer reads the normalized "Bearer <token>" set by Rewrite.
+// Case-sensitivity is not an issue because Rewrite always writes the canonical form.
 func extractBearer(req *http.Request) string {
-	h := req.Header.Get("Authorization")
-	if strings.HasPrefix(h, "Bearer ") {
-		return strings.TrimPrefix(h, "Bearer ")
+	auth := req.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(auth) > len(prefix) && auth[:len(prefix)] == prefix {
+		return auth[len(prefix):]
 	}
 	return ""
 }

--- a/tests/shell/test_scripts.bats
+++ b/tests/shell/test_scripts.bats
@@ -131,3 +131,34 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "HTTP only" ]] || [[ "$output" =~ "stdio" ]]
 }
+
+@test "generate-ide-config.sh: --service github-oauth-proxy claude-desktop 設定生成が動作する" {
+    run "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop --service github-oauth-proxy
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Claude Desktop設定を生成しました" ]]
+    [ -f "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/claude-desktop/claude_desktop_config.json" ]
+    grep -q '"mcp-remote"' "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/claude-desktop/claude_desktop_config.json"
+    grep -q '8084' "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/claude-desktop/claude_desktop_config.json"
+}
+
+@test "generate-ide-config.sh: --service github-oauth-proxy vscode 設定生成が動作する" {
+    run "${SCRIPTS_DIR}/generate-ide-config.sh" --ide vscode --service github-oauth-proxy
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "VS Code設定を生成しました" ]]
+    [ -f "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/vscode/settings.json" ]
+    grep -q '8084' "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/vscode/settings.json"
+}
+
+@test "generate-ide-config.sh: --service github-oauth-proxy codex 設定生成が動作する" {
+    run "${SCRIPTS_DIR}/generate-ide-config.sh" --ide codex --service github-oauth-proxy
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Codex設定を生成しました" ]]
+    [ -f "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/codex/config.toml" ]
+    grep -q '8084' "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/codex/config.toml"
+}
+
+@test "health-check.sh: --helpオプションにサービス説明が含まれる" {
+    run "${SCRIPTS_DIR}/health-check.sh" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "github-oauth-proxy" ]]
+}


### PR DESCRIPTION
## Summary

- `services/github-oauth-proxy/` を新設（Go製、外部ライブラリ依存ゼロ）
- mcp-remote 経由で Claude Desktop から `github-mcp-server` へ OAuth 認証付き接続が可能になる（Closes #41）
- `github-mcp` のホスト公開ポートを廃止し Docker ネットワーク内に閉じ込め（セキュリティ向上）

## Changes

### New: `services/github-oauth-proxy/`

| ファイル | 内容 |
|---------|------|
| `internal/auth/handler.go` | RFC 8414 discovery / RFC 7591 疑似 registration / Authorization Code + PKCE 実装 |
| `internal/auth/session.go` | オンメモリセッション・トークンキャッシュ・`InvalidateCachedToken()` |
| `internal/middleware/auth.go` | Bearer トークン検証 + ユーザーコンテキスト注入 |
| `internal/proxy/handler.go` | `Rewrite` API によるヘッダーサニタイズ + upstream 401 時のキャッシュ無効化 + 監査ログ |
| `cmd/server/main.go` | HTTP サーバー・ルーティング・設定ロード |
| `Dockerfile` | distroless/static-debian12:nonroot ベース最小イメージ |

### Modified

- **`docker-compose.yml`**: `github-oauth-proxy` サービス追加（ポート 8084）、`github-mcp` の `ports` を `expose` に変更
- **`.env.template`**: `GITHUB_MCP_CLIENT_ID` / `GITHUB_MCP_CLIENT_SECRET` 等の新規変数と GitHub OAuth App 作成手順を追加
- **`scripts/generate-ide-config.sh`**: `--service github-oauth-proxy` を追加（`claude-desktop` は mcp-remote 経由設定を出力）

## Architecture

```
Claude Desktop
  │ stdio
  ▼
mcp-remote
  │ HTTP + Bearer token
  ▼
github-oauth-proxy :8084  ← NEW
  ├── OAuth endpoints (discovery/register/authorize/callback/token)
  └── /mcp → (header sanitize + audit log)
       ▼
github-mcp-server :8082  (Docker network内のみ、ホスト公開廃止)
```

## Test plan

- [ ] `docker compose build github-oauth-proxy` が成功する
- [ ] `docker compose up -d github-mcp github-oauth-proxy` でサービスが起動する
- [ ] `curl http://localhost:8084/.well-known/oauth-authorization-server` が discovery JSON を返す
- [ ] `curl http://localhost:8084/health` が `{"status":"ok"}` を返す
- [ ] `scripts/generate-ide-config.sh --ide claude-desktop --service github-oauth-proxy` が設定ファイルを生成する
- [ ] mcp-remote 経由で Claude Desktop から GitHub MCP ツールが利用できる（手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)