### PR TITLE
fix(auth): GitHubトークン認証切れの3つの原因を修正

### DIFF
--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	// MCP endpoints (auth required) — Streamable HTTP transport (stateless, per-request server)
 	threshold := time.Duration(cfg.inProgressThresholdSec) * time.Second
-	mcpHandler := tools.BuildStreamableHandler(db, threshold)
+	mcpHandler := tools.BuildStreamableHandler(db, threshold, oauthHandler)
 	mux.Handle("/mcp", authMiddleware(mcpHandler))
 	mux.Handle("/mcp/", authMiddleware(mcpHandler))
 
@@ -104,7 +104,7 @@ func loadConfig() config {
 		port:                   getEnv("MCP_PORT", "8083"),
 		logLevel:               getEnv("LOG_LEVEL", "info"),
 		sessionTTLMin:          getEnvInt("SESSION_TTL_MIN", 10),
-		tokenCacheTTLMin:       getEnvInt("TOKEN_CACHE_TTL_MIN", 5),
+		tokenCacheTTLMin:       getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
 		tokenExpiresInSec:      getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
 		sqlitePath:             getEnv("SQLITE_PATH", "/data/copilot-review.db"),
 		inProgressThresholdSec: getEnvInt("IN_PROGRESS_THRESHOLD_SEC", 30),

--- a/services/copilot-review-mcp/internal/auth/handler.go
+++ b/services/copilot-review-mcp/internal/auth/handler.go
@@ -285,6 +285,13 @@ func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(tokenResp)
 }
 
+// InvalidateCachedToken removes a token from the validation cache immediately.
+// Call when a downstream GitHub API call returns HTTP 401 so the next request
+// forces a fresh GitHub API validation instead of using a stale cached entry.
+func (h *Handler) InvalidateCachedToken(token string) {
+	h.store.InvalidateCachedToken(token)
+}
+
 // ValidateToken checks the bearer token against GitHub API (with cache).
 func (h *Handler) ValidateToken(ctx context.Context, token string) (string, error) {
 	if login, ok := h.store.LookupToken(token); ok {

--- a/services/copilot-review-mcp/internal/auth/session.go
+++ b/services/copilot-review-mcp/internal/auth/session.go
@@ -140,6 +140,15 @@ func (s *Store) LookupToken(token string) (string, bool) {
 	return e.login, true
 }
 
+// InvalidateCachedToken removes a token from the cache immediately.
+// Call this when a downstream GitHub API call returns HTTP 401 to force
+// re-validation on the next request.
+func (s *Store) InvalidateCachedToken(token string) {
+	s.cache.mu.Lock()
+	defer s.cache.mu.Unlock()
+	delete(s.cache.entries, token)
+}
+
 func (s *Store) janitor() {
 	ticker := time.NewTicker(time.Minute)
 	for range ticker.C {

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -12,6 +13,23 @@ import (
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
+
+// invalidatingTransport wraps an HTTP transport and calls invalidate(token) when
+// GitHub returns HTTP 401, so the auth token cache is cleared immediately rather
+// than waiting for cacheTTL to expire.
+type invalidatingTransport struct {
+	inner      http.RoundTripper
+	token      string
+	invalidate func(string)
+}
+
+func (t *invalidatingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.inner.RoundTrip(req)
+	if err == nil && resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		t.invalidate(t.token)
+	}
+	return resp, err
+}
 
 // copilotLogins lists the known GitHub Copilot reviewer identities, checked in order.
 var copilotLogins = []string{
@@ -60,10 +78,21 @@ type Client struct {
 }
 
 // NewClient creates a new GitHub API client authenticated with the given token.
+// ctx should be the request context so GitHub API calls are cancelled when the
+// request is cancelled or times out.
+// invalidate is called with the token when GitHub returns HTTP 401, allowing the
+// auth layer to clear its cache immediately. May be nil to disable invalidation.
 // threshold is the elapsed time after which PENDING becomes IN_PROGRESS.
-func NewClient(token string, threshold time.Duration) *Client {
+func NewClient(ctx context.Context, token string, threshold time.Duration, invalidate func(string)) *Client {
 	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	httpClient := oauth2.NewClient(context.Background(), src)
+	httpClient := oauth2.NewClient(ctx, src)
+	if invalidate != nil {
+		httpClient.Transport = &invalidatingTransport{
+			inner:      httpClient.Transport,
+			token:      token,
+			invalidate: invalidate,
+		}
+	}
 	return &Client{
 		gh:        github.NewClient(httpClient),
 		v4:        githubv4.NewClient(httpClient),

--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -14,16 +14,23 @@ import (
 
 var schemaCache = mcp.NewSchemaCache()
 
+// TokenInvalidator is implemented by auth.Handler to clear a token from the
+// validation cache when a downstream GitHub API call returns HTTP 401.
+type TokenInvalidator interface {
+	InvalidateCachedToken(token string)
+}
+
 // BuildStreamableHandler returns an http.Handler that serves MCP over Streamable HTTP.
 // getServer is called for each request (stateless mode) to produce a fresh *mcp.Server
 // bound to the caller's GitHub access token.
-func BuildStreamableHandler(db *store.DB, threshold time.Duration) http.Handler {
+// inv is called to invalidate the cached token when GitHub returns HTTP 401.
+func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInvalidator) http.Handler {
 	getServer := func(r *http.Request) *mcp.Server {
 		token := middleware.TokenFromContext(r.Context())
 		if token == "" {
 			return nil
 		}
-		gh := ghclient.NewClient(token, threshold)
+		gh := ghclient.NewClient(r.Context(), token, threshold, inv.InvalidateCachedToken)
 		srv := mcp.NewServer(
 			&mcp.Implementation{Name: "copilot-review-mcp", Version: "1.0.0"},
 			&mcp.ServerOptions{SchemaCache: schemaCache},

--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -30,7 +30,11 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 		if token == "" {
 			return nil
 		}
-		gh := ghclient.NewClient(r.Context(), token, threshold, inv.InvalidateCachedToken)
+		var invalidate func(string)
+		if inv != nil {
+			invalidate = inv.InvalidateCachedToken
+		}
+		gh := ghclient.NewClient(r.Context(), token, threshold, invalidate)
 		srv := mcp.NewServer(
 			&mcp.Implementation{Name: "copilot-review-mcp", Version: "1.0.0"},
 			&mcp.ServerOptions{SchemaCache: schemaCache},

--- a/services/github-oauth-proxy/cmd/server/main.go
+++ b/services/github-oauth-proxy/cmd/server/main.go
@@ -106,7 +106,7 @@ func loadConfig() config {
 		logLevel:           getEnv("LOG_LEVEL", "info"),
 		upstreamURL:        getEnv("GITHUB_MCP_UPSTREAM_URL", "http://github-mcp:8082"),
 		sessionTTLMin:      getEnvInt("SESSION_TTL_MIN", 10),
-		tokenCacheTTLMin:   getEnvInt("TOKEN_CACHE_TTL_MIN", 5),
+		tokenCacheTTLMin:   getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
 		tokenExpiresInSec:  getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
 	}
 }


### PR DESCRIPTION
## 概要

使用中に認証が切れる問題の原因を3つ特定し、修正しました。

## 修正内容

### Fix 1: `copilot-review-mcp` で GitHub 401 発生時のキャッシュ即時無効化

**問題**: ツール（`github/client.go`）が GitHub API から 401 を受けても、トークンキャッシュが無効化されなかった。`cacheTTL`（デフォルト5分）が切れるまで、auth middleware はキャッシュヒットで通過し続け、ツールだけが失敗し続ける状態になっていた。

**修正**:
- `auth/session.go`, `auth/handler.go` に `InvalidateCachedToken` を追加（`github-oauth-proxy` 側と同様）
- `github/client.go` に `invalidatingTransport` を実装：GitHub 401 レスポンス検知時にコールバックでキャッシュを即時削除
- `tools/server.go` に `TokenInvalidator` インターフェースを追加し、`NewClient` に配線
- `main.go` で `oauthHandler` を `BuildStreamableHandler` に渡すよう変更

### Fix 2: `oauth2.NewClient` にリクエスト context を渡すよう変更

**問題**: `oauth2.NewClient(context.Background(), src)` を使っていたため、GitHub API 呼び出しがリクエストのキャンセルやタイムアウトに追従せずリソースリークの原因になっていた。

**修正**: `NewClient` のシグネチャを `NewClient(ctx context.Context, ...)` に変更し、`tools/server.go` から `r.Context()` を渡すようにした。

### Fix 3: `TOKEN_CACHE_TTL_MIN` デフォルトを 5 → 30 分に引き上げ

**問題**: デフォルト5分では GitHub API の再検証が頻繁に発生し、一時的なネットワーク障害・レート制限でも誤って 401/503 を返すリスクがあった。

**修正**: `copilot-review-mcp` / `github-oauth-proxy` 両方のデフォルトを30分に変更。`TOKEN_CACHE_TTL_MIN` 環境変数で引き続き上書き可能。

## テスト計画

- [ ] `go build ./...` が両サービスでクリーンに通ること（確認済み）
- [ ] `go test ./...` が `copilot-review-mcp` でパスすること（確認済み）
- [ ] GitHub token を意図的に revoke し、次のツール呼び出しで 401 → キャッシュ無効化 → 再認証フローが走ることを確認
- [ ] 正常フローで 30 分以上連続使用しても認証が切れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)