### PR TITLE
fix(copilot-review-mcp): RequestCopilotReview を GraphQL mutation へ移行

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Fix
+
+- `copilot-review-mcp`: `RequestCopilotReview` を REST API から GraphQL mutation へ移行（ISSUE #52）
+  - `POST /repos/{owner}/{repo}/pulls/{pr}/requested_reviewers` は bot actor を黙って無視する（#47 の根本原因）
+  - GitHub CLI と同じロジック（`requestReviewsByLogin` mutation + `botLogins`）で実装し直し
+  - `union: true` で既存の human reviewer を保持したまま Copilot を追加
+  - PR の GraphQL node ID を取得する際に空チェックを追加（PR 不存在・権限不足の検知）
+  - `copilotBotLogin` 定数と `buildCopilotReviewInput` 関数を分離し、typo ガードのユニットテストを追加
+
 ## [2.3.0] - 2026-04-06
 
 ### ✨ 新機能

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -31,7 +31,12 @@ func (t *invalidatingTransport) RoundTrip(req *http.Request) (*http.Response, er
 	return resp, err
 }
 
-// copilotLogins lists the known GitHub Copilot reviewer identities, checked in order.
+// copilotBotLogin is the login passed to the GraphQL requestReviewsByLogin mutation's
+// botLogins field. The [bot] suffix is part of the actor identity on GitHub's side.
+const copilotBotLogin = "copilot-pull-request-reviewer[bot]"
+
+// copilotLogins lists the known GitHub Copilot reviewer identities used for
+// detection in GetReviewData. Kept separate from copilotBotLogin (request path).
 var copilotLogins = []string{
 	"github-copilot[bot]",
 	"copilot-pull-request-reviewer[bot]",
@@ -191,20 +196,76 @@ func (c *Client) DeriveStatus(data *ReviewData, requestedAt *time.Time) ReviewSt
 	return StatusNotRequested
 }
 
-// RequestCopilotReview sends a review request for the Copilot bot on the given PR.
-// It tries each known Copilot identity in order, returning nil on the first success.
-func (c *Client) RequestCopilotReview(ctx context.Context, owner, repo string, prNumber int) error {
-	var lastErr error
-	for _, login := range copilotLogins {
-		_, _, err := c.gh.PullRequests.RequestReviewers(ctx, owner, repo, prNumber,
-			github.ReviewersRequest{Reviewers: []string{login}},
-		)
-		if err == nil {
-			return nil
-		}
-		lastErr = err
+// prNodeIDQuery fetches the GraphQL node ID for a pull request.
+// Used by RequestCopilotReview to obtain the ID required by the mutation.
+type prNodeIDQuery struct {
+	Repository struct {
+		PullRequest struct {
+			ID githubv4.ID
+		} `graphql:"pullRequest(number: $pr)"`
+	} `graphql:"repository(owner: $owner, name: $repo)"`
+}
+
+// requestReviewsByLoginMutation is the GraphQL mutation for requesting PR reviews by login.
+type requestReviewsByLoginMutation struct {
+	RequestReviewsByLogin struct {
+		ClientMutationID string `graphql:"clientMutationId"`
+	} `graphql:"requestReviewsByLogin(input: $input)"`
+}
+
+// requestReviewsByLoginInput is the input type for requestReviewsByLoginMutation.
+// Field names must be PascalCase so shurcooL/githubv4 serialises them correctly.
+type requestReviewsByLoginInput struct {
+	PullRequestID githubv4.ID        `json:"pullRequestId"`
+	BotLogins     []githubv4.String  `json:"botLogins"`
+	UserLogins    []githubv4.String  `json:"userLogins"`
+	TeamSlugs     []githubv4.String  `json:"teamSlugs"`
+	Union         githubv4.Boolean   `json:"union"`
+}
+
+// buildCopilotReviewInput constructs the mutation input for adding Copilot as a reviewer.
+// union: true preserves existing reviewers (additive); false would replace the entire set.
+func buildCopilotReviewInput(prNodeID githubv4.ID) requestReviewsByLoginInput {
+	return requestReviewsByLoginInput{
+		PullRequestID: prNodeID,
+		BotLogins:     []githubv4.String{githubv4.String(copilotBotLogin)},
+		UserLogins:    []githubv4.String{},
+		TeamSlugs:     []githubv4.String{},
+		Union:         githubv4.Boolean(true),
 	}
-	return lastErr
+}
+
+// RequestCopilotReview adds Copilot as a reviewer on the given PR using the GraphQL
+// requestReviewsByLogin mutation. This is the only reliable path on github.com;
+// the REST requested_reviewers endpoint silently no-ops for bot actors (#47).
+func (c *Client) RequestCopilotReview(ctx context.Context, owner, repo string, prNumber int) error {
+	if prNumber <= 0 || prNumber > math.MaxInt32 {
+		return fmt.Errorf("pr number out of valid range: %d", prNumber)
+	}
+
+	// Step 1: resolve the PR's GraphQL node ID (distinct from the REST integer ID).
+	var nodeQ prNodeIDQuery
+	if err := c.v4.Query(ctx, &nodeQ, map[string]interface{}{
+		"owner": githubv4.String(owner),
+		"repo":  githubv4.String(repo),
+		"pr":    githubv4.Int(int32(prNumber)), //nolint:gosec // range checked above
+	}); err != nil {
+		return fmt.Errorf("failed to fetch PR node ID: %w", err)
+	}
+	prNodeID := nodeQ.Repository.PullRequest.ID
+	// Guard: Query may succeed with a zero-value struct when the PR doesn't exist
+	// or the token lacks permission. Catch both nil and empty-string cases.
+	if prNodeID == nil || prNodeID == "" {
+		return fmt.Errorf("pull request node ID is empty (PR #%d may not exist or token lacks permission)", prNumber)
+	}
+
+	// Step 2: request review via GraphQL mutation.
+	var m requestReviewsByLoginMutation
+	input := buildCopilotReviewInput(prNodeID)
+	if err := c.v4.Mutate(ctx, &m, input, nil); err != nil {
+		return fmt.Errorf("requestReviewsByLogin mutation failed: %w", err)
+	}
+	return nil
 }
 
 // ─── GraphQL types for review thread operations ───────────────────────────────

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v72/github"
+	"github.com/shurcooL/githubv4"
 )
 
 // newReview creates a PullRequestReview with the given state and optional submittedAt.
@@ -16,6 +17,53 @@ func newReview(state string, submittedAt *time.Time) *github.PullRequestReview {
 		r.SubmittedAt = &github.Timestamp{Time: *submittedAt}
 	}
 	return r
+}
+
+// TestCopilotBotLoginValue guards against typos in the login constant.
+// A wrong value here would cause a silent failure where GitHub accepts the mutation
+// but Copilot is never actually added as a reviewer.
+func TestCopilotBotLoginValue(t *testing.T) {
+	const want = "copilot-pull-request-reviewer[bot]"
+	if copilotBotLogin != want {
+		t.Errorf("copilotBotLogin = %q, want %q", copilotBotLogin, want)
+	}
+}
+
+// TestBuildCopilotReviewInput verifies the mutation input constructed by
+// buildCopilotReviewInput satisfies the two critical invariants:
+//
+//  1. union must be true — preserves existing human reviewers.
+//     union:false would replace the entire reviewer set with Copilot only.
+//  2. botLogins[0] must equal copilotBotLogin — the exact identity GitHub expects.
+func TestBuildCopilotReviewInput(t *testing.T) {
+	testNodeID := githubv4.ID("PR_kwDOABCDEF12345")
+	input := buildCopilotReviewInput(testNodeID)
+
+	// Invariant 1: union must be true (additive, not replacing existing reviewers).
+	if !bool(input.Union) {
+		t.Error("Union must be true to preserve existing human reviewers; false would remove them")
+	}
+
+	// Invariant 2: exactly one bot login with the correct value.
+	if len(input.BotLogins) != 1 {
+		t.Fatalf("BotLogins length = %d, want 1", len(input.BotLogins))
+	}
+	if got := string(input.BotLogins[0]); got != copilotBotLogin {
+		t.Errorf("BotLogins[0] = %q, want %q", got, copilotBotLogin)
+	}
+
+	// Sanity: userLogins and teamSlugs must be empty — we're only adding Copilot.
+	if len(input.UserLogins) != 0 {
+		t.Errorf("UserLogins must be empty, got %v", input.UserLogins)
+	}
+	if len(input.TeamSlugs) != 0 {
+		t.Errorf("TeamSlugs must be empty, got %v", input.TeamSlugs)
+	}
+
+	// Sanity: PR node ID is passed through unchanged.
+	if input.PullRequestID != testNodeID {
+		t.Errorf("PullRequestID = %v, want %v", input.PullRequestID, testNodeID)
+	}
 }
 
 func TestDeriveStatus(t *testing.T) {


### PR DESCRIPTION
## Summary

- REST API（`POST /pulls/{pr}/requested_reviewers`）は bot actor を黙って no-op で返す仕様のため、Copilot reviewer が実際には登録されなかった問題を修正（根本原因: #47）
- GitHub CLI と同ロジックの `requestReviewsByLogin` GraphQL mutation に移行し、`botLogins` に `copilot-pull-request-reviewer[bot]` を渡すことで安定したレビューリクエストを実現
- `union: true` で既存の human reviewer を保持したまま Copilot を追加（`false` だと全 reviewer が置き換わる）
- PR の GraphQL node ID 取得後に空チェックを追加し、PR 不存在・権限不足を早期検知

Closes #52

## Test plan

- [x] `TestCopilotBotLoginValue` — `copilotBotLogin` 定数が `"copilot-pull-request-reviewer[bot]"` と厳密一致することを確認（typo ガード）
- [x] `TestBuildCopilotReviewInput` — `union: true`（既存 reviewer が消えない）、`botLogins[0]` の値、`userLogins`/`teamSlugs` が空であることを確認
- [x] 既存の `TestDeriveStatus`（15 ケース）が全て PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)