### PR TITLE
chore: .claude/ ディレクトリを .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code
+.claude/
+
 # Docker
 .env
 .env.*


### PR DESCRIPTION
## Summary

- `.claude/` ディレクトリを `.gitignore` に追加
- Claude Code のワークツリー一時データや設定ファイルをバージョン管理対象外にする
- チーム共有不要な個人環境固有のファイルをリポジトリから除外

## Test plan

- [ ] `.claude/` 以下のファイルが `git status` で追跡されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)