### PR TITLE
fix(copilot-review-mcp): TIMEOUT後の余分なAPIコールとCANCEL時の情報欠落を修正 (#56)

### DIFF
--- a/services/copilot-review-mcp/internal/tools/wait.go
+++ b/services/copilot-review-mcp/internal/tools/wait.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -31,7 +32,7 @@ type WaitOutput struct {
 // waitTool is the MCP tool definition for wait_for_copilot_review.
 var waitTool = &mcp.Tool{
 	Name:        "wait_for_copilot_review",
-	Description: "Copilot のレビューが COMPLETED または BLOCKED になるまで定期的にポーリングして待機する。タイムアウト時は TIMEOUT を返す。レート制限時は RATE_LIMITED を返す。",
+	Description: "Copilot のレビューが COMPLETED または BLOCKED になるまで定期的にポーリングして待機する。タイムアウト時は TIMEOUT を返す。レート制限時は RATE_LIMITED を返す。コンテキストキャンセル時は CANCELLED を返す。",
 }
 
 // waitHandler handles a single wait_for_copilot_review call.
@@ -107,6 +108,15 @@ func waitHandler(
 
 			data, err := ghClient.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
 			if err != nil {
+				if isCancellation(err) && lastData != nil {
+					rs := buildStatusOutput(lastData, lastEntry, lastStatus)
+					return nil, WaitOutput{
+						Status:        "CANCELLED",
+						ReviewStatus:  &rs,
+						PollsDone:     poll,
+						WaitedSeconds: int(time.Since(start).Seconds()),
+					}, err
+				}
 				return nil, WaitOutput{}, err
 			}
 
@@ -114,6 +124,15 @@ func waitHandler(
 			if data.RateLimitRemaining < 10 {
 				entry, err := db.GetLatest(in.Owner, in.Repo, in.PR)
 				if err != nil {
+					if isCancellation(err) && lastData != nil {
+						rs := buildStatusOutput(lastData, lastEntry, lastStatus)
+						return nil, WaitOutput{
+							Status:        "CANCELLED",
+							ReviewStatus:  &rs,
+							PollsDone:     poll,
+							WaitedSeconds: int(time.Since(start).Seconds()),
+						}, err
+					}
 					return nil, WaitOutput{}, fmt.Errorf("failed to get latest entry (RATE_LIMITED): %w", err)
 				}
 				var reqAt *time.Time
@@ -132,6 +151,15 @@ func waitHandler(
 
 			entry, err := db.GetLatest(in.Owner, in.Repo, in.PR)
 			if err != nil {
+				if isCancellation(err) && lastData != nil {
+					rs := buildStatusOutput(lastData, lastEntry, lastStatus)
+					return nil, WaitOutput{
+						Status:        "CANCELLED",
+						ReviewStatus:  &rs,
+						PollsDone:     poll,
+						WaitedSeconds: int(time.Since(start).Seconds()),
+					}, err
+				}
 				return nil, WaitOutput{}, err
 			}
 
@@ -166,7 +194,16 @@ func waitHandler(
 			}
 		}
 
-		// All polls exhausted — reuse last cached poll result (no extra API call).
+		// All polls exhausted — check context before reporting TIMEOUT.
+		if err := ctx.Err(); err != nil && lastData != nil {
+			rs := buildStatusOutput(lastData, lastEntry, lastStatus)
+			return nil, WaitOutput{
+				Status:        "CANCELLED",
+				ReviewStatus:  &rs,
+				PollsDone:     in.MaxPolls,
+				WaitedSeconds: int(time.Since(start).Seconds()),
+			}, err
+		}
 		rs := buildStatusOutput(lastData, lastEntry, lastStatus)
 		return nil, WaitOutput{
 			Status:        "TIMEOUT",
@@ -175,6 +212,11 @@ func waitHandler(
 			WaitedSeconds: int(time.Since(start).Seconds()),
 		}, nil
 	}
+}
+
+// isCancellation reports whether err represents a context cancellation or deadline.
+func isCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 // buildStatusOutput assembles a GetStatusOutput from already-fetched data.

--- a/services/copilot-review-mcp/internal/tools/wait.go
+++ b/services/copilot-review-mcp/internal/tools/wait.go
@@ -72,6 +72,12 @@ func waitHandler(
 		pollInterval := time.Duration(in.PollIntervalSeconds) * time.Second
 		start := time.Now()
 
+		// lastData/lastEntry/lastStatus hold the most recent successful poll result.
+		// Reused by TIMEOUT and CANCELLED paths to avoid an extra API call.
+		var lastData *ghclient.ReviewData
+		var lastEntry *store.TriggerEntry
+		var lastStatus ghclient.ReviewStatus
+
 		for poll := 0; poll < in.MaxPolls; poll++ {
 			// Wait between polls (skip on first iteration).
 			if poll > 0 {
@@ -83,6 +89,16 @@ func waitHandler(
 						case <-timer.C:
 						default:
 						}
+					}
+					// Return progress info from the previous poll if available.
+					if lastData != nil {
+						rs := buildStatusOutput(lastData, lastEntry, lastStatus)
+						return nil, WaitOutput{
+							Status:        "CANCELLED",
+							ReviewStatus:  &rs,
+							PollsDone:     poll,
+							WaitedSeconds: int(time.Since(start).Seconds()),
+						}, ctx.Err()
 					}
 					return nil, WaitOutput{}, ctx.Err()
 				case <-timer.C:
@@ -134,6 +150,11 @@ func waitHandler(
 				}
 			}
 
+			// Cache for TIMEOUT/CANCELLED paths.
+			lastData = data
+			lastEntry = entry
+			lastStatus = status
+
 			if status == ghclient.StatusCompleted || status == ghclient.StatusBlocked {
 				rs := buildStatusOutput(data, entry, status)
 				return nil, WaitOutput{
@@ -145,21 +166,8 @@ func waitHandler(
 			}
 		}
 
-		// All polls exhausted.
-		data, err := ghClient.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
-		if err != nil {
-			return nil, WaitOutput{}, fmt.Errorf("final review data fetch failed after %d polls: %w", in.MaxPolls, err)
-		}
-		entry, err := db.GetLatest(in.Owner, in.Repo, in.PR)
-		if err != nil {
-			return nil, WaitOutput{}, fmt.Errorf("failed to get latest entry (TIMEOUT): %w", err)
-		}
-		var requestedAt *time.Time
-		if entry != nil {
-			requestedAt = &entry.RequestedAt
-		}
-		status := ghClient.DeriveStatus(data, requestedAt)
-		rs := buildStatusOutput(data, entry, status)
+		// All polls exhausted — reuse last cached poll result (no extra API call).
+		rs := buildStatusOutput(lastData, lastEntry, lastStatus)
 		return nil, WaitOutput{
 			Status:        "TIMEOUT",
 			ReviewStatus:  &rs,

--- a/services/copilot-review-mcp/internal/tools/wait.go
+++ b/services/copilot-review-mcp/internal/tools/wait.go
@@ -91,31 +91,15 @@ func waitHandler(
 						default:
 						}
 					}
-					// Return progress info from the previous poll if available.
-					if lastData != nil {
-						rs := buildStatusOutput(lastData, lastEntry, lastStatus)
-						return nil, WaitOutput{
-							Status:        "CANCELLED",
-							ReviewStatus:  &rs,
-							PollsDone:     poll,
-							WaitedSeconds: int(time.Since(start).Seconds()),
-						}, ctx.Err()
-					}
-					return nil, WaitOutput{}, ctx.Err()
+					return nil, buildCancelledOutput(lastData, lastEntry, lastStatus, poll, time.Since(start)), ctx.Err()
 				case <-timer.C:
 				}
 			}
 
 			data, err := ghClient.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
 			if err != nil {
-				if isCancellation(err) && lastData != nil {
-					rs := buildStatusOutput(lastData, lastEntry, lastStatus)
-					return nil, WaitOutput{
-						Status:        "CANCELLED",
-						ReviewStatus:  &rs,
-						PollsDone:     poll,
-						WaitedSeconds: int(time.Since(start).Seconds()),
-					}, err
+				if isCancellation(err) {
+					return nil, buildCancelledOutput(lastData, lastEntry, lastStatus, poll, time.Since(start)), err
 				}
 				return nil, WaitOutput{}, err
 			}
@@ -124,14 +108,8 @@ func waitHandler(
 			if data.RateLimitRemaining < 10 {
 				entry, err := db.GetLatest(in.Owner, in.Repo, in.PR)
 				if err != nil {
-					if isCancellation(err) && lastData != nil {
-						rs := buildStatusOutput(lastData, lastEntry, lastStatus)
-						return nil, WaitOutput{
-							Status:        "CANCELLED",
-							ReviewStatus:  &rs,
-							PollsDone:     poll,
-							WaitedSeconds: int(time.Since(start).Seconds()),
-						}, err
+					if isCancellation(err) {
+						return nil, buildCancelledOutput(lastData, lastEntry, lastStatus, poll, time.Since(start)), err
 					}
 					return nil, WaitOutput{}, fmt.Errorf("failed to get latest entry (RATE_LIMITED): %w", err)
 				}
@@ -151,14 +129,8 @@ func waitHandler(
 
 			entry, err := db.GetLatest(in.Owner, in.Repo, in.PR)
 			if err != nil {
-				if isCancellation(err) && lastData != nil {
-					rs := buildStatusOutput(lastData, lastEntry, lastStatus)
-					return nil, WaitOutput{
-						Status:        "CANCELLED",
-						ReviewStatus:  &rs,
-						PollsDone:     poll,
-						WaitedSeconds: int(time.Since(start).Seconds()),
-					}, err
+				if isCancellation(err) {
+					return nil, buildCancelledOutput(lastData, lastEntry, lastStatus, poll, time.Since(start)), err
 				}
 				return nil, WaitOutput{}, err
 			}
@@ -195,14 +167,8 @@ func waitHandler(
 		}
 
 		// All polls exhausted — check context before reporting TIMEOUT.
-		if err := ctx.Err(); err != nil && lastData != nil {
-			rs := buildStatusOutput(lastData, lastEntry, lastStatus)
-			return nil, WaitOutput{
-				Status:        "CANCELLED",
-				ReviewStatus:  &rs,
-				PollsDone:     in.MaxPolls,
-				WaitedSeconds: int(time.Since(start).Seconds()),
-			}, err
+		if err := ctx.Err(); err != nil {
+			return nil, buildCancelledOutput(lastData, lastEntry, lastStatus, in.MaxPolls, time.Since(start)), err
 		}
 		rs := buildStatusOutput(lastData, lastEntry, lastStatus)
 		return nil, WaitOutput{
@@ -217,6 +183,22 @@ func waitHandler(
 // isCancellation reports whether err represents a context cancellation or deadline.
 func isCancellation(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// buildCancelledOutput assembles a CANCELLED WaitOutput.
+// data may be nil when cancellation occurs before the first successful poll;
+// in that case ReviewStatus is omitted but Status/PollsDone/WaitedSeconds are still set.
+func buildCancelledOutput(data *ghclient.ReviewData, entry *store.TriggerEntry, status ghclient.ReviewStatus, pollsDone int, waited time.Duration) WaitOutput {
+	out := WaitOutput{
+		Status:        "CANCELLED",
+		PollsDone:     pollsDone,
+		WaitedSeconds: int(waited.Seconds()),
+	}
+	if data != nil {
+		rs := buildStatusOutput(data, entry, status)
+		out.ReviewStatus = &rs
+	}
+	return out
 }
 
 // buildStatusOutput assembles a GetStatusOutput from already-fetched data.


### PR DESCRIPTION
## Summary

- TIMEOUT時: ループ末尾で `lastData/lastEntry/lastStatus` をキャッシュし、ポーリング終了後に再度 `GetReviewData()` / `db.GetLatest()` を呼ばないよう修正
- CANCEL時: `ctx.Done()` 時に `WaitOutput{}` の代わりに `Status: "CANCELLED"` と前回ポーリング結果（`PollsDone`, `WaitedSeconds`, `ReviewStatus`）を含むレスポンスを返すよう修正

Closes #56

## Test plan

- [ ] ビルド確認 (`go build ./...`)
- [ ] 既存テスト通過 (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)