### PR TITLE
improvement(copilot-review-mcp): ci_all_success自動取得とlast_comment_at自動算出を実装 (#57)

### DIFF
--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -52,6 +52,11 @@ func isCopilot(login string) bool {
 	return false
 }
 
+// IsCopilotLogin reports whether login belongs to a known Copilot bot identity.
+func IsCopilotLogin(login string) bool {
+	return isCopilot(login)
+}
+
 // ReviewStatus represents the Copilot review lifecycle state for a PR.
 type ReviewStatus string
 

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -475,6 +475,43 @@ func (c *Client) ReplyToThread(ctx context.Context, threadID, body string) (Repl
 	}, nil
 }
 
+// GetCIStatus returns true when all GitHub Check Runs for the PR's head commit have
+// passed (conclusion: success, skipped, or neutral). Returns true when no check runs exist.
+// Returns false when any run is not yet completed or has a failing conclusion.
+func (c *Client) GetCIStatus(ctx context.Context, owner, repo string, prNumber int) (bool, error) {
+	pr, _, err := c.gh.PullRequests.Get(ctx, owner, repo, prNumber)
+	if err != nil {
+		return false, fmt.Errorf("failed to get PR: %w", err)
+	}
+	sha := pr.GetHead().GetSHA()
+	if sha == "" {
+		return false, fmt.Errorf("PR #%d head SHA is empty", prNumber)
+	}
+
+	opts := &github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}}
+	for {
+		result, resp, err := c.gh.Checks.ListCheckRunsForRef(ctx, owner, repo, sha, opts)
+		if err != nil {
+			return false, fmt.Errorf("failed to list check runs: %w", err)
+		}
+		for _, r := range result.CheckRuns {
+			if r.GetStatus() != "completed" {
+				return false, nil
+			}
+			switch r.GetConclusion() {
+			case "success", "skipped", "neutral":
+			default:
+				return false, nil
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return true, nil
+}
+
 // ResolveThread resolves a review thread. Returns true if it was already resolved before the call.
 func (c *Client) ResolveThread(ctx context.Context, threadID string) (alreadyResolved bool, err error) {
 	alreadyResolved, err = c.IsThreadResolved(ctx, threadID)

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -299,6 +299,82 @@ func TestGetCIStatus(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("returns false when a later check-runs page contains failure", func(t *testing.T) {
+		mux := http.NewServeMux()
+		pagesSeen := []string{}
+
+		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, pr), func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, prJSON)
+		})
+		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", owner, repo, sha), func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			page := r.URL.Query().Get("page")
+			if page == "" {
+				page = "1"
+			}
+			pagesSeen = append(pagesSeen, page)
+			if page == "1" {
+				w.Header().Set("Link", fmt.Sprintf(`<http://%s/repos/%s/%s/commits/%s/check-runs?page=2>; rel="next"`, r.Host, owner, repo, sha))
+				fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}`)
+				return
+			}
+			fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":2,"status":"completed","conclusion":"failure"}]}`)
+		})
+
+		c, teardown := newTestGHClient(mux)
+		defer teardown()
+
+		got, err := c.GetCIStatus(context.Background(), owner, repo, pr)
+		if err != nil {
+			t.Fatalf("GetCIStatus() error = %v", err)
+		}
+		if got {
+			t.Fatalf("GetCIStatus() = %v, want false", got)
+		}
+		if join(pagesSeen, ",") != "1,2" {
+			t.Fatalf("GetCIStatus() did not request all pages, got pages %q, want %q", join(pagesSeen, ","), "1,2")
+		}
+	})
+
+	t.Run("returns true when all check-runs across later pages succeed", func(t *testing.T) {
+		mux := http.NewServeMux()
+		pagesSeen := []string{}
+
+		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, pr), func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, prJSON)
+		})
+		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", owner, repo, sha), func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			page := r.URL.Query().Get("page")
+			if page == "" {
+				page = "1"
+			}
+			pagesSeen = append(pagesSeen, page)
+			if page == "1" {
+				w.Header().Set("Link", fmt.Sprintf(`<http://%s/repos/%s/%s/commits/%s/check-runs?page=2>; rel="next"`, r.Host, owner, repo, sha))
+				fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}`)
+				return
+			}
+			fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":2,"status":"completed","conclusion":"success"}]}`)
+		})
+
+		c, teardown := newTestGHClient(mux)
+		defer teardown()
+
+		got, err := c.GetCIStatus(context.Background(), owner, repo, pr)
+		if err != nil {
+			t.Fatalf("GetCIStatus() error = %v", err)
+		}
+		if !got {
+			t.Fatalf("GetCIStatus() = %v, want true", got)
+		}
+		if join(pagesSeen, ",") != "1,2" {
+			t.Fatalf("GetCIStatus() did not request all pages, got pages %q, want %q", join(pagesSeen, ","), "1,2")
+		}
+	})
 }
 
 // join concatenates strings with a separator (avoids importing strings in test file).

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -1,6 +1,11 @@
 package ghclient
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -195,4 +200,115 @@ func TestDeriveStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newTestGHClient creates a Client backed by a test HTTP server.
+// The caller must call teardown() when done.
+func newTestGHClient(mux *http.ServeMux) (*Client, func()) {
+	srv := httptest.NewServer(mux)
+	gh := github.NewClient(nil)
+	u, _ := url.Parse(srv.URL + "/")
+	gh.BaseURL = u
+	gh.UploadURL = u
+	return &Client{gh: gh}, srv.Close
+}
+
+func TestGetCIStatus(t *testing.T) {
+	const (
+		owner = "owner"
+		repo  = "repo"
+		pr    = 1
+		sha   = "abc123def456"
+	)
+
+	prJSON := fmt.Sprintf(`{"number":%d,"head":{"sha":%q}}`, pr, sha)
+
+	makeChecksJSON := func(runs ...string) string {
+		return fmt.Sprintf(`{"total_count":%d,"check_runs":[%s]}`, len(runs), join(runs, ","))
+	}
+	makeRun := func(status, conclusion string) string {
+		return fmt.Sprintf(`{"id":1,"status":%q,"conclusion":%q}`, status, conclusion)
+	}
+
+	tests := []struct {
+		name       string
+		checksJSON string
+		want       bool
+	}{
+		{
+			name:       "zero check runs → true (CI not configured)",
+			checksJSON: makeChecksJSON(),
+			want:       true,
+		},
+		{
+			name:       "all success → true",
+			checksJSON: makeChecksJSON(makeRun("completed", "success")),
+			want:       true,
+		},
+		{
+			name:       "skipped → true",
+			checksJSON: makeChecksJSON(makeRun("completed", "skipped")),
+			want:       true,
+		},
+		{
+			name:       "neutral → true",
+			checksJSON: makeChecksJSON(makeRun("completed", "neutral")),
+			want:       true,
+		},
+		{
+			name:       "in_progress (not completed) → false",
+			checksJSON: makeChecksJSON(makeRun("in_progress", "")),
+			want:       false,
+		},
+		{
+			name:       "failure → false",
+			checksJSON: makeChecksJSON(makeRun("completed", "failure")),
+			want:       false,
+		},
+		{
+			name: "mixed success and failure → false",
+			checksJSON: makeChecksJSON(
+				makeRun("completed", "success"),
+				makeRun("completed", "failure"),
+			),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, pr), func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, prJSON)
+			})
+			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", owner, repo, sha), func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tt.checksJSON)
+			})
+
+			c, teardown := newTestGHClient(mux)
+			defer teardown()
+
+			got, err := c.GetCIStatus(context.Background(), owner, repo, pr)
+			if err != nil {
+				t.Fatalf("GetCIStatus() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("GetCIStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// join concatenates strings with a separator (avoids importing strings in test file).
+func join(ss []string, sep string) string {
+	if len(ss) == 0 {
+		return ""
+	}
+	result := ss[0]
+	for _, s := range ss[1:] {
+		result += sep + s
+	}
+	return result
 }

--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -46,7 +46,7 @@ type CycleStatusInput struct {
 	Owner         string  `json:"owner"`
 	Repo          string  `json:"repo"`
 	PR            int     `json:"pr"`
-	LastCommentAt *string `json:"last_comment_at,omitempty"` // ISO8601 | null | omitted; auto-computed from threads when absent
+	LastCommentAt *string `json:"last_comment_at,omitempty"` // RFC3339 timestamp (ISO8601 subset) | null | omitted; auto-computed from threads when absent
 	CyclesDone    int     `json:"cycles_done"`
 	MaxCycles     int     `json:"max_cycles"` // 0 → use env/default
 	FixType       string  `json:"fix_type"`   // logic | spec_change | trivial | none

--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -46,8 +46,7 @@ type CycleStatusInput struct {
 	Owner         string  `json:"owner"`
 	Repo          string  `json:"repo"`
 	PR            int     `json:"pr"`
-	CIAllSuccess  bool    `json:"ci_all_success"`
-	LastCommentAt *string `json:"last_comment_at,omitempty"` // ISO8601 | null | omitted
+	LastCommentAt *string `json:"last_comment_at,omitempty"` // ISO8601 | null | omitted; auto-computed from threads when absent
 	CyclesDone    int     `json:"cycles_done"`
 	MaxCycles     int     `json:"max_cycles"` // 0 → use env/default
 	FixType       string  `json:"fix_type"`   // logic | spec_change | trivial | none
@@ -153,9 +152,7 @@ func cycleStatusHandler(
 				RereviewReason:    rereviewReason,
 				CyclesDone:        in.CyclesDone,
 				MaxCycles:         maxCycles,
-				// Reflect at least the caller-provided CI status; thread counts are unavailable
-				// at this early-exit point (threads not yet fetched).
-				MergeConditions: MergeConditions{CIOK: in.CIAllSuccess},
+				MergeConditions: MergeConditions{},
 				Notes:           notes,
 			}, nil
 		}
@@ -207,8 +204,15 @@ func cycleStatusHandler(
 			NonBlocking: nonBlockingCount,
 			Suggestion:  suggestionCount,
 		}
+
+		// Auto-detect CI status from GitHub Checks API.
+		ciAllSuccess, err := gh.GetCIStatus(ctx, in.Owner, in.Repo, in.PR)
+		if err != nil {
+			return nil, CycleStatusOutput{}, fmt.Errorf("failed to get CI status: %w", err)
+		}
+
 		mergeConditions := MergeConditions{
-			CIOK:            in.CIAllSuccess,
+			CIOK:            ciAllSuccess,
 			BlockingCount:   blockingCount,
 			UnresolvedCount: unresolvedCount,
 			AllReplied:      allReplied,
@@ -246,13 +250,16 @@ func cycleStatusHandler(
 				return nil, CycleStatusOutput{}, fmt.Errorf("invalid last_comment_at: must be RFC3339: %w", parseErr)
 			}
 			elapsedMinutes = int(time.Since(lastAt).Minutes())
+		} else if latest := findLatestCommentAt(rawThreads); latest != nil {
+			// Auto-compute from thread comments when last_comment_at is not provided.
+			elapsedMinutes = int(time.Since(*latest).Minutes())
 		}
 
 		// ── Termination condition checks (used for action and notes) ─────────
 		// Condition 1: all comments resolved, no blocking, CI OK.
-		terminateCond1 := blockingCount == 0 && unresolvedCount == 0 && in.CIAllSuccess
+		terminateCond1 := blockingCount == 0 && unresolvedCount == 0 && ciAllSuccess
 		// Condition 2: no new Copilot comment for ≥ threshold minutes, CI OK, no blocking.
-		terminateCond2 := elapsedMinutes >= noCommentThreshold && in.CIAllSuccess && blockingCount == 0
+		terminateCond2 := elapsedMinutes >= noCommentThreshold && ciAllSuccess && blockingCount == 0
 
 		// ── Determine recommended_action ──────────────────────────────────────
 		var recommendedAction string
@@ -350,7 +357,7 @@ func cycleStatusHandler(
 				if unresolvedCount > 0 {
 					reasons = append(reasons, fmt.Sprintf("unresolved=%d残存", unresolvedCount))
 				}
-				if !in.CIAllSuccess {
+				if !ciAllSuccess {
 					reasons = append(reasons, "CI未達成")
 				}
 				if len(reasons) == 0 {
@@ -378,4 +385,22 @@ func cycleStatusHandler(
 // RegisterCycleTool adds get_pr_review_cycle_status to the MCP server.
 func RegisterCycleTool(server *mcp.Server, gh *ghclient.Client, db *store.DB) {
 	mcp.AddTool(server, cycleTool, cycleStatusHandler(gh, db))
+}
+
+// findLatestCommentAt returns the most recent CreatedAt across all thread comments,
+// or nil when there are no comments.
+func findLatestCommentAt(threads []ghclient.ReviewThread) *time.Time {
+	var latest time.Time
+	for _, t := range threads {
+		for _, c := range t.Comments {
+			ts, err := time.Parse(time.RFC3339, c.CreatedAt)
+			if err == nil && ts.After(latest) {
+				latest = ts
+			}
+		}
+	}
+	if latest.IsZero() {
+		return nil
+	}
+	return &latest
 }

--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -138,6 +138,12 @@ func cycleStatusHandler(
 			rereviewReason = &reason
 		}
 
+		// Auto-detect CI status early so all exit paths return accurate ci_ok.
+		ciAllSuccess, err := gh.GetCIStatus(ctx, in.Owner, in.Repo, in.PR)
+		if err != nil {
+			return nil, CycleStatusOutput{}, fmt.Errorf("failed to get CI status: %w", err)
+		}
+
 		// ── Early exit: max cycles exceeded ────────────────────────────────
 		if in.CyclesDone >= maxCycles {
 			notes := []string{
@@ -152,8 +158,8 @@ func cycleStatusHandler(
 				RereviewReason:    rereviewReason,
 				CyclesDone:        in.CyclesDone,
 				MaxCycles:         maxCycles,
-				MergeConditions: MergeConditions{},
-				Notes:           notes,
+				MergeConditions:   MergeConditions{CIOK: ciAllSuccess},
+				Notes:             notes,
 			}, nil
 		}
 
@@ -203,12 +209,6 @@ func cycleStatusHandler(
 			Blocking:    blockingCount,
 			NonBlocking: nonBlockingCount,
 			Suggestion:  suggestionCount,
-		}
-
-		// Auto-detect CI status from GitHub Checks API.
-		ciAllSuccess, err := gh.GetCIStatus(ctx, in.Owner, in.Repo, in.PR)
-		if err != nil {
-			return nil, CycleStatusOutput{}, fmt.Errorf("failed to get CI status: %w", err)
 		}
 
 		mergeConditions := MergeConditions{
@@ -387,12 +387,15 @@ func RegisterCycleTool(server *mcp.Server, gh *ghclient.Client, db *store.DB) {
 	mcp.AddTool(server, cycleTool, cycleStatusHandler(gh, db))
 }
 
-// findLatestCommentAt returns the most recent CreatedAt across all thread comments,
-// or nil when there are no comments.
+// findLatestCommentAt returns the most recent CreatedAt across Copilot-authored
+// thread comments, or nil when no such comments exist.
 func findLatestCommentAt(threads []ghclient.ReviewThread) *time.Time {
 	var latest time.Time
 	for _, t := range threads {
 		for _, c := range t.Comments {
+			if !ghclient.IsCopilotLogin(c.Author) {
+				continue
+			}
 			ts, err := time.Parse(time.RFC3339, c.CreatedAt)
 			if err == nil && ts.After(latest) {
 				latest = ts


### PR DESCRIPTION
## Summary

- `ci_all_success` 入力パラメータを廃止。`GetCIStatus()` を `ghclient` に追加し、PR headのSHAに対するGitHub Check Runsを自動取得して判定するよう変更（conclusion: success/skipped/neutral を合格扱い）
- `last_comment_at` 省略時、取得済みスレッドのコメント最新時刻を `findLatestCommentAt()` で自動算出し `terminateCond2` を有効化

Closes #57

## Test plan

- [ ] ビルド確認 (`go build ./...`)
- [ ] 既存テスト通過 (`go test ./...`)
- [ ] `ci_all_success` を受け付けなくなったことを確認（破壊的変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)