### PR TITLE
refactor(copilot-review-mcp): スレッド分類をMCPから削除しLLMルールファイルベースへ移行 (#55 #58)

### DIFF
--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -56,29 +56,20 @@ type CycleStatusInput struct {
 // MergeConditions holds the per-condition merge readiness check.
 type MergeConditions struct {
 	CIOK            bool `json:"ci_ok"`
-	BlockingCount   int  `json:"blocking_count"`
 	UnresolvedCount int  `json:"unresolved_count"`
 	AllReplied      bool `json:"all_replied"`
 }
 
-// CycleClassificationSummary holds aggregate thread classification counts.
-type CycleClassificationSummary struct {
-	Blocking    int `json:"blocking"`
-	NonBlocking int `json:"nonBlocking"`
-	Suggestion  int `json:"suggestion"`
-}
-
 // CycleStatusOutput is the output schema for get_pr_review_cycle_status.
 type CycleStatusOutput struct {
-	CycleStatus           string                     `json:"cycle_status"`       // CONTINUE | TERMINATE  ※TERMINATE は推奨アクションが終端アクション(READY_TO_MERGE/ESCALATE)の場合のみ
-	RecommendedAction     string                     `json:"recommended_action"` // WAIT | APPLY_FIXES | REPLY_RESOLVE | REQUEST_REREVIEW | READY_TO_MERGE | ESCALATE
-	RereviewRequired      bool                       `json:"rereview_required"`
-	RereviewReason        *string                    `json:"rereview_reason"`
-	CyclesDone            int                        `json:"cycles_done"`
-	MaxCycles             int                        `json:"max_cycles"`
-	MergeConditions       MergeConditions            `json:"merge_conditions"`
-	ClassificationSummary CycleClassificationSummary `json:"classification_summary"`
-	Notes                 []string                   `json:"notes"`
+	CycleStatus       string          `json:"cycle_status"`       // CONTINUE | TERMINATE
+	RecommendedAction string          `json:"recommended_action"` // WAIT | REPLY_RESOLVE | REQUEST_REREVIEW | READY_TO_MERGE | ESCALATE
+	RereviewRequired  bool            `json:"rereview_required"`
+	RereviewReason    *string         `json:"rereview_reason"`
+	CyclesDone        int             `json:"cycles_done"`
+	MaxCycles         int             `json:"max_cycles"`
+	MergeConditions   MergeConditions `json:"merge_conditions"`
+	Notes             []string        `json:"notes"`
 }
 
 // ─── Tool 8: get_pr_review_cycle_status ──────────────────────────────────────
@@ -86,8 +77,8 @@ type CycleStatusOutput struct {
 var cycleTool = &mcp.Tool{
 	Name: "get_pr_review_cycle_status",
 	Description: "PR レビューサイクルの現在状態を評価し、次の推奨アクション " +
-		"(WAIT / APPLY_FIXES / REPLY_RESOLVE / REQUEST_REREVIEW / READY_TO_MERGE / ESCALATE) を返す。" +
-		"ISSUE#25・ISSUE#26 のツール群を組み合わせた PR レビューサイクルのオーケストレーション用。\n\n" +
+		"(WAIT / REPLY_RESOLVE / REQUEST_REREVIEW / READY_TO_MERGE / ESCALATE) を返す。" +
+		"スレッドの blocking/non-blocking/suggestion 分類は呼び出し元 LLM がルールファイルに基づいて判断する。\n\n" +
 		"【cycle_status の定義】\n" +
 		"  TERMINATE = recommended_action が READY_TO_MERGE または ESCALATE の場合のみ。\n" +
 		"  これらは \"次のサイクル不要\" を意味する終端アクション。\n" +
@@ -160,32 +151,18 @@ func cycleStatusHandler(
 			}, nil
 		}
 
-		// ── Fetch review threads and classify ────────────────────────────────
+		// ── Fetch review threads ─────────────────────────────────────────────
 		rawThreads, err := gh.GetReviewThreads(ctx, in.Owner, in.Repo, in.PR)
 		if err != nil {
 			return nil, CycleStatusOutput{}, fmt.Errorf("failed to fetch review threads: %w", err)
 		}
 
-		blockingCount := 0
-		nonBlockingCount := 0
-		suggestionCount := 0
 		unresolvedCount := 0
 		allReplied := true // vacuously true when there are no threads
 
 		for _, t := range rawThreads {
-			cls, _ := classifyThread(t.Comments)
-			// Count classifications only for unresolved threads so that
-			// resolved/fixed issues do not keep the cycle stuck.
 			if !t.IsResolved {
 				unresolvedCount++
-				switch cls {
-				case "blocking":
-					blockingCount++
-				case "non-blocking":
-					nonBlockingCount++
-				default:
-					suggestionCount++
-				}
 			}
 			// A thread is "replied" only when there are comments from
 			// at least two distinct authors (for example, Copilot and a user).
@@ -202,14 +179,8 @@ func cycleStatusHandler(
 			}
 		}
 
-		classSummary := CycleClassificationSummary{
-			Blocking:    blockingCount,
-			NonBlocking: nonBlockingCount,
-			Suggestion:  suggestionCount,
-		}
 		mergeConditions := MergeConditions{
 			CIOK:            in.CIAllSuccess,
-			BlockingCount:   blockingCount,
 			UnresolvedCount: unresolvedCount,
 			AllReplied:      allReplied,
 		}
@@ -249,10 +220,10 @@ func cycleStatusHandler(
 		}
 
 		// ── Termination condition checks (used for action and notes) ─────────
-		// Condition 1: all comments resolved, no blocking, CI OK.
-		terminateCond1 := blockingCount == 0 && unresolvedCount == 0 && in.CIAllSuccess
-		// Condition 2: no new Copilot comment for ≥ threshold minutes, CI OK, no blocking.
-		terminateCond2 := elapsedMinutes >= noCommentThreshold && in.CIAllSuccess && blockingCount == 0
+		// Condition 1: all comments resolved, CI OK.
+		terminateCond1 := unresolvedCount == 0 && in.CIAllSuccess
+		// Condition 2: no new Copilot comment for ≥ threshold minutes, CI OK.
+		terminateCond2 := elapsedMinutes >= noCommentThreshold && in.CIAllSuccess
 
 		// ── Determine recommended_action ──────────────────────────────────────
 		var recommendedAction string
@@ -265,10 +236,8 @@ func cycleStatusHandler(
 		case reviewStatus == ghclient.StatusPending || reviewStatus == ghclient.StatusInProgress:
 			recommendedAction = "WAIT"
 
-		case blockingCount > 0:
-			recommendedAction = "APPLY_FIXES"
-
 		case unresolvedCount > 0:
+			// LLM determines blocking vs non-blocking from raw thread content per SKILL.md.
 			recommendedAction = "REPLY_RESOLVE"
 
 		case rereviewRequired:
@@ -306,8 +275,7 @@ func cycleStatusHandler(
 		// ── Build notes ───────────────────────────────────────────────────────
 		notes := []string{
 			fmt.Sprintf("■ サイクル: %d/%d回目", in.CyclesDone+1, maxCycles),
-			fmt.Sprintf("■ コメント分類: blocking=%d, non-blocking=%d, suggestion=%d",
-				blockingCount, nonBlockingCount, suggestionCount),
+			fmt.Sprintf("■ 未解決スレッド: %d件", unresolvedCount),
 		}
 		if in.FixType != "" {
 			fixNote := fmt.Sprintf("■ 修正種別: %s", in.FixType)
@@ -344,9 +312,6 @@ func cycleStatusHandler(
 					reasons = append(reasons, fmt.Sprintf("継続理由: 推奨アクション=%s", recommendedAction))
 				}
 			} else {
-				if blockingCount > 0 {
-					reasons = append(reasons, fmt.Sprintf("blocking=%d残存", blockingCount))
-				}
 				if unresolvedCount > 0 {
 					reasons = append(reasons, fmt.Sprintf("unresolved=%d残存", unresolvedCount))
 				}
@@ -362,15 +327,14 @@ func cycleStatusHandler(
 		notes = append(notes, fmt.Sprintf("■ 推奨アクション: %s", recommendedAction))
 
 		return nil, CycleStatusOutput{
-			CycleStatus:           cycleStatus,
-			RecommendedAction:     recommendedAction,
-			RereviewRequired:      rereviewRequired,
-			RereviewReason:        rereviewReason,
-			CyclesDone:            in.CyclesDone,
-			MaxCycles:             maxCycles,
-			MergeConditions:       mergeConditions,
-			ClassificationSummary: classSummary,
-			Notes:                 notes,
+			CycleStatus:       cycleStatus,
+			RecommendedAction: recommendedAction,
+			RereviewRequired:  rereviewRequired,
+			RereviewReason:    rereviewReason,
+			CyclesDone:        in.CyclesDone,
+			MaxCycles:         maxCycles,
+			MergeConditions:   mergeConditions,
+			Notes:             notes,
 		}, nil
 	}
 }

--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -220,9 +220,9 @@ func cycleStatusHandler(
 		}
 
 		// ── Termination condition checks (used for action and notes) ─────────
-		// Condition 1: all comments resolved, CI OK.
+		// Condition 1: unresolved=0 and CI=OK.
 		terminateCond1 := unresolvedCount == 0 && in.CIAllSuccess
-		// Condition 2: no new Copilot comment for ≥ threshold minutes, CI OK.
+		// Condition 2: no new Copilot comment for ≥ threshold minutes and CI=OK.
 		terminateCond2 := elapsedMinutes >= noCommentThreshold && in.CIAllSuccess
 
 		// ── Determine recommended_action ──────────────────────────────────────
@@ -290,7 +290,7 @@ func cycleStatusHandler(
 		if cycleStatus == "TERMINATE" {
 			switch {
 			case terminateCond1:
-				notes = append(notes, "■ サイクル終了条件: 達成（blocking=0, unresolved=0, CI=OK）")
+				notes = append(notes, "■ サイクル終了条件: 達成（unresolved=0, CI=OK）")
 			default:
 				notes = append(notes, fmt.Sprintf(
 					"■ サイクル終了条件: 達成（コメントなし %d分経過 ≥ %d分閾値 & CI=OK）",

--- a/services/copilot-review-mcp/internal/tools/status.go
+++ b/services/copilot-review-mcp/internal/tools/status.go
@@ -25,7 +25,6 @@ type GetStatusOutput struct {
 	Status              string  `json:"status"`
 	Trigger             *string `json:"trigger"`
 	IsBlocking          bool    `json:"isBlocking"`
-	BlockingThreadCount int     `json:"blockingThreadCount"`
 	LastReviewAt        *string `json:"lastReviewAt"`
 	ElapsedSinceRequest *string `json:"elapsedSinceRequest"`
 }

--- a/services/copilot-review-mcp/internal/tools/threads.go
+++ b/services/copilot-review-mcp/internal/tools/threads.go
@@ -10,61 +10,6 @@ import (
 	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
 )
 
-// ─── Classification keywords ──────────────────────────────────────────────────
-
-var blockingKeywords = []string{
-	// エラー・クラッシュ系
-	"panic", "nil pointer", "null reference", "index out of", "runtime error",
-	"will fail", "causes error", "throws exception", "crash",
-	// セキュリティ系
-	"sql injection", "xss", "csrf", "authentication", "authorization",
-	"unvalidated", "unsanitized", "hardcoded secret", "exposed credential",
-	// データ整合性系
-	"data loss", "data corruption", "race condition", "deadlock",
-	"transaction", "rollback", "inconsistent state",
-	// 型・互換性系
-	"type mismatch", "breaking change", "incompatible", "removed api",
-	"deprecated and removed",
-}
-
-var nonBlockingKeywords = []string{
-	"consider adding test", "missing test", "log", "logging",
-	"consider", "might want to", "optional",
-}
-
-var suggestionKeywords = []string{
-	"rename", "refactor", "extract", "naming", "abstract", "simplify",
-	"nit:", "style:", "minor:",
-}
-
-// classifyThread returns the classification and reason for a thread based on its comments.
-// Priority: blocking > non-blocking > suggestion.
-func classifyThread(comments []ghclient.ThreadComment) (classification, reason string) {
-	var bodyBuilder strings.Builder
-	for _, c := range comments {
-		bodyBuilder.WriteByte(' ')
-		bodyBuilder.WriteString(strings.ToLower(c.Body))
-	}
-	body := bodyBuilder.String()
-
-	for _, kw := range blockingKeywords {
-		if strings.Contains(body, kw) {
-			return "blocking", fmt.Sprintf("keyword matched: %q", kw)
-		}
-	}
-	for _, kw := range nonBlockingKeywords {
-		if strings.Contains(body, kw) {
-			return "non-blocking", fmt.Sprintf("keyword matched: %q", kw)
-		}
-	}
-	for _, kw := range suggestionKeywords {
-		if strings.Contains(body, kw) {
-			return "suggestion", fmt.Sprintf("keyword matched: %q", kw)
-		}
-	}
-	return "suggestion", "no keywords matched"
-}
-
 // ─── Tool 4: get_review_threads ───────────────────────────────────────────────
 
 // GetReviewThreadsInput is the input schema for get_review_threads.
@@ -83,22 +28,17 @@ type ThreadCommentOutput struct {
 
 // ThreadResult is the result for a single review thread.
 type ThreadResult struct {
-	ID                   string                `json:"id"`
-	Path                 string                `json:"path"`
-	Line                 *int32                `json:"line"`
-	IsResolved           bool                  `json:"isResolved"`
-	Classification       string                `json:"classification"`
-	ClassificationReason string                `json:"classificationReason"`
-	Comments             []ThreadCommentOutput `json:"comments"`
+	ID         string                `json:"id"`
+	Path       string                `json:"path"`
+	Line       *int32                `json:"line"`
+	IsResolved bool                  `json:"isResolved"`
+	Comments   []ThreadCommentOutput `json:"comments"`
 }
 
 // ThreadSummary holds aggregate counts across all threads.
 type ThreadSummary struct {
-	Total       int `json:"total"`
-	Blocking    int `json:"blocking"`
-	NonBlocking int `json:"nonBlocking"`
-	Suggestion  int `json:"suggestion"`
-	Unresolved  int `json:"unresolved"`
+	Total      int `json:"total"`
+	Unresolved int `json:"unresolved"`
 }
 
 // GetReviewThreadsOutput is the output schema for get_review_threads.
@@ -109,7 +49,7 @@ type GetReviewThreadsOutput struct {
 
 var getReviewThreadsTool = &mcp.Tool{
 	Name:        "get_review_threads",
-	Description: "PR のレビュースレッド一覧を分類情報付きで返す。各スレッドに PRRT_xxx 形式の ID を含む。ページネーション対応。",
+	Description: "PR のレビュースレッド一覧（Raw コメントデータ）を返す。各スレッドに PRRT_xxx 形式の ID を含む。分類（blocking/non-blocking/suggestion）は呼び出し元 LLM がルールファイルに基づいて判断する。",
 }
 
 func getReviewThreadsHandler(
@@ -128,20 +68,9 @@ func getReviewThreadsHandler(
 		summary := ThreadSummary{Total: len(rawThreads)}
 		results := make([]ThreadResult, 0, len(rawThreads))
 		for _, t := range rawThreads {
-			classification, reason := classifyThread(t.Comments)
-
-			switch classification {
-			case "blocking":
-				summary.Blocking++
-			case "non-blocking":
-				summary.NonBlocking++
-			default:
-				summary.Suggestion++
-			}
 			if !t.IsResolved {
 				summary.Unresolved++
 			}
-
 			comments := make([]ThreadCommentOutput, 0, len(t.Comments))
 			for _, c := range t.Comments {
 				comments = append(comments, ThreadCommentOutput{
@@ -151,13 +80,11 @@ func getReviewThreadsHandler(
 				})
 			}
 			results = append(results, ThreadResult{
-				ID:                   t.ID,
-				Path:                 t.Path,
-				Line:                 t.Line,
-				IsResolved:           t.IsResolved,
-				Classification:       classification,
-				ClassificationReason: reason,
-				Comments:             comments,
+				ID:         t.ID,
+				Path:       t.Path,
+				Line:       t.Line,
+				IsResolved: t.IsResolved,
+				Comments:   comments,
 			})
 		}
 


### PR DESCRIPTION
## Summary

- `classifyThread()` および `blockingKeywords/nonBlockingKeywords/suggestionKeywords` を `threads.go` から完全削除
- `get_review_threads`: `classification`/`classificationReason` フィールドを廃止。Rawコメントデータのみ返すよう簡素化。`ThreadSummary` から Blocking/NonBlocking/Suggestion カウントを削除
- `get_pr_review_cycle_status`: `CycleClassificationSummary` 型と `classification_summary` フィールドを廃止。`MergeConditions` から `blocking_count` を削除。`recommended_action` から `APPLY_FIXES` を削除（LLMがSKILL.mdに基づいて判断）
- `get_copilot_review_status`: `blockingThreadCount` フィールドを削除 (Closes #55)

分類判断の責務は LLM が `~/.claude/skills/pr-review-cycle/SKILL.md` Phase 3 に基づいて担う。

Closes #55, Closes #58

## Test plan

- [ ] ビルド確認 (`go build ./...`)
- [ ] 既存テスト通過 (`go test ./...`)
- [ ] `get_review_threads` レスポンスに `classification` フィールドが含まれないことを確認（破壊的変更）
- [ ] `get_pr_review_cycle_status` レスポンスに `classification_summary` が含まれないことを確認（破壊的変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)