### PR TITLE
fix(ci): pin github-mcp-server ref for security scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,9 @@ on:
   workflow_dispatch:
 
 env:
-  GITHUB_MCP_SERVER_REF: ${{ vars.GITHUB_MCP_SERVER_REF || 'main' }}
+  # Pin to a known-compatible upstream commit until the patch set is updated
+  # for newer github-mcp-server/go-sdk changes.
+  GITHUB_MCP_SERVER_REF: ${{ vars.GITHUB_MCP_SERVER_REF || 'a24c0be254cd72f80aa76b2a90395f2ce155dd94' }}
   GITHUB_MCP_GO_SDK_VERSION: ${{ vars.GITHUB_MCP_GO_SDK_VERSION || 'v1.3.1' }}
   SECURITY_SCAN_IMAGE: github-mcp-server:security-scan
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,9 +10,6 @@ on:
   workflow_dispatch:
 
 env:
-  # Pin to a known-compatible upstream commit until the patch set is updated
-  # for newer github-mcp-server/go-sdk changes.
-  GITHUB_MCP_SERVER_REF: ${{ vars.GITHUB_MCP_SERVER_REF || 'a24c0be254cd72f80aa76b2a90395f2ce155dd94' }}
   GITHUB_MCP_GO_SDK_VERSION: ${{ vars.GITHUB_MCP_GO_SDK_VERSION || 'v1.3.1' }}
   SECURITY_SCAN_IMAGE: github-mcp-server:security-scan
 
@@ -61,10 +58,19 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build patched GitHub MCP Server image
+        env:
+          GITHUB_MCP_SERVER_REF: ${{ vars.GITHUB_MCP_SERVER_REF }}
         run: |
+          build_args=(
+            --build-arg GO_SDK_VERSION=${{ env.GITHUB_MCP_GO_SDK_VERSION }}
+          )
+
+          if [ -n "$GITHUB_MCP_SERVER_REF" ]; then
+            build_args+=(--build-arg GITHUB_MCP_SERVER_REF=$GITHUB_MCP_SERVER_REF)
+          fi
+
           docker build \
-            --build-arg GITHUB_MCP_SERVER_REF=${{ env.GITHUB_MCP_SERVER_REF }} \
-            --build-arg GO_SDK_VERSION=${{ env.GITHUB_MCP_GO_SDK_VERSION }} \
+            "${build_args[@]}" \
             -f Dockerfile.github-mcp-server \
             -t ${{ env.SECURITY_SCAN_IMAGE }} \
             .

--- a/Dockerfile.github-mcp-server
+++ b/Dockerfile.github-mcp-server
@@ -18,7 +18,9 @@ RUN apt-get update && \
 FROM golang:1.26-bookworm AS builder
 
 ARG GITHUB_MCP_SERVER_REPO=https://github.com/github/github-mcp-server.git
-ARG GITHUB_MCP_SERVER_REF=main
+# Pin to a known-compatible upstream commit until the patch set is updated
+# for newer github-mcp-server/go-sdk changes.
+ARG GITHUB_MCP_SERVER_REF=a24c0be254cd72f80aa76b2a90395f2ce155dd94
 ARG GO_SDK_VERSION=v1.3.1
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64


### PR DESCRIPTION
## Summary
- pin the patched `github-mcp-server` build to a known-compatible upstream commit
- apply the same pin in the workflow default and Dockerfile default
- keep the current `go-sdk v1.3.1` patch path working until a dedicated follow-up updates the patch set

## Root Cause
`github/github-mcp-server@main` added `CrossOriginProtection` to `mcp.StreamableHTTPOptions`, but this repo still forces `github.com/modelcontextprotocol/go-sdk@v1.3.1` in `Dockerfile.github-mcp-server`.
That made `Security Scan` fail during `docker build` before Trivy could run, even on docs-only PRs.

## Validation
- `docker build -f Dockerfile.github-mcp-server -t github-mcp-server:security-scan .`

## Follow-up
A separate PR should update the patch set and SDK compatibility so the pin can be removed.