### PR TITLE
[codex] feat: add memory-only copilot review watch manager

### DIFF
--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -60,6 +61,7 @@ func main() {
 	// MCP endpoints (auth required) — Streamable HTTP transport (stateless, per-request server)
 	threshold := time.Duration(cfg.inProgressThresholdSec) * time.Second
 	mcpHandler := tools.BuildStreamableHandler(db, threshold, oauthHandler)
+	defer mcpHandler.Close()
 	mux.Handle("/mcp", authMiddleware(mcpHandler))
 	mux.Handle("/mcp/", authMiddleware(mcpHandler))
 
@@ -75,7 +77,9 @@ func main() {
 		WriteTimeout:      0,
 		IdleTimeout:       120 * time.Second,
 	}
-	if err := server.ListenAndServe(); err != nil {
+	server.RegisterOnShutdown(mcpHandler.Close)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		mcpHandler.Close()
 		slog.Error("server error", "err", err)
 		os.Exit(1)
 	}

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -3,6 +3,7 @@ package ghclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -168,6 +169,11 @@ func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber
 // DeriveStatus resolves the ReviewStatus from raw data and optional trigger_log requestedAt.
 // requestedAt is nil when no trigger_log entry exists (AUTO trigger or not yet recorded).
 func (c *Client) DeriveStatus(data *ReviewData, requestedAt *time.Time) ReviewStatus {
+	return DeriveStatusWithThreshold(c.threshold, data, requestedAt)
+}
+
+// DeriveStatusWithThreshold resolves the ReviewStatus from raw data and an elapsed threshold.
+func DeriveStatusWithThreshold(threshold time.Duration, data *ReviewData, requestedAt *time.Time) ReviewStatus {
 	if data.LatestCopilotReview != nil {
 		// When requestedAt is known, only treat this review as relevant if it was submitted
 		// at or after the request time. This prevents a stale pre-existing review from being
@@ -190,7 +196,7 @@ func (c *Client) DeriveStatus(data *ReviewData, requestedAt *time.Time) ReviewSt
 	if data.IsCopilotInReviewers {
 		if requestedAt != nil {
 			elapsed := time.Since(*requestedAt)
-			if elapsed >= c.threshold {
+			if elapsed >= threshold {
 				return StatusInProgress
 			}
 			return StatusPending
@@ -199,6 +205,12 @@ func (c *Client) DeriveStatus(data *ReviewData, requestedAt *time.Time) ReviewSt
 		return StatusInProgress
 	}
 	return StatusNotRequested
+}
+
+// IsAuthError reports whether err is a GitHub authentication failure.
+func IsAuthError(err error) bool {
+	var ghErr *github.ErrorResponse
+	return errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusUnauthorized
 }
 
 // prNodeIDQuery fetches the GraphQL node ID for a pull request.
@@ -221,11 +233,11 @@ type requestReviewsByLoginMutation struct {
 // requestReviewsByLoginInput is the input type for requestReviewsByLoginMutation.
 // Field names must be PascalCase so shurcooL/githubv4 serialises them correctly.
 type requestReviewsByLoginInput struct {
-	PullRequestID githubv4.ID        `json:"pullRequestId"`
-	BotLogins     []githubv4.String  `json:"botLogins"`
-	UserLogins    []githubv4.String  `json:"userLogins"`
-	TeamSlugs     []githubv4.String  `json:"teamSlugs"`
-	Union         githubv4.Boolean   `json:"union"`
+	PullRequestID githubv4.ID       `json:"pullRequestId"`
+	BotLogins     []githubv4.String `json:"botLogins"`
+	UserLogins    []githubv4.String `json:"userLogins"`
+	TeamSlugs     []githubv4.String `json:"teamSlugs"`
+	Union         githubv4.Boolean  `json:"union"`
 }
 
 // buildCopilotReviewInput constructs the mutation input for adding Copilot as a reviewer.

--- a/services/copilot-review-mcp/internal/middleware/auth.go
+++ b/services/copilot-review-mcp/internal/middleware/auth.go
@@ -79,3 +79,9 @@ func TokenFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(ContextKeyToken).(string)
 	return v
 }
+
+// LoginFromContext retrieves the GitHub login injected by Auth middleware.
+func LoginFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ContextKeyLogin).(string)
+	return v
+}

--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -21,11 +21,30 @@ type TokenInvalidator interface {
 	InvalidateCachedToken(token string)
 }
 
-// BuildStreamableHandler returns an http.Handler that serves MCP over Streamable HTTP.
+// StreamableHandler serves MCP over Streamable HTTP and owns shared background state.
+type StreamableHandler struct {
+	handler      http.Handler
+	watchManager *watch.Manager
+}
+
+// ServeHTTP proxies requests to the underlying MCP streamable handler.
+func (h *StreamableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.handler.ServeHTTP(w, r)
+}
+
+// Close stops background review watches owned by this handler.
+func (h *StreamableHandler) Close() {
+	if h == nil || h.watchManager == nil {
+		return
+	}
+	h.watchManager.Close()
+}
+
+// BuildStreamableHandler returns a handler that serves MCP over Streamable HTTP.
 // getServer is called for each request (stateless mode) to produce a fresh *mcp.Server
 // bound to the caller's GitHub access token.
 // inv is called to invalidate the cached token when GitHub returns HTTP 401.
-func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInvalidator) http.Handler {
+func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInvalidator) *StreamableHandler {
 	var invalidate func(string)
 	if inv != nil {
 		invalidate = inv.InvalidateCachedToken
@@ -53,10 +72,13 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 		RegisterCycleTool(srv, gh, db)
 		return srv
 	}
-	return mcp.NewStreamableHTTPHandler(getServer, &mcp.StreamableHTTPOptions{
-		Stateless: true,
-		// DisableLocalhostProtection is opt-in via MCP_DISABLE_LOCALHOST_PROTECTION=true.
-		// Enable when the server runs behind a reverse proxy or inside a Docker network.
-		DisableLocalhostProtection: os.Getenv("MCP_DISABLE_LOCALHOST_PROTECTION") == "true",
-	})
+	return &StreamableHandler{
+		handler: mcp.NewStreamableHTTPHandler(getServer, &mcp.StreamableHTTPOptions{
+			Stateless: true,
+			// DisableLocalhostProtection is opt-in via MCP_DISABLE_LOCALHOST_PROTECTION=true.
+			// Enable when the server runs behind a reverse proxy or inside a Docker network.
+			DisableLocalhostProtection: os.Getenv("MCP_DISABLE_LOCALHOST_PROTECTION") == "true",
+		}),
+		watchManager: watchManager,
+	}
 }

--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -10,6 +10,7 @@ import (
 	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
 	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
 	"github.com/scottlz0310/copilot-review-mcp/internal/store"
+	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
 )
 
 var schemaCache = mcp.NewSchemaCache()
@@ -25,14 +26,19 @@ type TokenInvalidator interface {
 // bound to the caller's GitHub access token.
 // inv is called to invalidate the cached token when GitHub returns HTTP 401.
 func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInvalidator) http.Handler {
+	var invalidate func(string)
+	if inv != nil {
+		invalidate = inv.InvalidateCachedToken
+	}
+	watchManager := watch.NewManager(db, watch.Options{
+		Threshold:       threshold,
+		InvalidateToken: invalidate,
+	})
+
 	getServer := func(r *http.Request) *mcp.Server {
 		token := middleware.TokenFromContext(r.Context())
 		if token == "" {
 			return nil
-		}
-		var invalidate func(string)
-		if inv != nil {
-			invalidate = inv.InvalidateCachedToken
 		}
 		gh := ghclient.NewClient(r.Context(), token, threshold, invalidate)
 		srv := mcp.NewServer(
@@ -40,6 +46,7 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 			&mcp.ServerOptions{SchemaCache: schemaCache},
 		)
 		RegisterStatusTool(srv, gh, db)
+		RegisterWatchTools(srv, watchManager)
 		RegisterWaitTool(srv, gh, db)
 		RegisterRequestTool(srv, gh, db)
 		RegisterThreadTools(srv, gh)

--- a/services/copilot-review-mcp/internal/tools/server_test.go
+++ b/services/copilot-review-mcp/internal/tools/server_test.go
@@ -1,0 +1,40 @@
+package tools
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/store"
+	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
+)
+
+func TestStreamableHandlerCloseClosesWatchManager(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "server-test.db"))
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+
+	handler := BuildStreamableHandler(db, 30*time.Second, nil)
+	handler.Close()
+	handler.Close()
+
+	_, _, err = handler.watchManager.Start(watch.StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    1,
+	})
+	if err == nil {
+		t.Fatal("Start() after Close() = nil error, want watch manager is closed")
+	}
+	if err.Error() != "watch manager is closed" {
+		t.Fatalf("Start() after Close() error = %q, want %q", err.Error(), "watch manager is closed")
+	}
+}

--- a/services/copilot-review-mcp/internal/tools/watch.go
+++ b/services/copilot-review-mcp/internal/tools/watch.go
@@ -1,0 +1,215 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
+	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
+)
+
+// StartReviewWatchInput is the input schema for start_copilot_review_watch.
+type StartReviewWatchInput struct {
+	Owner string `json:"owner"`
+	Repo  string `json:"repo"`
+	PR    int    `json:"pr"`
+}
+
+// StartReviewWatchOutput is the output schema for start_copilot_review_watch.
+type StartReviewWatchOutput struct {
+	WatchID       string  `json:"watch_id"`
+	Reused        bool    `json:"reused"`
+	WatchStatus   string  `json:"watch_status"`
+	ReviewStatus  *string `json:"review_status,omitempty"`
+	FailureReason *string `json:"failure_reason,omitempty"`
+	Terminal      bool    `json:"terminal"`
+	WorkerRunning bool    `json:"worker_running"`
+	PollsDone     int     `json:"polls_done"`
+	StartedAt     string  `json:"started_at"`
+	UpdatedAt     string  `json:"updated_at"`
+	LastPolledAt  *string `json:"last_polled_at,omitempty"`
+	CompletedAt   *string `json:"completed_at,omitempty"`
+	LastError     *string `json:"last_error,omitempty"`
+	Note          string  `json:"note"`
+}
+
+// GetReviewWatchStatusInput is the input schema for get_copilot_review_watch_status.
+type GetReviewWatchStatusInput struct {
+	WatchID string `json:"watch_id,omitempty"`
+	Owner   string `json:"owner,omitempty"`
+	Repo    string `json:"repo,omitempty"`
+	PR      int    `json:"pr,omitempty"`
+}
+
+// GetReviewWatchStatusOutput is the output schema for get_copilot_review_watch_status.
+type GetReviewWatchStatusOutput struct {
+	Found         bool    `json:"found"`
+	WatchID       *string `json:"watch_id,omitempty"`
+	WatchStatus   *string `json:"watch_status,omitempty"`
+	ReviewStatus  *string `json:"review_status,omitempty"`
+	FailureReason *string `json:"failure_reason,omitempty"`
+	Terminal      bool    `json:"terminal"`
+	WorkerRunning bool    `json:"worker_running"`
+	PollsDone     int     `json:"polls_done"`
+	StartedAt     *string `json:"started_at,omitempty"`
+	UpdatedAt     *string `json:"updated_at,omitempty"`
+	LastPolledAt  *string `json:"last_polled_at,omitempty"`
+	CompletedAt   *string `json:"completed_at,omitempty"`
+	LastError     *string `json:"last_error,omitempty"`
+	Note          string  `json:"note"`
+}
+
+var startWatchTool = &mcp.Tool{
+	Name:        "start_copilot_review_watch",
+	Description: "Copilot review の background watch を開始し、即時 return する。同一ユーザー・同一 PR の active watch があればそれを再利用する。watch state は memory-only で、サーバー再起動後は維持されない。",
+}
+
+var getWatchStatusTool = &mcp.Tool{
+	Name:        "get_copilot_review_watch_status",
+	Description: "background watch の現在状態を memory-only state から返す。watch_id を優先し、watch_id が無い場合は owner/repo/pr から同一ユーザーの最新 watch を引く。",
+}
+
+func startWatchHandler(
+	manager *watch.Manager,
+) func(context.Context, *mcp.CallToolRequest, StartReviewWatchInput) (*mcp.CallToolResult, StartReviewWatchOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, in StartReviewWatchInput) (*mcp.CallToolResult, StartReviewWatchOutput, error) {
+		if in.Owner == "" || in.Repo == "" || in.PR <= 0 {
+			return nil, StartReviewWatchOutput{}, fmt.Errorf("owner, repo, and pr are required")
+		}
+
+		login := middleware.LoginFromContext(ctx)
+		token := middleware.TokenFromContext(ctx)
+		if login == "" || token == "" {
+			return nil, StartReviewWatchOutput{}, fmt.Errorf("authenticated GitHub login and token are required")
+		}
+
+		snapshot, reused, err := manager.Start(watch.StartInput{
+			Login: login,
+			Token: token,
+			Owner: in.Owner,
+			Repo:  in.Repo,
+			PR:    in.PR,
+		})
+		if err != nil {
+			return nil, StartReviewWatchOutput{}, err
+		}
+
+		out := buildStartWatchOutput(snapshot, reused)
+		if reused {
+			out.Note = "既存の active watch を再利用しました。"
+		} else {
+			out.Note = "background watch を開始しました。"
+		}
+		return nil, out, nil
+	}
+}
+
+func getWatchStatusHandler(
+	manager *watch.Manager,
+) func(context.Context, *mcp.CallToolRequest, GetReviewWatchStatusInput) (*mcp.CallToolResult, GetReviewWatchStatusOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, in GetReviewWatchStatusInput) (*mcp.CallToolResult, GetReviewWatchStatusOutput, error) {
+		var (
+			snapshot watch.Snapshot
+			ok       bool
+		)
+
+		switch {
+		case in.WatchID != "":
+			snapshot, ok = manager.GetByID(in.WatchID)
+		case in.Owner != "" && in.Repo != "" && in.PR > 0:
+			login := middleware.LoginFromContext(ctx)
+			if login == "" {
+				return nil, GetReviewWatchStatusOutput{}, fmt.Errorf("authenticated GitHub login is required")
+			}
+			snapshot, ok = manager.GetLatest(login, in.Owner, in.Repo, in.PR)
+		default:
+			return nil, GetReviewWatchStatusOutput{}, fmt.Errorf("watch_id or owner, repo, and pr are required")
+		}
+
+		if !ok {
+			return nil, GetReviewWatchStatusOutput{
+				Found: false,
+				Note:  "watch が見つかりませんでした。",
+			}, nil
+		}
+
+		return nil, buildGetWatchStatusOutput(snapshot), nil
+	}
+}
+
+// RegisterWatchTools adds the async review watch tools to the MCP server.
+func RegisterWatchTools(server *mcp.Server, manager *watch.Manager) {
+	mcp.AddTool(server, startWatchTool, startWatchHandler(manager))
+	mcp.AddTool(server, getWatchStatusTool, getWatchStatusHandler(manager))
+}
+
+func buildStartWatchOutput(snapshot watch.Snapshot, reused bool) StartReviewWatchOutput {
+	out := StartReviewWatchOutput{
+		WatchID:       snapshot.WatchID,
+		Reused:        reused,
+		WatchStatus:   string(snapshot.WatchStatus),
+		Terminal:      snapshot.Terminal,
+		WorkerRunning: snapshot.WorkerRunning,
+		PollsDone:     snapshot.PollsDone,
+		StartedAt:     snapshot.StartedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:     snapshot.UpdatedAt.UTC().Format(time.RFC3339),
+		LastError:     snapshot.LastError,
+	}
+	if snapshot.ReviewStatus != nil {
+		status := string(*snapshot.ReviewStatus)
+		out.ReviewStatus = &status
+	}
+	if snapshot.FailureReason != nil {
+		reason := string(*snapshot.FailureReason)
+		out.FailureReason = &reason
+	}
+	if snapshot.LastPolledAt != nil {
+		ts := snapshot.LastPolledAt.UTC().Format(time.RFC3339)
+		out.LastPolledAt = &ts
+	}
+	if snapshot.CompletedAt != nil {
+		ts := snapshot.CompletedAt.UTC().Format(time.RFC3339)
+		out.CompletedAt = &ts
+	}
+	return out
+}
+
+func buildGetWatchStatusOutput(snapshot watch.Snapshot) GetReviewWatchStatusOutput {
+	watchID := snapshot.WatchID
+	watchStatus := string(snapshot.WatchStatus)
+	startedAt := snapshot.StartedAt.UTC().Format(time.RFC3339)
+	updatedAt := snapshot.UpdatedAt.UTC().Format(time.RFC3339)
+
+	out := GetReviewWatchStatusOutput{
+		Found:         true,
+		WatchID:       &watchID,
+		WatchStatus:   &watchStatus,
+		Terminal:      snapshot.Terminal,
+		WorkerRunning: snapshot.WorkerRunning,
+		PollsDone:     snapshot.PollsDone,
+		StartedAt:     &startedAt,
+		UpdatedAt:     &updatedAt,
+		LastError:     snapshot.LastError,
+		Note:          "watch の現在状態です。",
+	}
+	if snapshot.ReviewStatus != nil {
+		status := string(*snapshot.ReviewStatus)
+		out.ReviewStatus = &status
+	}
+	if snapshot.FailureReason != nil {
+		reason := string(*snapshot.FailureReason)
+		out.FailureReason = &reason
+	}
+	if snapshot.LastPolledAt != nil {
+		ts := snapshot.LastPolledAt.UTC().Format(time.RFC3339)
+		out.LastPolledAt = &ts
+	}
+	if snapshot.CompletedAt != nil {
+		ts := snapshot.CompletedAt.UTC().Format(time.RFC3339)
+		out.CompletedAt = &ts
+	}
+	return out
+}

--- a/services/copilot-review-mcp/internal/tools/watch.go
+++ b/services/copilot-review-mcp/internal/tools/watch.go
@@ -118,7 +118,14 @@ func getWatchStatusHandler(
 
 		switch {
 		case in.WatchID != "":
+			login := middleware.LoginFromContext(ctx)
+			if login == "" {
+				return nil, GetReviewWatchStatusOutput{}, fmt.Errorf("authenticated GitHub login is required")
+			}
 			snapshot, ok = manager.GetByID(in.WatchID)
+			if ok && snapshot.Login != login {
+				ok = false
+			}
 		case in.Owner != "" && in.Repo != "" && in.PR > 0:
 			login := middleware.LoginFromContext(ctx)
 			if login == "" {

--- a/services/copilot-review-mcp/internal/tools/watch_test.go
+++ b/services/copilot-review-mcp/internal/tools/watch_test.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
+	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
+	"github.com/scottlz0310/copilot-review-mcp/internal/store"
+	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
+)
+
+func TestGetWatchStatusHandlerScopesWatchIDByLogin(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "watch-tools.db"))
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+
+	manager := watch.NewManager(db, watch.Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+			return testStaticFetcher{}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(watch.StartInput{
+		Login: "owner-user",
+		Token: "token-a",
+		Owner: "scottlz0310",
+		Repo:  "Mcp-Docker",
+		PR:    71,
+	})
+	if err != nil {
+		t.Fatalf("manager.Start() error = %v", err)
+	}
+
+	handler := getWatchStatusHandler(manager)
+	ctx := context.WithValue(context.Background(), middleware.ContextKeyLogin, "different-user")
+
+	_, out, err := handler(ctx, nil, GetReviewWatchStatusInput{WatchID: started.WatchID})
+	if err != nil {
+		t.Fatalf("getWatchStatusHandler() error = %v", err)
+	}
+	if out.Found {
+		t.Fatalf("Found = %v, want false", out.Found)
+	}
+}
+
+type testStaticFetcher struct{}
+
+func (testStaticFetcher) GetReviewData(context.Context, string, string, int) (*ghclient.ReviewData, error) {
+	return &ghclient.ReviewData{
+		IsCopilotInReviewers: true,
+		RateLimitRemaining:   100,
+	}, nil
+}

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -334,7 +334,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 	}
 	now := m.now().UTC()
 	if now.Sub(w.startedAt) >= m.maxWatchDuration {
-		m.finishStatus(w.id, now, StatusTimeout, nil, fmt.Sprintf("watch exceeded max duration of %s", m.maxWatchDuration))
+		m.finishStatusWithoutPoll(w.id, now, StatusTimeout, nil, fmt.Sprintf("watch exceeded max duration of %s", m.maxWatchDuration))
 		return true
 	}
 
@@ -342,7 +342,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 	client := w.client
 	w.clientMu.RUnlock()
 	if client == nil {
-		m.finishFailure(w.id, now, FailureReasonInternal, "watch client is unavailable")
+		m.finishFailureWithoutPoll(w.id, now, FailureReasonInternal, "watch client is unavailable")
 		return true
 	}
 
@@ -360,24 +360,24 @@ func (m *Manager) pollOnce(watchID string) bool {
 			if w.ctx.Err() != nil {
 				return true
 			}
-			m.finishFailure(w.id, now, FailureReasonGitHubError, fmt.Sprintf("github poll timed out after %s", m.pollTimeout))
+			m.finishFailureWithPoll(w.id, now, FailureReasonGitHubError, fmt.Sprintf("github poll timed out after %s", m.pollTimeout))
 			return true
 		}
 		if IsRateLimitHTTPError(err) {
-			m.finishStatus(w.id, now, StatusRateLimited, nil, err.Error())
+			m.finishStatusWithPoll(w.id, now, StatusRateLimited, nil, err.Error())
 			return true
 		}
 		reason := FailureReasonGitHubError
 		if ghclient.IsAuthError(err) {
 			reason = FailureReasonAuthExpired
 		}
-		m.finishFailure(w.id, now, reason, err.Error())
+		m.finishFailureWithPoll(w.id, now, reason, err.Error())
 		return true
 	}
 
 	entry, err := m.db.GetLatest(w.key.owner, w.key.repo, w.key.pr)
 	if err != nil {
-		m.finishFailure(w.id, now, FailureReasonInternal, fmt.Sprintf("failed to read trigger_log: %v", err))
+		m.finishFailureWithPoll(w.id, now, FailureReasonInternal, fmt.Sprintf("failed to read trigger_log: %v", err))
 		return true
 	}
 
@@ -387,20 +387,16 @@ func (m *Manager) pollOnce(watchID string) bool {
 	}
 	reviewStatus := ghclient.DeriveStatusWithThreshold(m.threshold, data, requestedAt)
 
-	m.mu.Lock()
-	current := m.watchesByID[watchID]
-	if current == nil || current.terminal {
-		m.mu.Unlock()
-		return true
-	}
-
-	current.pollsDone++
-	current.updatedAt = now
-	current.lastPolledAt = timePtr(now)
-	current.reviewStatus = reviewStatusPtr(reviewStatus)
-	current.lastError = nil
-
 	if data.RateLimitRemaining < 10 {
+		m.mu.Lock()
+		current := m.watchesByID[watchID]
+		if current == nil || current.terminal {
+			m.mu.Unlock()
+			return true
+		}
+		m.markPollLocked(current, now)
+		current.reviewStatus = reviewStatusPtr(reviewStatus)
+		current.lastError = nil
 		m.finishLocked(current, StatusRateLimited, nil, now, formatRateLimitMessage(data.RateLimitRemaining, data.RateLimitReset))
 		m.mu.Unlock()
 		return true
@@ -408,46 +404,60 @@ func (m *Manager) pollOnce(watchID string) bool {
 
 	terminalStatus, terminal := watchStatusForReview(reviewStatus)
 	if terminal {
-		m.mu.Unlock()
 		if entry != nil && entry.CompletedAt == nil {
 			if err := m.db.UpdateCompletedAt(entry.ID); err != nil {
-				m.finishFailure(w.id, now, FailureReasonInternal, fmt.Sprintf("failed to update trigger_log completed_at: %v", err))
+				m.finishFailureWithPoll(w.id, now, FailureReasonInternal, fmt.Sprintf("failed to update trigger_log completed_at: %v", err))
 				return true
 			}
 		}
 		m.mu.Lock()
-		current = m.watchesByID[watchID]
+		current := m.watchesByID[watchID]
 		if current == nil || current.terminal {
 			m.mu.Unlock()
 			return true
 		}
+		m.markPollLocked(current, now)
+		current.reviewStatus = reviewStatusPtr(reviewStatus)
+		current.lastError = nil
 		m.finishLocked(current, terminalStatus, nil, now, "")
 		m.mu.Unlock()
 		return true
 	}
 
+	m.mu.Lock()
+	current := m.watchesByID[watchID]
+	if current == nil || current.terminal {
+		m.mu.Unlock()
+		return true
+	}
+	m.markPollLocked(current, now)
+	current.reviewStatus = reviewStatusPtr(reviewStatus)
+	current.lastError = nil
 	current.status = StatusWatching
 	current.workerRunning = true
 	m.mu.Unlock()
 	return false
 }
 
-func (m *Manager) finishFailure(watchID string, now time.Time, reason FailureReason, errText string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	w := m.watchesByID[watchID]
-	if w == nil || w.terminal {
-		return
-	}
-
-	w.pollsDone++
-	w.updatedAt = now
-	w.lastPolledAt = timePtr(now)
-	m.finishLocked(w, StatusFailed, &reason, now, errText)
+func (m *Manager) finishFailureWithPoll(watchID string, now time.Time, reason FailureReason, errText string) {
+	reasonCopy := reason
+	m.finishState(watchID, now, StatusFailed, &reasonCopy, errText, true)
 }
 
-func (m *Manager) finishStatus(watchID string, now time.Time, status Status, reason *FailureReason, errText string) {
+func (m *Manager) finishFailureWithoutPoll(watchID string, now time.Time, reason FailureReason, errText string) {
+	reasonCopy := reason
+	m.finishState(watchID, now, StatusFailed, &reasonCopy, errText, false)
+}
+
+func (m *Manager) finishStatusWithPoll(watchID string, now time.Time, status Status, reason *FailureReason, errText string) {
+	m.finishState(watchID, now, status, reason, errText, true)
+}
+
+func (m *Manager) finishStatusWithoutPoll(watchID string, now time.Time, status Status, reason *FailureReason, errText string) {
+	m.finishState(watchID, now, status, reason, errText, false)
+}
+
+func (m *Manager) finishState(watchID string, now time.Time, status Status, reason *FailureReason, errText string, countedPoll bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -456,9 +466,11 @@ func (m *Manager) finishStatus(watchID string, now time.Time, status Status, rea
 		return
 	}
 
-	w.pollsDone++
-	w.updatedAt = now
-	w.lastPolledAt = timePtr(now)
+	if countedPoll {
+		m.markPollLocked(w, now)
+	} else {
+		w.updatedAt = now
+	}
 	m.finishLocked(w, status, reason, now, errText)
 }
 
@@ -473,6 +485,12 @@ func (m *Manager) markStale(watchID, errText string) {
 
 	now := m.now().UTC()
 	m.finishLocked(w, StatusStale, nil, now, errText)
+}
+
+func (m *Manager) markPollLocked(w *watchState, now time.Time) {
+	w.pollsDone++
+	w.updatedAt = now
+	w.lastPolledAt = timePtr(now)
 }
 
 func (m *Manager) finishLocked(w *watchState, status Status, reason *FailureReason, now time.Time, errText string) {
@@ -506,22 +524,54 @@ func snapshotFromState(w *watchState) Snapshot {
 		Repo:          w.key.repo,
 		PR:            w.key.pr,
 		WatchStatus:   w.status,
-		ReviewStatus:  w.reviewStatus,
-		FailureReason: w.failureReason,
+		ReviewStatus:  cloneReviewStatusPtr(w.reviewStatus),
+		FailureReason: cloneFailureReasonPtr(w.failureReason),
 		Terminal:      w.terminal,
 		WorkerRunning: w.workerRunning,
 		PollsDone:     w.pollsDone,
 		StartedAt:     w.startedAt,
 		UpdatedAt:     w.updatedAt,
-		CompletedAt:   w.completedAt,
-		LastPolledAt:  w.lastPolledAt,
-		LastError:     w.lastError,
+		CompletedAt:   cloneTimePtr(w.completedAt),
+		LastPolledAt:  cloneTimePtr(w.lastPolledAt),
+		LastError:     cloneStringPtr(w.lastError),
 	}
 }
 
 func reviewStatusPtr(status ghclient.ReviewStatus) *ghclient.ReviewStatus {
 	s := status
 	return &s
+}
+
+func cloneReviewStatusPtr(status *ghclient.ReviewStatus) *ghclient.ReviewStatus {
+	if status == nil {
+		return nil
+	}
+	s := *status
+	return &s
+}
+
+func cloneFailureReasonPtr(reason *FailureReason) *FailureReason {
+	if reason == nil {
+		return nil
+	}
+	r := *reason
+	return &r
+}
+
+func cloneTimePtr(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	v := *t
+	return &v
+}
+
+func cloneStringPtr(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	v := *s
+	return &v
 }
 
 func timePtr(t time.Time) *time.Time {

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -15,6 +15,8 @@ import (
 )
 
 const defaultPollInterval = 90 * time.Second
+const defaultPollTimeout = 30 * time.Second
+const defaultMaxWatchDuration = 2 * time.Hour
 
 // Status is the lifecycle state of a background review watch.
 type Status string
@@ -75,28 +77,32 @@ type ReviewDataFetcher interface {
 
 // Options configures the watch manager.
 type Options struct {
-	PollInterval    time.Duration
-	Threshold       time.Duration
-	InvalidateToken func(string)
-	ClientFactory   func(ctx context.Context, token string) ReviewDataFetcher
-	Now             func() time.Time
+	PollInterval     time.Duration
+	PollTimeout      time.Duration
+	MaxWatchDuration time.Duration
+	Threshold        time.Duration
+	InvalidateToken  func(string)
+	ClientFactory    func(ctx context.Context, token string) ReviewDataFetcher
+	Now              func() time.Time
 }
 
 // Manager owns background review-watch workers for the current server process.
 type Manager struct {
-	db            *store.DB
-	threshold     time.Duration
-	pollInterval  time.Duration
-	clientFactory func(ctx context.Context, token string) ReviewDataFetcher
-	now           func() time.Time
-	ctx           context.Context
-	cancel        context.CancelFunc
-	idSeq         atomic.Uint64
-	mu            sync.RWMutex
-	watchesByID   map[string]*watchState
-	activeByKey   map[watchKey]string
-	latestByKey   map[watchKey]string
-	closed        bool
+	db               *store.DB
+	threshold        time.Duration
+	pollInterval     time.Duration
+	pollTimeout      time.Duration
+	maxWatchDuration time.Duration
+	clientFactory    func(ctx context.Context, token string) ReviewDataFetcher
+	now              func() time.Time
+	ctx              context.Context
+	cancel           context.CancelFunc
+	idSeq            atomic.Uint64
+	mu               sync.RWMutex
+	watchesByID      map[string]*watchState
+	activeByKey      map[watchKey]string
+	latestByKey      map[watchKey]string
+	closed           bool
 }
 
 type watchKey struct {
@@ -133,6 +139,14 @@ func NewManager(db *store.DB, opts Options) *Manager {
 	if pollInterval <= 0 {
 		pollInterval = defaultPollInterval
 	}
+	pollTimeout := opts.PollTimeout
+	if pollTimeout <= 0 {
+		pollTimeout = defaultPollTimeout
+	}
+	maxWatchDuration := opts.MaxWatchDuration
+	if maxWatchDuration <= 0 {
+		maxWatchDuration = defaultMaxWatchDuration
+	}
 	now := opts.Now
 	if now == nil {
 		now = time.Now
@@ -145,16 +159,18 @@ func NewManager(db *store.DB, opts Options) *Manager {
 		}
 	}
 	return &Manager{
-		db:            db,
-		threshold:     opts.Threshold,
-		pollInterval:  pollInterval,
-		clientFactory: clientFactory,
-		now:           now,
-		ctx:           ctx,
-		cancel:        cancel,
-		watchesByID:   make(map[string]*watchState),
-		activeByKey:   make(map[watchKey]string),
-		latestByKey:   make(map[watchKey]string),
+		db:               db,
+		threshold:        opts.Threshold,
+		pollInterval:     pollInterval,
+		pollTimeout:      pollTimeout,
+		maxWatchDuration: maxWatchDuration,
+		clientFactory:    clientFactory,
+		now:              now,
+		ctx:              ctx,
+		cancel:           cancel,
+		watchesByID:      make(map[string]*watchState),
+		activeByKey:      make(map[watchKey]string),
+		latestByKey:      make(map[watchKey]string),
 	}
 }
 
@@ -180,6 +196,9 @@ func (m *Manager) Close() {
 		w.updatedAt = now
 		w.completedAt = timePtr(now)
 		w.token = ""
+		w.clientMu.Lock()
+		w.client = nil
+		w.clientMu.Unlock()
 		errText := "watch manager closed before the watch could finish"
 		w.lastError = &errText
 		watches = append(watches, w)
@@ -313,16 +332,35 @@ func (m *Manager) pollOnce(watchID string) bool {
 	if w == nil {
 		return true
 	}
+	now := m.now().UTC()
+	if now.Sub(w.startedAt) >= m.maxWatchDuration {
+		m.finishStatus(w.id, now, StatusTimeout, nil, fmt.Sprintf("watch exceeded max duration of %s", m.maxWatchDuration))
+		return true
+	}
 
 	w.clientMu.RLock()
 	client := w.client
 	w.clientMu.RUnlock()
+	if client == nil {
+		m.finishFailure(w.id, now, FailureReasonInternal, "watch client is unavailable")
+		return true
+	}
 
-	data, err := client.GetReviewData(w.ctx, w.key.owner, w.key.repo, w.key.pr)
-	now := m.now().UTC()
+	callCtx, cancel := context.WithTimeout(w.ctx, m.pollTimeout)
+	defer cancel()
+
+	data, err := client.GetReviewData(callCtx, w.key.owner, w.key.repo, w.key.pr)
+	now = m.now().UTC()
 
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.Canceled) && w.ctx.Err() != nil {
+			return true
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			if w.ctx.Err() != nil {
+				return true
+			}
+			m.finishFailure(w.id, now, FailureReasonGitHubError, fmt.Sprintf("github poll timed out after %s", m.pollTimeout))
 			return true
 		}
 		if IsRateLimitHTTPError(err) {
@@ -445,6 +483,9 @@ func (m *Manager) finishLocked(w *watchState, status Status, reason *FailureReas
 	w.updatedAt = now
 	w.completedAt = timePtr(now)
 	w.token = ""
+	w.clientMu.Lock()
+	w.client = nil
+	w.clientMu.Unlock()
 	if errText != "" {
 		w.lastError = &errText
 	}

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -1,0 +1,493 @@
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/go-github/v72/github"
+
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
+	"github.com/scottlz0310/copilot-review-mcp/internal/store"
+)
+
+const defaultPollInterval = 90 * time.Second
+
+// Status is the lifecycle state of a background review watch.
+type Status string
+
+const (
+	StatusWatching    Status = "WATCHING"
+	StatusCompleted   Status = "COMPLETED"
+	StatusBlocked     Status = "BLOCKED"
+	StatusTimeout     Status = "TIMEOUT"
+	StatusRateLimited Status = "RATE_LIMITED"
+	StatusFailed      Status = "FAILED"
+	StatusStale       Status = "STALE"
+	StatusCancelled   Status = "CANCELLED"
+)
+
+// FailureReason describes why a watch entered FAILED.
+type FailureReason string
+
+const (
+	FailureReasonAuthExpired FailureReason = "AUTH_EXPIRED"
+	FailureReasonGitHubError FailureReason = "GITHUB_ERROR"
+	FailureReasonInternal    FailureReason = "INTERNAL_ERROR"
+)
+
+// Snapshot is the externally visible state of a watch at a point in time.
+type Snapshot struct {
+	WatchID       string
+	Login         string
+	Owner         string
+	Repo          string
+	PR            int
+	WatchStatus   Status
+	ReviewStatus  *ghclient.ReviewStatus
+	FailureReason *FailureReason
+	Terminal      bool
+	WorkerRunning bool
+	PollsDone     int
+	StartedAt     time.Time
+	UpdatedAt     time.Time
+	CompletedAt   *time.Time
+	LastPolledAt  *time.Time
+	LastError     *string
+}
+
+// StartInput identifies a PR watch owned by one authenticated GitHub user.
+type StartInput struct {
+	Login string
+	Token string
+	Owner string
+	Repo  string
+	PR    int
+}
+
+// ReviewDataFetcher fetches the GitHub snapshot needed to update watch state.
+type ReviewDataFetcher interface {
+	GetReviewData(ctx context.Context, owner, repo string, prNumber int) (*ghclient.ReviewData, error)
+}
+
+// Options configures the watch manager.
+type Options struct {
+	PollInterval    time.Duration
+	Threshold       time.Duration
+	InvalidateToken func(string)
+	ClientFactory   func(ctx context.Context, token string) ReviewDataFetcher
+	Now             func() time.Time
+}
+
+// Manager owns background review-watch workers for the current server process.
+type Manager struct {
+	db            *store.DB
+	threshold     time.Duration
+	pollInterval  time.Duration
+	clientFactory func(ctx context.Context, token string) ReviewDataFetcher
+	now           func() time.Time
+	ctx           context.Context
+	cancel        context.CancelFunc
+	idSeq         atomic.Uint64
+	mu            sync.RWMutex
+	watchesByID   map[string]*watchState
+	activeByKey   map[watchKey]string
+	latestByKey   map[watchKey]string
+	closed        bool
+}
+
+type watchKey struct {
+	login string
+	owner string
+	repo  string
+	pr    int
+}
+
+type watchState struct {
+	id            string
+	key           watchKey
+	token         string
+	ctx           context.Context
+	cancel        context.CancelFunc
+	client        ReviewDataFetcher
+	status        Status
+	reviewStatus  *ghclient.ReviewStatus
+	failureReason *FailureReason
+	terminal      bool
+	workerRunning bool
+	pollsDone     int
+	startedAt     time.Time
+	updatedAt     time.Time
+	completedAt   *time.Time
+	lastPolledAt  *time.Time
+	lastError     *string
+}
+
+// NewManager creates a process-local, memory-only watch manager.
+func NewManager(db *store.DB, opts Options) *Manager {
+	pollInterval := opts.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultPollInterval
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	clientFactory := opts.ClientFactory
+	if clientFactory == nil {
+		clientFactory = func(ctx context.Context, token string) ReviewDataFetcher {
+			return ghclient.NewClient(ctx, token, opts.Threshold, opts.InvalidateToken)
+		}
+	}
+	return &Manager{
+		db:            db,
+		threshold:     opts.Threshold,
+		pollInterval:  pollInterval,
+		clientFactory: clientFactory,
+		now:           now,
+		ctx:           ctx,
+		cancel:        cancel,
+		watchesByID:   make(map[string]*watchState),
+		activeByKey:   make(map[watchKey]string),
+		latestByKey:   make(map[watchKey]string),
+	}
+}
+
+// Close cancels all active workers and marks them as STALE.
+func (m *Manager) Close() {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.closed = true
+	now := m.now().UTC()
+	watches := make([]*watchState, 0, len(m.activeByKey))
+	for key, id := range m.activeByKey {
+		w := m.watchesByID[id]
+		if w == nil || w.terminal {
+			delete(m.activeByKey, key)
+			continue
+		}
+		w.status = StatusStale
+		w.terminal = true
+		w.workerRunning = false
+		w.updatedAt = now
+		w.completedAt = timePtr(now)
+		w.token = ""
+		errText := "watch manager closed before the watch could finish"
+		w.lastError = &errText
+		watches = append(watches, w)
+		delete(m.activeByKey, key)
+	}
+	m.mu.Unlock()
+
+	for _, w := range watches {
+		w.cancel()
+	}
+	m.cancel()
+}
+
+// Start begins a new background watch or reuses the current active watch for the same user/PR.
+func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
+	if in.Login == "" || in.Token == "" || in.Owner == "" || in.Repo == "" || in.PR <= 0 {
+		return Snapshot{}, false, fmt.Errorf("login, token, owner, repo, and pr are required")
+	}
+
+	key := watchKey{
+		login: in.Login,
+		owner: in.Owner,
+		repo:  in.Repo,
+		pr:    in.PR,
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.closed {
+		return Snapshot{}, false, fmt.Errorf("watch manager is closed")
+	}
+
+	if id, ok := m.activeByKey[key]; ok {
+		if existing := m.watchesByID[id]; existing != nil && !existing.terminal {
+			if existing.token != in.Token {
+				existing.token = in.Token
+				existing.client = m.clientFactory(existing.ctx, in.Token)
+				existing.updatedAt = m.now().UTC()
+			}
+			return snapshotFromState(existing), true, nil
+		}
+		delete(m.activeByKey, key)
+	}
+
+	now := m.now().UTC()
+	watchCtx, cancel := context.WithCancel(m.ctx)
+	id := m.nextID()
+	state := &watchState{
+		id:            id,
+		key:           key,
+		token:         in.Token,
+		ctx:           watchCtx,
+		cancel:        cancel,
+		client:        m.clientFactory(watchCtx, in.Token),
+		status:        StatusWatching,
+		workerRunning: true,
+		startedAt:     now,
+		updatedAt:     now,
+	}
+	m.watchesByID[id] = state
+	m.activeByKey[key] = id
+	m.latestByKey[key] = id
+
+	go m.run(state)
+
+	return snapshotFromState(state), false, nil
+}
+
+// GetByID returns the latest snapshot for a watch ID.
+func (m *Manager) GetByID(watchID string) (Snapshot, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	w := m.watchesByID[watchID]
+	if w == nil {
+		return Snapshot{}, false
+	}
+	return snapshotFromState(w), true
+}
+
+// GetLatest returns the latest watch snapshot for a given user/PR key.
+func (m *Manager) GetLatest(login, owner, repo string, pr int) (Snapshot, bool) {
+	key := watchKey{login: login, owner: owner, repo: repo, pr: pr}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	id, ok := m.latestByKey[key]
+	if !ok {
+		return Snapshot{}, false
+	}
+	w := m.watchesByID[id]
+	if w == nil {
+		return Snapshot{}, false
+	}
+	return snapshotFromState(w), true
+}
+
+func (m *Manager) run(w *watchState) {
+	defer func() {
+		if r := recover(); r != nil {
+			m.markStale(w.id, fmt.Sprintf("watch worker panicked: %v", r))
+		}
+	}()
+
+	if m.pollOnce(w.id) {
+		return
+	}
+
+	ticker := time.NewTicker(m.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case <-ticker.C:
+			if m.pollOnce(w.id) {
+				return
+			}
+		}
+	}
+}
+
+func (m *Manager) pollOnce(watchID string) bool {
+	m.mu.RLock()
+	w := m.watchesByID[watchID]
+	m.mu.RUnlock()
+	if w == nil {
+		return true
+	}
+
+	data, err := w.client.GetReviewData(w.ctx, w.key.owner, w.key.repo, w.key.pr)
+	now := m.now().UTC()
+
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return true
+		}
+		if IsRateLimitHTTPError(err) {
+			m.finishStatus(w.id, now, StatusRateLimited, nil, err.Error())
+			return true
+		}
+		reason := FailureReasonGitHubError
+		if ghclient.IsAuthError(err) {
+			reason = FailureReasonAuthExpired
+		}
+		m.finishFailure(w.id, now, reason, err.Error())
+		return true
+	}
+
+	entry, err := m.db.GetLatest(w.key.owner, w.key.repo, w.key.pr)
+	if err != nil {
+		m.finishFailure(w.id, now, FailureReasonInternal, fmt.Sprintf("failed to read trigger_log: %v", err))
+		return true
+	}
+
+	var requestedAt *time.Time
+	if entry != nil {
+		requestedAt = &entry.RequestedAt
+	}
+	reviewStatus := ghclient.DeriveStatusWithThreshold(m.threshold, data, requestedAt)
+
+	m.mu.Lock()
+	current := m.watchesByID[watchID]
+	if current == nil || current.terminal {
+		m.mu.Unlock()
+		return true
+	}
+
+	current.pollsDone++
+	current.updatedAt = now
+	current.lastPolledAt = timePtr(now)
+	current.reviewStatus = reviewStatusPtr(reviewStatus)
+	current.lastError = nil
+
+	if data.RateLimitRemaining < 10 {
+		m.finishLocked(current, StatusRateLimited, nil, now, "")
+		m.mu.Unlock()
+		return true
+	}
+
+	switch reviewStatus {
+	case ghclient.StatusCompleted:
+		m.finishLocked(current, StatusCompleted, nil, now, "")
+		m.mu.Unlock()
+		if entry != nil && entry.CompletedAt == nil {
+			_ = m.db.UpdateCompletedAt(entry.ID)
+		}
+		return true
+	case ghclient.StatusBlocked:
+		m.finishLocked(current, StatusBlocked, nil, now, "")
+		m.mu.Unlock()
+		if entry != nil && entry.CompletedAt == nil {
+			_ = m.db.UpdateCompletedAt(entry.ID)
+		}
+		return true
+	default:
+		current.status = StatusWatching
+		current.workerRunning = true
+		m.mu.Unlock()
+		return false
+	}
+}
+
+func (m *Manager) finishFailure(watchID string, now time.Time, reason FailureReason, errText string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	w := m.watchesByID[watchID]
+	if w == nil || w.terminal {
+		return
+	}
+
+	w.pollsDone++
+	w.updatedAt = now
+	w.lastPolledAt = timePtr(now)
+	m.finishLocked(w, StatusFailed, &reason, now, errText)
+}
+
+func (m *Manager) finishStatus(watchID string, now time.Time, status Status, reason *FailureReason, errText string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	w := m.watchesByID[watchID]
+	if w == nil || w.terminal {
+		return
+	}
+
+	w.pollsDone++
+	w.updatedAt = now
+	w.lastPolledAt = timePtr(now)
+	m.finishLocked(w, status, reason, now, errText)
+}
+
+func (m *Manager) markStale(watchID, errText string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	w := m.watchesByID[watchID]
+	if w == nil || w.terminal {
+		return
+	}
+
+	now := m.now().UTC()
+	m.finishLocked(w, StatusStale, nil, now, errText)
+}
+
+func (m *Manager) finishLocked(w *watchState, status Status, reason *FailureReason, now time.Time, errText string) {
+	w.status = status
+	w.failureReason = reason
+	w.terminal = true
+	w.workerRunning = false
+	w.updatedAt = now
+	w.completedAt = timePtr(now)
+	w.token = ""
+	if errText != "" {
+		w.lastError = &errText
+	}
+	delete(m.activeByKey, w.key)
+	w.cancel()
+}
+
+func (m *Manager) nextID() string {
+	seq := m.idSeq.Add(1)
+	return fmt.Sprintf("cw_%d_%d", m.now().UTC().UnixNano(), seq)
+}
+
+func snapshotFromState(w *watchState) Snapshot {
+	return Snapshot{
+		WatchID:       w.id,
+		Login:         w.key.login,
+		Owner:         w.key.owner,
+		Repo:          w.key.repo,
+		PR:            w.key.pr,
+		WatchStatus:   w.status,
+		ReviewStatus:  w.reviewStatus,
+		FailureReason: w.failureReason,
+		Terminal:      w.terminal,
+		WorkerRunning: w.workerRunning,
+		PollsDone:     w.pollsDone,
+		StartedAt:     w.startedAt,
+		UpdatedAt:     w.updatedAt,
+		CompletedAt:   w.completedAt,
+		LastPolledAt:  w.lastPolledAt,
+		LastError:     w.lastError,
+	}
+}
+
+func reviewStatusPtr(status ghclient.ReviewStatus) *ghclient.ReviewStatus {
+	s := status
+	return &s
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}
+
+// IsRateLimitHTTPError reports whether err is a GitHub rate-limit HTTP failure.
+func IsRateLimitHTTPError(err error) bool {
+	var rateErr *github.RateLimitError
+	if errors.As(err, &rateErr) {
+		return true
+	}
+	var abuseErr *github.AbuseRateLimitError
+	if errors.As(err, &abuseErr) {
+		return true
+	}
+	var ghErr *github.ErrorResponse
+	return errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusForbidden
+}

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -401,7 +401,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 	current.lastError = nil
 
 	if data.RateLimitRemaining < 10 {
-		m.finishLocked(current, StatusRateLimited, nil, now, "")
+		m.finishLocked(current, StatusRateLimited, nil, now, formatRateLimitMessage(data.RateLimitRemaining, data.RateLimitReset))
 		m.mu.Unlock()
 		return true
 	}
@@ -526,6 +526,18 @@ func reviewStatusPtr(status ghclient.ReviewStatus) *ghclient.ReviewStatus {
 
 func timePtr(t time.Time) *time.Time {
 	return &t
+}
+
+func formatRateLimitMessage(remaining int, reset time.Time) string {
+	resetText := "unknown"
+	if !reset.IsZero() {
+		resetText = reset.UTC().Format(time.RFC3339)
+	}
+	return fmt.Sprintf(
+		"GitHub API rate limit is low (remaining=%d, reset=%s); poll again after the reset time",
+		remaining,
+		resetText,
+	)
 }
 
 // IsRateLimitHTTPError reports whether err is a GitHub rate-limit HTTP failure.

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -113,6 +112,7 @@ type watchState struct {
 	token         string
 	ctx           context.Context
 	cancel        context.CancelFunc
+	clientMu      sync.RWMutex
 	client        ReviewDataFetcher
 	status        Status
 	reviewStatus  *ghclient.ReviewStatus
@@ -217,7 +217,9 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 		if existing := m.watchesByID[id]; existing != nil && !existing.terminal {
 			if existing.token != in.Token {
 				existing.token = in.Token
+				existing.clientMu.Lock()
 				existing.client = m.clientFactory(existing.ctx, in.Token)
+				existing.clientMu.Unlock()
 				existing.updatedAt = m.now().UTC()
 			}
 			return snapshotFromState(existing), true, nil
@@ -312,7 +314,11 @@ func (m *Manager) pollOnce(watchID string) bool {
 		return true
 	}
 
-	data, err := w.client.GetReviewData(w.ctx, w.key.owner, w.key.repo, w.key.pr)
+	w.clientMu.RLock()
+	client := w.client
+	w.clientMu.RUnlock()
+
+	data, err := client.GetReviewData(w.ctx, w.key.owner, w.key.repo, w.key.pr)
 	now := m.now().UTC()
 
 	if err != nil {
@@ -362,27 +368,30 @@ func (m *Manager) pollOnce(watchID string) bool {
 		return true
 	}
 
-	switch reviewStatus {
-	case ghclient.StatusCompleted:
-		m.finishLocked(current, StatusCompleted, nil, now, "")
+	terminalStatus, terminal := watchStatusForReview(reviewStatus)
+	if terminal {
 		m.mu.Unlock()
 		if entry != nil && entry.CompletedAt == nil {
-			_ = m.db.UpdateCompletedAt(entry.ID)
+			if err := m.db.UpdateCompletedAt(entry.ID); err != nil {
+				m.finishFailure(w.id, now, FailureReasonInternal, fmt.Sprintf("failed to update trigger_log completed_at: %v", err))
+				return true
+			}
 		}
-		return true
-	case ghclient.StatusBlocked:
-		m.finishLocked(current, StatusBlocked, nil, now, "")
-		m.mu.Unlock()
-		if entry != nil && entry.CompletedAt == nil {
-			_ = m.db.UpdateCompletedAt(entry.ID)
+		m.mu.Lock()
+		current = m.watchesByID[watchID]
+		if current == nil || current.terminal {
+			m.mu.Unlock()
+			return true
 		}
-		return true
-	default:
-		current.status = StatusWatching
-		current.workerRunning = true
+		m.finishLocked(current, terminalStatus, nil, now, "")
 		m.mu.Unlock()
-		return false
+		return true
 	}
+
+	current.status = StatusWatching
+	current.workerRunning = true
+	m.mu.Unlock()
+	return false
 }
 
 func (m *Manager) finishFailure(watchID string, now time.Time, reason FailureReason, errText string) {
@@ -488,6 +497,16 @@ func IsRateLimitHTTPError(err error) bool {
 	if errors.As(err, &abuseErr) {
 		return true
 	}
-	var ghErr *github.ErrorResponse
-	return errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusForbidden
+	return false
+}
+
+func watchStatusForReview(status ghclient.ReviewStatus) (Status, bool) {
+	switch status {
+	case ghclient.StatusCompleted:
+		return StatusCompleted, true
+	case ghclient.StatusBlocked:
+		return StatusBlocked, true
+	default:
+		return "", false
+	}
 }

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -106,6 +107,12 @@ func TestManagerMarksCompletedAndClearsActiveKey(t *testing.T) {
 	if snapshot.ReviewStatus == nil || *snapshot.ReviewStatus != ghclient.StatusCompleted {
 		t.Fatalf("ReviewStatus = %v, want %q", snapshot.ReviewStatus, ghclient.StatusCompleted)
 	}
+	manager.mu.RLock()
+	client := manager.watchesByID[started.WatchID].client
+	manager.mu.RUnlock()
+	if client != nil {
+		t.Fatal("completed watch retained client, want nil")
+	}
 	if _, ok := manager.GetLatest("alice", "octo", "demo", 7); !ok {
 		t.Fatal("GetLatest() after completion = not found, want last terminal watch")
 	}
@@ -202,6 +209,78 @@ func TestManagerCloseMarksActiveWatchStale(t *testing.T) {
 	}
 }
 
+func TestManagerPollTimeoutFailsWatch(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval: 5 * time.Millisecond,
+		PollTimeout:  10 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return blockingFetcher{}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    200,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusFailed {
+		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusFailed)
+	}
+	if snapshot.FailureReason == nil || *snapshot.FailureReason != FailureReasonGitHubError {
+		t.Fatalf("FailureReason = %v, want %q", snapshot.FailureReason, FailureReasonGitHubError)
+	}
+	if snapshot.LastError == nil || !strings.Contains(*snapshot.LastError, "timed out") {
+		t.Fatalf("LastError = %v, want timeout detail", snapshot.LastError)
+	}
+}
+
+func TestManagerMaxWatchDurationTransitionsToTimeout(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval:     1 * time.Millisecond,
+		MaxWatchDuration: 1 * time.Millisecond,
+		Threshold:        30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    201,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusTimeout {
+		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusTimeout)
+	}
+}
+
 func TestIsRateLimitHTTPError(t *testing.T) {
 	t.Run("matches typed rate limit errors", func(t *testing.T) {
 		if !IsRateLimitHTTPError(&github.RateLimitError{Rate: github.Rate{Remaining: 0}}) {
@@ -231,6 +310,8 @@ type fakeFetcher struct {
 	calls   int
 }
 
+type blockingFetcher struct{}
+
 func (f *fakeFetcher) GetReviewData(_ context.Context, _, _ string, _ int) (*ghclient.ReviewData, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -245,6 +326,11 @@ func (f *fakeFetcher) GetReviewData(_ context.Context, _, _ string, _ int) (*ghc
 	f.calls++
 	result := f.results[index]
 	return result.data, result.err
+}
+
+func (blockingFetcher) GetReviewData(ctx context.Context, _, _ string, _ int) (*ghclient.ReviewData, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
 }
 
 func waitForWatch(t *testing.T, manager *Manager, watchID string, done func(Snapshot) bool) Snapshot {

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -1,0 +1,272 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v72/github"
+
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
+	"github.com/scottlz0310/copilot-review-mcp/internal/store"
+)
+
+func TestManagerStartReusesActiveWatch(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	first, reused, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    42,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if reused {
+		t.Fatalf("Start() reused = %v, want false", reused)
+	}
+
+	second, reused, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-b",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    42,
+	})
+	if err != nil {
+		t.Fatalf("Start() second call error = %v", err)
+	}
+	if !reused {
+		t.Fatalf("second Start() reused = %v, want true", reused)
+	}
+	if second.WatchID != first.WatchID {
+		t.Fatalf("second Start() returned watch %q, want %q", second.WatchID, first.WatchID)
+	}
+}
+
+func TestManagerMarksCompletedAndClearsActiveKey(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := db.Insert("octo", "demo", 7, "MANUAL"); err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+	reviewTime := time.Now().Add(time.Minute)
+	manager := NewManager(db, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{
+						data: &ghclient.ReviewData{
+							LatestCopilotReview: newReview("APPROVED", &reviewTime),
+							RateLimitRemaining:  100,
+						},
+					},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    7,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusCompleted {
+		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusCompleted)
+	}
+	if snapshot.ReviewStatus == nil || *snapshot.ReviewStatus != ghclient.StatusCompleted {
+		t.Fatalf("ReviewStatus = %v, want %q", snapshot.ReviewStatus, ghclient.StatusCompleted)
+	}
+	if _, ok := manager.GetLatest("alice", "octo", "demo", 7); !ok {
+		t.Fatal("GetLatest() after completion = not found, want last terminal watch")
+	}
+
+	next, reused, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    7,
+	})
+	if err != nil {
+		t.Fatalf("Start() after completion error = %v", err)
+	}
+	if reused {
+		t.Fatalf("Start() after completion reused = %v, want false", reused)
+	}
+	if next.WatchID == started.WatchID {
+		t.Fatalf("Start() after completion reused old watch ID %q", next.WatchID)
+	}
+}
+
+func TestManagerAuthExpiredFailsWatch(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{err: &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusUnauthorized}}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "expired-token",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    99,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusFailed {
+		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusFailed)
+	}
+	if snapshot.FailureReason == nil || *snapshot.FailureReason != FailureReasonAuthExpired {
+		t.Fatalf("FailureReason = %v, want %q", snapshot.FailureReason, FailureReasonAuthExpired)
+	}
+}
+
+func TestManagerCloseMarksActiveWatchStale(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval: 50 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    123,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	manager.Close()
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusStale {
+		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusStale)
+	}
+	if snapshot.WorkerRunning {
+		t.Fatal("WorkerRunning = true, want false")
+	}
+}
+
+type fetchResult struct {
+	data *ghclient.ReviewData
+	err  error
+}
+
+type fakeFetcher struct {
+	mu      sync.Mutex
+	results []fetchResult
+	calls   int
+}
+
+func (f *fakeFetcher) GetReviewData(_ context.Context, _, _ string, _ int) (*ghclient.ReviewData, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if len(f.results) == 0 {
+		return nil, fmt.Errorf("no fake results configured")
+	}
+	index := f.calls
+	if index >= len(f.results) {
+		index = len(f.results) - 1
+	}
+	f.calls++
+	result := f.results[index]
+	return result.data, result.err
+}
+
+func waitForWatch(t *testing.T, manager *Manager, watchID string, done func(Snapshot) bool) Snapshot {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot, ok := manager.GetByID(watchID)
+		if ok && done(snapshot) {
+			return snapshot
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	snapshot, _ := manager.GetByID(watchID)
+	t.Fatalf("watch %q did not reach expected state before timeout; last snapshot=%+v", watchID, snapshot)
+	return Snapshot{}
+}
+
+func openTestDB(t *testing.T) *store.DB {
+	t.Helper()
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "watch-test.db"))
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+	return db
+}
+
+func newReview(state string, submittedAt *time.Time) *github.PullRequestReview {
+	review := &github.PullRequestReview{
+		State: github.Ptr(state),
+	}
+	if submittedAt != nil {
+		review.SubmittedAt = &github.Timestamp{Time: *submittedAt}
+	}
+	return review
+}

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -281,6 +281,56 @@ func TestManagerMaxWatchDurationTransitionsToTimeout(t *testing.T) {
 	}
 }
 
+func TestManagerLowRateLimitIncludesRetryDetail(t *testing.T) {
+	db := openTestDB(t)
+	reset := time.Now().UTC().Add(5 * time.Minute).Truncate(time.Second)
+	manager := NewManager(db, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{
+						data: &ghclient.ReviewData{
+							IsCopilotInReviewers: true,
+							RateLimitRemaining:   5,
+							RateLimitReset:       reset,
+						},
+					},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    202,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusRateLimited {
+		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusRateLimited)
+	}
+	if snapshot.LastError == nil {
+		t.Fatal("LastError = nil, want rate-limit detail")
+	}
+	if !strings.Contains(*snapshot.LastError, "remaining=5") {
+		t.Fatalf("LastError = %q, want remaining count", *snapshot.LastError)
+	}
+	if !strings.Contains(*snapshot.LastError, reset.Format(time.RFC3339)) {
+		t.Fatalf("LastError = %q, want reset time %q", *snapshot.LastError, reset.Format(time.RFC3339))
+	}
+}
+
 func TestIsRateLimitHTTPError(t *testing.T) {
 	t.Run("matches typed rate limit errors", func(t *testing.T) {
 		if !IsRateLimitHTTPError(&github.RateLimitError{Rate: github.Rate{Remaining: 0}}) {

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -248,17 +248,35 @@ func TestManagerPollTimeoutFailsWatch(t *testing.T) {
 
 func TestManagerMaxWatchDurationTransitionsToTimeout(t *testing.T) {
 	db := openTestDB(t)
+	base := time.Now().UTC()
+	nowValues := []time.Time{
+		base,
+		base,
+		base.Add(2 * time.Millisecond),
+	}
+	var nowMu sync.Mutex
+	nowIndex := 0
+	nowFn := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		if nowIndex >= len(nowValues) {
+			return nowValues[len(nowValues)-1]
+		}
+		value := nowValues[nowIndex]
+		nowIndex++
+		return value
+	}
+	fetcher := &fakeFetcher{
+		results: []fetchResult{
+			{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+		},
+	}
 	manager := NewManager(db, Options{
 		PollInterval:     1 * time.Millisecond,
 		MaxWatchDuration: 1 * time.Millisecond,
 		Threshold:        30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
-			return &fakeFetcher{
-				results: []fetchResult{
-					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
-				},
-			}
-		},
+		Now:              nowFn,
+		ClientFactory:    func(_ context.Context, _ string) ReviewDataFetcher { return fetcher },
 	})
 	t.Cleanup(manager.Close)
 
@@ -278,6 +296,15 @@ func TestManagerMaxWatchDurationTransitionsToTimeout(t *testing.T) {
 	})
 	if snapshot.WatchStatus != StatusTimeout {
 		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusTimeout)
+	}
+	if snapshot.PollsDone != 0 {
+		t.Fatalf("PollsDone = %d, want 0 when timeout occurs before polling", snapshot.PollsDone)
+	}
+	if snapshot.LastPolledAt != nil {
+		t.Fatalf("LastPolledAt = %v, want nil when timeout occurs before polling", snapshot.LastPolledAt)
+	}
+	if fetcher.calls != 0 {
+		t.Fatalf("GetReviewData() calls = %d, want 0", fetcher.calls)
 	}
 }
 
@@ -347,6 +374,107 @@ func TestIsRateLimitHTTPError(t *testing.T) {
 			t.Fatal("generic HTTP 403 should not be classified as rate limited")
 		}
 	})
+}
+
+func TestSnapshotFromStateClonesPointerFields(t *testing.T) {
+	reviewStatus := ghclient.StatusCompleted
+	failureReason := FailureReasonGitHubError
+	startedAt := time.Now().UTC()
+	updatedAt := startedAt.Add(time.Minute)
+	completedAt := updatedAt.Add(time.Minute)
+	lastPolledAt := updatedAt
+	lastError := "original error"
+
+	state := &watchState{
+		id:            "cw_test",
+		key:           watchKey{login: "alice", owner: "octo", repo: "demo", pr: 42},
+		status:        StatusFailed,
+		reviewStatus:  &reviewStatus,
+		failureReason: &failureReason,
+		terminal:      true,
+		startedAt:     startedAt,
+		updatedAt:     updatedAt,
+		completedAt:   &completedAt,
+		lastPolledAt:  &lastPolledAt,
+		lastError:     &lastError,
+	}
+
+	snapshot := snapshotFromState(state)
+	if snapshot.ReviewStatus == state.reviewStatus {
+		t.Fatal("ReviewStatus pointer aliases internal state")
+	}
+	if snapshot.FailureReason == state.failureReason {
+		t.Fatal("FailureReason pointer aliases internal state")
+	}
+	if snapshot.CompletedAt == state.completedAt {
+		t.Fatal("CompletedAt pointer aliases internal state")
+	}
+	if snapshot.LastPolledAt == state.lastPolledAt {
+		t.Fatal("LastPolledAt pointer aliases internal state")
+	}
+	if snapshot.LastError == state.lastError {
+		t.Fatal("LastError pointer aliases internal state")
+	}
+
+	*snapshot.ReviewStatus = ghclient.StatusBlocked
+	*snapshot.FailureReason = FailureReasonInternal
+	*snapshot.CompletedAt = snapshot.CompletedAt.Add(time.Hour)
+	*snapshot.LastPolledAt = snapshot.LastPolledAt.Add(time.Hour)
+	*snapshot.LastError = "mutated error"
+
+	if *state.reviewStatus != ghclient.StatusCompleted {
+		t.Fatalf("internal ReviewStatus = %q, want %q", *state.reviewStatus, ghclient.StatusCompleted)
+	}
+	if *state.failureReason != FailureReasonGitHubError {
+		t.Fatalf("internal FailureReason = %q, want %q", *state.failureReason, FailureReasonGitHubError)
+	}
+	if !state.completedAt.Equal(completedAt) {
+		t.Fatalf("internal CompletedAt = %v, want %v", state.completedAt, completedAt)
+	}
+	if !state.lastPolledAt.Equal(lastPolledAt) {
+		t.Fatalf("internal LastPolledAt = %v, want %v", state.lastPolledAt, lastPolledAt)
+	}
+	if *state.lastError != "original error" {
+		t.Fatalf("internal LastError = %q, want %q", *state.lastError, "original error")
+	}
+}
+
+func TestFinishFailureWithPollCountsExactlyOnce(t *testing.T) {
+	manager := &Manager{
+		watchesByID: make(map[string]*watchState),
+		activeByKey: make(map[watchKey]string),
+		latestByKey: make(map[watchKey]string),
+	}
+	key := watchKey{login: "alice", owner: "octo", repo: "demo", pr: 77}
+	now := time.Now().UTC()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	state := &watchState{
+		id:     "cw_test_failure",
+		key:    key,
+		ctx:    ctx,
+		cancel: cancel,
+		status: StatusWatching,
+	}
+	manager.watchesByID[state.id] = state
+	manager.activeByKey[key] = state.id
+	manager.latestByKey[key] = state.id
+
+	manager.finishFailureWithPoll(state.id, now, FailureReasonInternal, "failed to update trigger_log completed_at")
+
+	if state.pollsDone != 1 {
+		t.Fatalf("PollsDone = %d, want 1", state.pollsDone)
+	}
+	if state.lastPolledAt == nil {
+		t.Fatal("LastPolledAt = nil, want poll timestamp")
+	}
+	if state.status != StatusFailed {
+		t.Fatalf("status = %q, want %q", state.status, StatusFailed)
+	}
+	if state.failureReason == nil || *state.failureReason != FailureReasonInternal {
+		t.Fatalf("FailureReason = %v, want %q", state.failureReason, FailureReasonInternal)
+	}
 }
 
 type fetchResult struct {

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -202,6 +202,24 @@ func TestManagerCloseMarksActiveWatchStale(t *testing.T) {
 	}
 }
 
+func TestIsRateLimitHTTPError(t *testing.T) {
+	t.Run("matches typed rate limit errors", func(t *testing.T) {
+		if !IsRateLimitHTTPError(&github.RateLimitError{Rate: github.Rate{Remaining: 0}}) {
+			t.Fatal("RateLimitError should be classified as rate limited")
+		}
+		if !IsRateLimitHTTPError(&github.AbuseRateLimitError{Response: &http.Response{StatusCode: http.StatusForbidden}}) {
+			t.Fatal("AbuseRateLimitError should be classified as rate limited")
+		}
+	})
+
+	t.Run("does not treat generic forbidden as rate limited", func(t *testing.T) {
+		err := &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusForbidden}}
+		if IsRateLimitHTTPError(err) {
+			t.Fatal("generic HTTP 403 should not be classified as rate limited")
+		}
+	})
+}
+
 type fetchResult struct {
 	data *ghclient.ReviewData
 	err  error


### PR DESCRIPTION
## Summary
- add a process-local memory-only watch manager for `copilot-review-mcp`
- add `start_copilot_review_watch` and `get_copilot_review_watch_status` as the minimal async watch surface
- share watch state across stateless requests and cover reuse / terminal-state handling with unit tests

## Why
- `wait_for_copilot_review` currently blocks one MCP tool call for a long time
- issue #68 is the first implementation step for the async watch redesign in #63
- we need an idempotent active watch per authenticated user and PR before persistence and notifications

## Impact
- an LLM can start a watch and come back later for cheap local status reads instead of holding a tool call open
- repeated watch starts for the same authenticated user and PR reuse the active watch
- auth expiry and worker loss now surface as explicit `FAILED/AUTH_EXPIRED` and `STALE` states

## Root Cause
The current implementation only had request-scoped GitHub clients and blocking wait logic, so there was no process-level component that could keep polling after a request returned.

## Validation
- `go test ./...` in `services/copilot-review-mcp`

## Notes
- Closes #68
- Part of #63
- Real end-to-end validation against a live MCP host was not performed in this PR