### PR TITLE
[codex] fix request_copilot_review GraphQL input type

### DIFF
--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -230,25 +230,20 @@ type requestReviewsByLoginMutation struct {
 	} `graphql:"requestReviewsByLogin(input: $input)"`
 }
 
-// requestReviewsByLoginInput is the input type for requestReviewsByLoginMutation.
-// Field names must be PascalCase so shurcooL/githubv4 serialises them correctly.
-type requestReviewsByLoginInput struct {
-	PullRequestID githubv4.ID       `json:"pullRequestId"`
-	BotLogins     []githubv4.String `json:"botLogins"`
-	UserLogins    []githubv4.String `json:"userLogins"`
-	TeamSlugs     []githubv4.String `json:"teamSlugs"`
-	Union         githubv4.Boolean  `json:"union"`
-}
-
 // buildCopilotReviewInput constructs the mutation input for adding Copilot as a reviewer.
 // union: true preserves existing reviewers (additive); false would replace the entire set.
-func buildCopilotReviewInput(prNodeID githubv4.ID) requestReviewsByLoginInput {
-	return requestReviewsByLoginInput{
+func buildCopilotReviewInput(prNodeID githubv4.ID) githubv4.RequestReviewsByLoginInput {
+	botLogins := []githubv4.String{githubv4.String(copilotBotLogin)}
+	userLogins := []githubv4.String{}
+	teamSlugs := []githubv4.String{}
+	union := githubv4.Boolean(true)
+
+	return githubv4.RequestReviewsByLoginInput{
 		PullRequestID: prNodeID,
-		BotLogins:     []githubv4.String{githubv4.String(copilotBotLogin)},
-		UserLogins:    []githubv4.String{},
-		TeamSlugs:     []githubv4.String{},
-		Union:         githubv4.Boolean(true),
+		BotLogins:     &botLogins,
+		UserLogins:    &userLogins,
+		TeamSlugs:     &teamSlugs,
+		Union:         &union,
 	}
 }
 

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -110,15 +110,15 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 		normalizedQuery := strings.Join(strings.Fields(req.Query), "")
 
 		switch {
-		case strings.Contains(normalizedQuery, "pullRequest(number:$pr){id}"):
+		case strings.Contains(normalizedQuery, "pullRequest(number:$pr)") && strings.Contains(normalizedQuery, "id"):
 			sawNodeIDQuery.Store(true)
 			fmt.Fprintf(w, `{"data":{"repository":{"pullRequest":{"id":%q}}}}`, prNodeID)
 		case strings.Contains(normalizedQuery, "requestReviewsByLogin(input:$input)"):
 			sawRequestMutation.Store(true)
-			if !strings.Contains(normalizedQuery, "$input:RequestReviewsByLoginInput!") {
+			if !strings.Contains(normalizedQuery, "RequestReviewsByLoginInput") {
 				t.Errorf("mutation query = %q, want RequestReviewsByLoginInput", req.Query)
 			}
-			if strings.Contains(normalizedQuery, "$input:requestReviewsByLoginInput!") {
+			if strings.Contains(normalizedQuery, "requestReviewsByLoginInput") {
 				t.Errorf("mutation query = %q, unexpected lower-camel input type", req.Query)
 			}
 

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -85,10 +85,9 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 		prNodeID = "PR_kwDOABCDEF12345"
 	)
 
-	requestCount := 0
+	sawNodeIDQuery := false
+	sawRequestMutation := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("ReadAll() error = %v", err)
@@ -107,15 +106,18 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
+		normalizedQuery := strings.Join(strings.Fields(req.Query), "")
 
-		switch requestCount {
-		case 1:
+		switch {
+		case strings.Contains(normalizedQuery, "pullRequest(number:$pr){id}"):
+			sawNodeIDQuery = true
 			fmt.Fprintf(w, `{"data":{"repository":{"pullRequest":{"id":%q}}}}`, prNodeID)
-		case 2:
-			if !strings.Contains(req.Query, "$input:RequestReviewsByLoginInput!") {
+		case strings.Contains(normalizedQuery, "requestReviewsByLogin(input:$input)"):
+			sawRequestMutation = true
+			if !strings.Contains(normalizedQuery, "$input:RequestReviewsByLoginInput!") {
 				t.Errorf("mutation query = %q, want RequestReviewsByLoginInput", req.Query)
 			}
-			if strings.Contains(req.Query, "$input:requestReviewsByLoginInput!") {
+			if strings.Contains(normalizedQuery, "$input:requestReviewsByLoginInput!") {
 				t.Errorf("mutation query = %q, unexpected lower-camel input type", req.Query)
 			}
 
@@ -149,8 +151,7 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 
 			fmt.Fprint(w, `{"data":{"requestReviewsByLogin":{"clientMutationId":""}}}`)
 		default:
-			t.Errorf("unexpected GraphQL request count = %d", requestCount)
-			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			fmt.Fprint(w, `{"data":{}}`)
 		}
 	}))
 	defer srv.Close()
@@ -162,8 +163,11 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 	if err := c.RequestCopilotReview(context.Background(), owner, repo, pr); err != nil {
 		t.Fatalf("RequestCopilotReview() error = %v", err)
 	}
-	if requestCount != 2 {
-		t.Fatalf("GraphQL request count = %d, want 2", requestCount)
+	if !sawNodeIDQuery {
+		t.Fatal("did not observe PR node ID query")
+	}
+	if !sawRequestMutation {
+		t.Fatal("did not observe requestReviewsByLogin mutation")
 	}
 }
 

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -85,8 +86,8 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 		prNodeID = "PR_kwDOABCDEF12345"
 	)
 
-	sawNodeIDQuery := false
-	sawRequestMutation := false
+	var sawNodeIDQuery atomic.Bool
+	var sawRequestMutation atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -110,10 +111,10 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 
 		switch {
 		case strings.Contains(normalizedQuery, "pullRequest(number:$pr){id}"):
-			sawNodeIDQuery = true
+			sawNodeIDQuery.Store(true)
 			fmt.Fprintf(w, `{"data":{"repository":{"pullRequest":{"id":%q}}}}`, prNodeID)
 		case strings.Contains(normalizedQuery, "requestReviewsByLogin(input:$input)"):
-			sawRequestMutation = true
+			sawRequestMutation.Store(true)
 			if !strings.Contains(normalizedQuery, "$input:RequestReviewsByLoginInput!") {
 				t.Errorf("mutation query = %q, want RequestReviewsByLoginInput", req.Query)
 			}
@@ -163,10 +164,10 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 	if err := c.RequestCopilotReview(context.Background(), owner, repo, pr); err != nil {
 		t.Fatalf("RequestCopilotReview() error = %v", err)
 	}
-	if !sawNodeIDQuery {
+	if !sawNodeIDQuery.Load() {
 		t.Fatal("did not observe PR node ID query")
 	}
-	if !sawRequestMutation {
+	if !sawRequestMutation.Load() {
 		t.Fatal("did not observe requestReviewsByLogin mutation")
 	}
 }

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -2,10 +2,13 @@ package ghclient
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,29 +48,122 @@ func TestBuildCopilotReviewInput(t *testing.T) {
 	input := buildCopilotReviewInput(testNodeID)
 
 	// Invariant 1: union must be true (additive, not replacing existing reviewers).
-	if !bool(input.Union) {
+	if input.Union == nil || !bool(*input.Union) {
 		t.Error("Union must be true to preserve existing human reviewers; false would remove them")
 	}
 
 	// Invariant 2: exactly one bot login with the correct value.
-	if len(input.BotLogins) != 1 {
-		t.Fatalf("BotLogins length = %d, want 1", len(input.BotLogins))
+	if input.BotLogins == nil {
+		t.Fatal("BotLogins must be set")
 	}
-	if got := string(input.BotLogins[0]); got != copilotBotLogin {
+	if len(*input.BotLogins) != 1 {
+		t.Fatalf("BotLogins length = %d, want 1", len(*input.BotLogins))
+	}
+	if got := string((*input.BotLogins)[0]); got != copilotBotLogin {
 		t.Errorf("BotLogins[0] = %q, want %q", got, copilotBotLogin)
 	}
 
 	// Sanity: userLogins and teamSlugs must be empty — we're only adding Copilot.
-	if len(input.UserLogins) != 0 {
+	if input.UserLogins == nil || len(*input.UserLogins) != 0 {
 		t.Errorf("UserLogins must be empty, got %v", input.UserLogins)
 	}
-	if len(input.TeamSlugs) != 0 {
+	if input.TeamSlugs == nil || len(*input.TeamSlugs) != 0 {
 		t.Errorf("TeamSlugs must be empty, got %v", input.TeamSlugs)
 	}
 
 	// Sanity: PR node ID is passed through unchanged.
 	if input.PullRequestID != testNodeID {
 		t.Errorf("PullRequestID = %v, want %v", input.PullRequestID, testNodeID)
+	}
+}
+
+func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
+	const (
+		owner    = "owner"
+		repo     = "repo"
+		pr       = 123
+		prNodeID = "PR_kwDOABCDEF12345"
+	)
+
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("ReadAll() error = %v", err)
+			http.Error(w, "failed to read body", http.StatusInternalServerError)
+			return
+		}
+
+		var req struct {
+			Query     string                     `json:"query"`
+			Variables map[string]json.RawMessage `json:"variables"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Errorf("json.Unmarshal() error = %v", err)
+			http.Error(w, "invalid JSON", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch requestCount {
+		case 1:
+			fmt.Fprintf(w, `{"data":{"repository":{"pullRequest":{"id":%q}}}}`, prNodeID)
+		case 2:
+			if !strings.Contains(req.Query, "$input:RequestReviewsByLoginInput!") {
+				t.Errorf("mutation query = %q, want RequestReviewsByLoginInput", req.Query)
+			}
+			if strings.Contains(req.Query, "$input:requestReviewsByLoginInput!") {
+				t.Errorf("mutation query = %q, unexpected lower-camel input type", req.Query)
+			}
+
+			var input struct {
+				PullRequestID string   `json:"pullRequestId"`
+				BotLogins     []string `json:"botLogins"`
+				UserLogins    []string `json:"userLogins"`
+				TeamSlugs     []string `json:"teamSlugs"`
+				Union         bool     `json:"union"`
+			}
+			if err := json.Unmarshal(req.Variables["input"], &input); err != nil {
+				t.Errorf("json.Unmarshal(input) error = %v", err)
+				http.Error(w, "invalid input payload", http.StatusBadRequest)
+				return
+			}
+			if input.PullRequestID != prNodeID {
+				t.Errorf("input.pullRequestId = %q, want %q", input.PullRequestID, prNodeID)
+			}
+			if len(input.BotLogins) != 1 || input.BotLogins[0] != copilotBotLogin {
+				t.Errorf("input.botLogins = %v, want [%q]", input.BotLogins, copilotBotLogin)
+			}
+			if len(input.UserLogins) != 0 {
+				t.Errorf("input.userLogins = %v, want empty", input.UserLogins)
+			}
+			if len(input.TeamSlugs) != 0 {
+				t.Errorf("input.teamSlugs = %v, want empty", input.TeamSlugs)
+			}
+			if !input.Union {
+				t.Error("input.union = false, want true")
+			}
+
+			fmt.Fprint(w, `{"data":{"requestReviewsByLogin":{"clientMutationId":""}}}`)
+		default:
+			t.Errorf("unexpected GraphQL request count = %d", requestCount)
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		v4: githubv4.NewEnterpriseClient(srv.URL, srv.Client()),
+	}
+
+	if err := c.RequestCopilotReview(context.Background(), owner, repo, pr); err != nil {
+		t.Fatalf("RequestCopilotReview() error = %v", err)
+	}
+	if requestCount != 2 {
+		t.Fatalf("GraphQL request count = %d, want 2", requestCount)
 	}
 }
 
@@ -78,7 +174,7 @@ func TestDeriveStatus(t *testing.T) {
 	c := &Client{threshold: 30 * time.Second}
 
 	now := time.Now()
-	recentRequest := now.Add(-time.Second)   // 1s ago — safely within 30s threshold
+	recentRequest := now.Add(-time.Second)      // 1s ago — safely within 30s threshold
 	longAgoRequest := now.Add(-2 * time.Minute) // 2min ago — safely past threshold
 	threeMinAgo := now.Add(-3 * time.Minute)
 	oneMinAgo := now.Add(-1 * time.Minute)


### PR DESCRIPTION
## Summary
- switch `request_copilot_review` to use `githubv4.RequestReviewsByLoginInput`
- stop relying on a local lower-camel input struct name that mismatches the live GitHub schema
- add a regression test that inspects the outgoing GraphQL mutation and variables

## Root Cause
`request_copilot_review` was constructing the GraphQL mutation input from a local type named `requestReviewsByLoginInput`.
`githubv4` derives the GraphQL input object name from the Go type name, so the client was sending `requestReviewsByLoginInput` instead of the live schema type `RequestReviewsByLoginInput`.
That causes the live error reported in #72:

```text
requestReviewsByLogin mutation failed: requestReviewsByLoginInput isn't a defined input type (on $input)
```

## Impact
- `request_copilot_review` can request Copilot review through the GraphQL mutation path again
- the input type name now matches the live GitHub schema
- the regression test locks the mutation shape so the same bug is harder to reintroduce

## Validation
- `go test ./... -count=1` in `services/copilot-review-mcp`
- live GraphQL introspection confirms `RequestReviewsByLoginInput` exists
- live GraphQL mutation with `RequestReviewsByLoginInput` is accepted by schema and fails only on the fake node id
- live GraphQL mutation with `requestReviewsByLoginInput` reproduces the current schema error from #72

Closes #72
