### PR TITLE
[codex] Persist review watch state in SQLite

### DIFF
--- a/services/copilot-review-mcp/internal/store/db.go
+++ b/services/copilot-review-mcp/internal/store/db.go
@@ -193,17 +193,12 @@ func (d *DB) UpsertReviewWatch(entry ReviewWatchEntry) error {
 		    started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
-		    github_login        = excluded.github_login,
-		    owner               = excluded.owner,
-		    repo                = excluded.repo,
-		    pr                  = excluded.pr,
 		    trigger_log_id      = excluded.trigger_log_id,
 		    resource_uri        = excluded.resource_uri,
 		    watch_status        = excluded.watch_status,
 		    review_status       = excluded.review_status,
 		    failure_reason      = excluded.failure_reason,
 		    is_active           = excluded.is_active,
-		    started_at          = excluded.started_at,
 		    updated_at          = excluded.updated_at,
 		    completed_at        = excluded.completed_at,
 		    stale_at            = excluded.stale_at,

--- a/services/copilot-review-mcp/internal/store/db.go
+++ b/services/copilot-review-mcp/internal/store/db.go
@@ -40,11 +40,15 @@ CREATE TABLE IF NOT EXISTS review_watch (
     last_error          TEXT,
     rate_limit_reset_at INTEGER
 );
-CREATE INDEX IF NOT EXISTS idx_review_watch_lookup
-    ON review_watch(github_login, owner, repo, pr, updated_at DESC, id DESC);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_review_watch_active_per_pr
     ON review_watch(github_login, owner, repo, pr)
     WHERE is_active = 1;
+`
+
+const reviewWatchLookupIndexSQL = `
+DROP INDEX IF EXISTS idx_review_watch_lookup;
+CREATE INDEX idx_review_watch_lookup
+    ON review_watch(github_login, owner, repo, pr, updated_at DESC, started_at DESC);
 `
 
 const staleOnOpenMessage = "watch became stale because the copilot-review-mcp process restarted"
@@ -69,6 +73,10 @@ func Open(path string) (*DB, error) {
 		return nil, err
 	}
 	if _, err := db.Exec(schema); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if _, err := db.Exec(reviewWatchLookupIndexSQL); err != nil {
 		db.Close()
 		return nil, err
 	}

--- a/services/copilot-review-mcp/internal/store/db.go
+++ b/services/copilot-review-mcp/internal/store/db.go
@@ -1,5 +1,5 @@
-// Package store manages the SQLite trigger_log database used to track
-// when Copilot reviews were requested and completed.
+// Package store manages the SQLite database used to track trigger_log
+// and persisted review_watch state.
 package store
 
 import (
@@ -20,7 +20,34 @@ CREATE TABLE IF NOT EXISTS trigger_log (
     completed_at INTEGER                                          -- epoch seconds (UTC), NULL while pending
 );
 CREATE INDEX IF NOT EXISTS idx_trigger_log_pr ON trigger_log(owner, repo, pr);
+
+CREATE TABLE IF NOT EXISTS review_watch (
+    id                  TEXT PRIMARY KEY,
+    github_login        TEXT    NOT NULL,
+    owner               TEXT    NOT NULL,
+    repo                TEXT    NOT NULL,
+    pr                  INTEGER NOT NULL,
+    trigger_log_id      INTEGER,
+    resource_uri        TEXT,
+    watch_status        TEXT    NOT NULL,
+    review_status       TEXT,
+    failure_reason      TEXT,
+    is_active           INTEGER NOT NULL DEFAULT 1,
+    started_at          INTEGER NOT NULL,
+    updated_at          INTEGER NOT NULL,
+    completed_at        INTEGER,
+    stale_at            INTEGER,
+    last_error          TEXT,
+    rate_limit_reset_at INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_review_watch_lookup
+    ON review_watch(github_login, owner, repo, pr, updated_at DESC, id DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_review_watch_active_per_pr
+    ON review_watch(github_login, owner, repo, pr)
+    WHERE is_active = 1;
 `
+
+const staleOnOpenMessage = "watch became stale because the copilot-review-mcp process restarted"
 
 // DB wraps a SQLite database for trigger_log operations.
 type DB struct {
@@ -45,7 +72,12 @@ func Open(path string) (*DB, error) {
 		db.Close()
 		return nil, err
 	}
-	return &DB{db: db}, nil
+	d := &DB{db: db}
+	if _, err := d.MarkActiveReviewWatchesStale(staleOnOpenMessage); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return d, nil
 }
 
 // Close releases the database connection.
@@ -57,6 +89,27 @@ type TriggerEntry struct {
 	Trigger     string    // "MANUAL" or "AUTO"
 	RequestedAt time.Time // when the review was requested
 	CompletedAt *time.Time
+}
+
+// ReviewWatchEntry is a persisted watch snapshot in review_watch.
+type ReviewWatchEntry struct {
+	ID               string
+	GitHubLogin      string
+	Owner            string
+	Repo             string
+	PR               int
+	TriggerLogID     *int64
+	ResourceURI      *string
+	WatchStatus      string
+	ReviewStatus     *string
+	FailureReason    *string
+	IsActive         bool
+	StartedAt        time.Time
+	UpdatedAt        time.Time
+	CompletedAt      *time.Time
+	StaleAt          *time.Time
+	LastError        *string
+	RateLimitResetAt *time.Time
 }
 
 // Insert adds a new trigger_log entry and returns the assigned ID.
@@ -121,4 +174,217 @@ func (d *DB) HasPending(owner, repo string, pr int) (bool, error) {
 		owner, repo, pr,
 	).Scan(&count)
 	return count > 0, err
+}
+
+// UpsertReviewWatch inserts or updates a persisted review_watch snapshot by watch ID.
+func (d *DB) UpsertReviewWatch(entry ReviewWatchEntry) error {
+	_, err := d.db.Exec(
+		`INSERT INTO review_watch (
+		    id, github_login, owner, repo, pr, trigger_log_id, resource_uri,
+		    watch_status, review_status, failure_reason, is_active,
+		    started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+		    github_login        = excluded.github_login,
+		    owner               = excluded.owner,
+		    repo                = excluded.repo,
+		    pr                  = excluded.pr,
+		    trigger_log_id      = excluded.trigger_log_id,
+		    resource_uri        = excluded.resource_uri,
+		    watch_status        = excluded.watch_status,
+		    review_status       = excluded.review_status,
+		    failure_reason      = excluded.failure_reason,
+		    is_active           = excluded.is_active,
+		    started_at          = excluded.started_at,
+		    updated_at          = excluded.updated_at,
+		    completed_at        = excluded.completed_at,
+		    stale_at            = excluded.stale_at,
+		    last_error          = excluded.last_error,
+		    rate_limit_reset_at = excluded.rate_limit_reset_at`,
+		entry.ID,
+		entry.GitHubLogin,
+		entry.Owner,
+		entry.Repo,
+		entry.PR,
+		nullInt64(entry.TriggerLogID),
+		nullString(entry.ResourceURI),
+		entry.WatchStatus,
+		nullString(entry.ReviewStatus),
+		nullString(entry.FailureReason),
+		boolToInt(entry.IsActive),
+		entry.StartedAt.UTC().Unix(),
+		entry.UpdatedAt.UTC().Unix(),
+		nullTime(entry.CompletedAt),
+		nullTime(entry.StaleAt),
+		nullString(entry.LastError),
+		nullTime(entry.RateLimitResetAt),
+	)
+	return err
+}
+
+// GetReviewWatchByID returns a persisted review_watch row by watch ID.
+func (d *DB) GetReviewWatchByID(id string) (*ReviewWatchEntry, error) {
+	row := d.db.QueryRow(
+		`SELECT id, github_login, owner, repo, pr, trigger_log_id, resource_uri,
+		        watch_status, review_status, failure_reason, is_active,
+		        started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at
+		   FROM review_watch
+		  WHERE id = ?`,
+		id,
+	)
+	return scanReviewWatch(row)
+}
+
+// GetLatestReviewWatch returns the most recently updated watch for the user/PR key.
+func (d *DB) GetLatestReviewWatch(login, owner, repo string, pr int) (*ReviewWatchEntry, error) {
+	row := d.db.QueryRow(
+		`SELECT id, github_login, owner, repo, pr, trigger_log_id, resource_uri,
+		        watch_status, review_status, failure_reason, is_active,
+		        started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at
+		   FROM review_watch
+		  WHERE github_login = ? AND owner = ? AND repo = ? AND pr = ?
+		  ORDER BY updated_at DESC, started_at DESC, id DESC
+		  LIMIT 1`,
+		login, owner, repo, pr,
+	)
+	return scanReviewWatch(row)
+}
+
+// MarkActiveReviewWatchesStale deactivates any persisted active watches.
+// Used on startup because worker state is memory-only and cannot survive process restart.
+func (d *DB) MarkActiveReviewWatchesStale(lastError string) (int64, error) {
+	res, err := d.db.Exec(
+		`UPDATE review_watch
+		    SET watch_status = 'STALE',
+		        failure_reason = NULL,
+		        is_active = 0,
+		        updated_at = strftime('%s','now'),
+		        completed_at = COALESCE(completed_at, strftime('%s','now')),
+		        stale_at = COALESCE(stale_at, strftime('%s','now')),
+		        last_error = CASE
+		                       WHEN ? = '' THEN last_error
+		                       WHEN last_error IS NULL OR last_error = '' THEN ?
+		                       ELSE last_error
+		                     END
+		  WHERE is_active = 1`,
+		lastError,
+		lastError,
+	)
+	if err != nil {
+		return 0, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return rows, nil
+}
+
+func scanReviewWatch(row scanner) (*ReviewWatchEntry, error) {
+	var entry ReviewWatchEntry
+	var (
+		triggerLogID     sql.NullInt64
+		resourceURI      sql.NullString
+		reviewStatus     sql.NullString
+		failureReason    sql.NullString
+		completedAt      sql.NullInt64
+		staleAt          sql.NullInt64
+		lastError        sql.NullString
+		rateLimitResetAt sql.NullInt64
+		isActive         int
+		startedAtUnix    int64
+		updatedAtUnix    int64
+	)
+	if err := row.Scan(
+		&entry.ID,
+		&entry.GitHubLogin,
+		&entry.Owner,
+		&entry.Repo,
+		&entry.PR,
+		&triggerLogID,
+		&resourceURI,
+		&entry.WatchStatus,
+		&reviewStatus,
+		&failureReason,
+		&isActive,
+		&startedAtUnix,
+		&updatedAtUnix,
+		&completedAt,
+		&staleAt,
+		&lastError,
+		&rateLimitResetAt,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	entry.IsActive = isActive != 0
+	entry.StartedAt = time.Unix(startedAtUnix, 0).UTC()
+	entry.UpdatedAt = time.Unix(updatedAtUnix, 0).UTC()
+	entry.TriggerLogID = fromNullInt64(triggerLogID)
+	entry.ResourceURI = fromNullString(resourceURI)
+	entry.ReviewStatus = fromNullString(reviewStatus)
+	entry.FailureReason = fromNullString(failureReason)
+	entry.CompletedAt = fromNullUnix(completedAt)
+	entry.StaleAt = fromNullUnix(staleAt)
+	entry.LastError = fromNullString(lastError)
+	entry.RateLimitResetAt = fromNullUnix(rateLimitResetAt)
+	return &entry, nil
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func boolToInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+func nullInt64(v *int64) sql.NullInt64 {
+	if v == nil {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: *v, Valid: true}
+}
+
+func nullString(v *string) sql.NullString {
+	if v == nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: *v, Valid: true}
+}
+
+func nullTime(v *time.Time) sql.NullInt64 {
+	if v == nil {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: v.UTC().Unix(), Valid: true}
+}
+
+func fromNullInt64(v sql.NullInt64) *int64 {
+	if !v.Valid {
+		return nil
+	}
+	value := v.Int64
+	return &value
+}
+
+func fromNullString(v sql.NullString) *string {
+	if !v.Valid {
+		return nil
+	}
+	value := v.String
+	return &value
+}
+
+func fromNullUnix(v sql.NullInt64) *time.Time {
+	if !v.Valid {
+		return nil
+	}
+	t := time.Unix(v.Int64, 0).UTC()
+	return &t
 }

--- a/services/copilot-review-mcp/internal/store/db.go
+++ b/services/copilot-review-mcp/internal/store/db.go
@@ -243,7 +243,7 @@ func (d *DB) GetLatestReviewWatch(login, owner, repo string, pr int) (*ReviewWat
 		        started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at
 		   FROM review_watch
 		  WHERE github_login = ? AND owner = ? AND repo = ? AND pr = ?
-		  ORDER BY updated_at DESC, started_at DESC, id DESC
+		  ORDER BY updated_at DESC, started_at DESC, rowid DESC
 		  LIMIT 1`,
 		login, owner, repo, pr,
 	)

--- a/services/copilot-review-mcp/internal/store/db_test.go
+++ b/services/copilot-review-mcp/internal/store/db_test.go
@@ -192,6 +192,26 @@ func TestOpenMarksActiveReviewWatchesStale(t *testing.T) {
 	}
 }
 
+func TestOpenRebuildsReviewWatchLookupIndex(t *testing.T) {
+	db := openTestDB(t, filepath.Join(t.TempDir(), "review-watch-index.db"))
+
+	var sqlText string
+	err := db.db.QueryRow(
+		`SELECT sql
+		   FROM sqlite_master
+		  WHERE type = 'index' AND name = 'idx_review_watch_lookup'`,
+	).Scan(&sqlText)
+	if err != nil {
+		t.Fatalf("index lookup error = %v", err)
+	}
+	if !strings.Contains(sqlText, "updated_at DESC, started_at DESC") {
+		t.Fatalf("index SQL = %q, want updated_at/started_at ordering", sqlText)
+	}
+	if strings.Contains(sqlText, "id DESC") {
+		t.Fatalf("index SQL = %q, want id ordering removed", sqlText)
+	}
+}
+
 func openTestDB(t *testing.T, path string) *DB {
 	t.Helper()
 

--- a/services/copilot-review-mcp/internal/store/db_test.go
+++ b/services/copilot-review-mcp/internal/store/db_test.go
@@ -1,0 +1,168 @@
+package store
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReviewWatchActiveUniqueConstraint(t *testing.T) {
+	db := openTestDB(t, filepath.Join(t.TempDir(), "review-watch-unique.db"))
+
+	startedAt := time.Now().UTC().Truncate(time.Second)
+	first := ReviewWatchEntry{
+		ID:          "cw_first",
+		GitHubLogin: "alice",
+		Owner:       "octo",
+		Repo:        "demo",
+		PR:          42,
+		WatchStatus: "WATCHING",
+		IsActive:    true,
+		StartedAt:   startedAt,
+		UpdatedAt:   startedAt,
+	}
+	if err := db.UpsertReviewWatch(first); err != nil {
+		t.Fatalf("UpsertReviewWatch(first) error = %v", err)
+	}
+
+	second := first
+	second.ID = "cw_second"
+	second.UpdatedAt = startedAt.Add(time.Minute)
+	if err := db.UpsertReviewWatch(second); err == nil {
+		t.Fatal("UpsertReviewWatch(second) = nil error, want unique constraint failure")
+	}
+
+	first.IsActive = false
+	first.WatchStatus = "COMPLETED"
+	completedAt := startedAt.Add(2 * time.Minute)
+	first.CompletedAt = &completedAt
+	first.UpdatedAt = completedAt
+	if err := db.UpsertReviewWatch(first); err != nil {
+		t.Fatalf("UpsertReviewWatch(first inactive) error = %v", err)
+	}
+	if err := db.UpsertReviewWatch(second); err != nil {
+		t.Fatalf("UpsertReviewWatch(second after deactivation) error = %v", err)
+	}
+}
+
+func TestGetLatestReviewWatchReturnsNewestSnapshot(t *testing.T) {
+	db := openTestDB(t, filepath.Join(t.TempDir(), "review-watch-latest.db"))
+
+	base := time.Now().UTC().Truncate(time.Second)
+	first := ReviewWatchEntry{
+		ID:          "cw_old",
+		GitHubLogin: "alice",
+		Owner:       "octo",
+		Repo:        "demo",
+		PR:          7,
+		WatchStatus: "COMPLETED",
+		IsActive:    false,
+		StartedAt:   base,
+		UpdatedAt:   base,
+	}
+	if err := db.UpsertReviewWatch(first); err != nil {
+		t.Fatalf("UpsertReviewWatch(first) error = %v", err)
+	}
+
+	lastError := "auth expired"
+	reviewStatus := "PENDING"
+	failureReason := "AUTH_EXPIRED"
+	second := ReviewWatchEntry{
+		ID:            "cw_new",
+		GitHubLogin:   "alice",
+		Owner:         "octo",
+		Repo:          "demo",
+		PR:            7,
+		WatchStatus:   "FAILED",
+		ReviewStatus:  &reviewStatus,
+		FailureReason: &failureReason,
+		IsActive:      false,
+		StartedAt:     base.Add(time.Minute),
+		UpdatedAt:     base.Add(2 * time.Minute),
+		LastError:     &lastError,
+	}
+	if err := db.UpsertReviewWatch(second); err != nil {
+		t.Fatalf("UpsertReviewWatch(second) error = %v", err)
+	}
+
+	got, err := db.GetLatestReviewWatch("alice", "octo", "demo", 7)
+	if err != nil {
+		t.Fatalf("GetLatestReviewWatch() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetLatestReviewWatch() = nil, want entry")
+	}
+	if got.ID != second.ID {
+		t.Fatalf("GetLatestReviewWatch().ID = %q, want %q", got.ID, second.ID)
+	}
+	if got.LastError == nil || *got.LastError != lastError {
+		t.Fatalf("GetLatestReviewWatch().LastError = %v, want %q", got.LastError, lastError)
+	}
+}
+
+func TestOpenMarksActiveReviewWatchesStale(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "review-watch-open.db")
+	db := openTestDB(t, path)
+
+	startedAt := time.Now().UTC().Truncate(time.Second)
+	entry := ReviewWatchEntry{
+		ID:          "cw_active",
+		GitHubLogin: "alice",
+		Owner:       "octo",
+		Repo:        "demo",
+		PR:          99,
+		WatchStatus: "WATCHING",
+		IsActive:    true,
+		StartedAt:   startedAt,
+		UpdatedAt:   startedAt,
+	}
+	if err := db.UpsertReviewWatch(entry); err != nil {
+		t.Fatalf("UpsertReviewWatch() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("store.Open(reopen) error = %v", err)
+	}
+	defer reopened.Close()
+
+	got, err := reopened.GetReviewWatchByID(entry.ID)
+	if err != nil {
+		t.Fatalf("GetReviewWatchByID() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetReviewWatchByID() = nil, want entry")
+	}
+	if got.WatchStatus != "STALE" {
+		t.Fatalf("WatchStatus = %q, want %q", got.WatchStatus, "STALE")
+	}
+	if got.IsActive {
+		t.Fatal("IsActive = true, want false")
+	}
+	if got.StaleAt == nil {
+		t.Fatal("StaleAt = nil, want timestamp")
+	}
+	if got.CompletedAt == nil {
+		t.Fatal("CompletedAt = nil, want timestamp")
+	}
+	if got.LastError == nil || !strings.Contains(*got.LastError, staleOnOpenMessage) {
+		t.Fatalf("LastError = %v, want message containing %q", got.LastError, staleOnOpenMessage)
+	}
+}
+
+func openTestDB(t *testing.T, path string) *DB {
+	t.Helper()
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return db
+}

--- a/services/copilot-review-mcp/internal/store/db_test.go
+++ b/services/copilot-review-mcp/internal/store/db_test.go
@@ -101,6 +101,44 @@ func TestGetLatestReviewWatchReturnsNewestSnapshot(t *testing.T) {
 	}
 }
 
+func TestGetLatestReviewWatchIgnoresLexicographicIDTies(t *testing.T) {
+	db := openTestDB(t, filepath.Join(t.TempDir(), "review-watch-latest-tie.db"))
+
+	base := time.Now().UTC().Truncate(time.Second)
+	first := ReviewWatchEntry{
+		ID:          "cw_100_2",
+		GitHubLogin: "alice",
+		Owner:       "octo",
+		Repo:        "demo",
+		PR:          8,
+		WatchStatus: "COMPLETED",
+		IsActive:    false,
+		StartedAt:   base,
+		UpdatedAt:   base,
+	}
+	if err := db.UpsertReviewWatch(first); err != nil {
+		t.Fatalf("UpsertReviewWatch(first) error = %v", err)
+	}
+
+	second := first
+	second.ID = "cw_100_10"
+	second.LastError = strPtr("newer insert")
+	if err := db.UpsertReviewWatch(second); err != nil {
+		t.Fatalf("UpsertReviewWatch(second) error = %v", err)
+	}
+
+	got, err := db.GetLatestReviewWatch("alice", "octo", "demo", 8)
+	if err != nil {
+		t.Fatalf("GetLatestReviewWatch() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetLatestReviewWatch() = nil, want entry")
+	}
+	if got.ID != second.ID {
+		t.Fatalf("GetLatestReviewWatch().ID = %q, want %q", got.ID, second.ID)
+	}
+}
+
 func TestOpenMarksActiveReviewWatchesStale(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "review-watch-open.db")
 	db := openTestDB(t, path)
@@ -166,3 +204,5 @@ func openTestDB(t *testing.T, path string) *DB {
 	})
 	return db
 }
+
+func strPtr(s string) *string { return &s }

--- a/services/copilot-review-mcp/internal/store/db_test.go
+++ b/services/copilot-review-mcp/internal/store/db_test.go
@@ -46,6 +46,81 @@ func TestReviewWatchActiveUniqueConstraint(t *testing.T) {
 	}
 }
 
+func TestUpsertReviewWatchKeepsImmutableIdentityFields(t *testing.T) {
+	db := openTestDB(t, filepath.Join(t.TempDir(), "review-watch-upsert-identity.db"))
+
+	startedAt := time.Now().UTC().Truncate(time.Second)
+	updatedAt := startedAt.Add(time.Minute)
+	first := ReviewWatchEntry{
+		ID:          "cw_identity",
+		GitHubLogin: "alice",
+		Owner:       "octo",
+		Repo:        "demo",
+		PR:          42,
+		WatchStatus: "WATCHING",
+		IsActive:    true,
+		StartedAt:   startedAt,
+		UpdatedAt:   startedAt,
+	}
+	if err := db.UpsertReviewWatch(first); err != nil {
+		t.Fatalf("UpsertReviewWatch(first) error = %v", err)
+	}
+
+	lastError := "persisted update"
+	reviewStatus := "COMPLETED"
+	updated := ReviewWatchEntry{
+		ID:           first.ID,
+		GitHubLogin:  "bob",
+		Owner:        "other-owner",
+		Repo:         "other-repo",
+		PR:           99,
+		WatchStatus:  "COMPLETED",
+		ReviewStatus: &reviewStatus,
+		IsActive:     false,
+		StartedAt:    startedAt.Add(24 * time.Hour),
+		UpdatedAt:    updatedAt,
+		LastError:    &lastError,
+	}
+	if err := db.UpsertReviewWatch(updated); err != nil {
+		t.Fatalf("UpsertReviewWatch(updated) error = %v", err)
+	}
+
+	got, err := db.GetReviewWatchByID(first.ID)
+	if err != nil {
+		t.Fatalf("GetReviewWatchByID() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetReviewWatchByID() = nil, want row")
+	}
+	if got.GitHubLogin != first.GitHubLogin {
+		t.Fatalf("GitHubLogin = %q, want %q", got.GitHubLogin, first.GitHubLogin)
+	}
+	if got.Owner != first.Owner {
+		t.Fatalf("Owner = %q, want %q", got.Owner, first.Owner)
+	}
+	if got.Repo != first.Repo {
+		t.Fatalf("Repo = %q, want %q", got.Repo, first.Repo)
+	}
+	if got.PR != first.PR {
+		t.Fatalf("PR = %d, want %d", got.PR, first.PR)
+	}
+	if !got.StartedAt.Equal(first.StartedAt) {
+		t.Fatalf("StartedAt = %v, want %v", got.StartedAt, first.StartedAt)
+	}
+	if got.WatchStatus != updated.WatchStatus {
+		t.Fatalf("WatchStatus = %q, want %q", got.WatchStatus, updated.WatchStatus)
+	}
+	if got.UpdatedAt != updatedAt {
+		t.Fatalf("UpdatedAt = %v, want %v", got.UpdatedAt, updatedAt)
+	}
+	if got.LastError == nil || *got.LastError != lastError {
+		t.Fatalf("LastError = %v, want %q", got.LastError, lastError)
+	}
+	if got.IsActive {
+		t.Fatal("IsActive = true, want false")
+	}
+}
+
 func TestGetLatestReviewWatchReturnsNewestSnapshot(t *testing.T) {
 	db := openTestDB(t, filepath.Join(t.TempDir(), "review-watch-latest.db"))
 

--- a/services/copilot-review-mcp/internal/tools/watch.go
+++ b/services/copilot-review-mcp/internal/tools/watch.go
@@ -64,12 +64,12 @@ type GetReviewWatchStatusOutput struct {
 
 var startWatchTool = &mcp.Tool{
 	Name:        "start_copilot_review_watch",
-	Description: "Copilot review の background watch を開始し、即時 return する。同一ユーザー・同一 PR の active watch があればそれを再利用する。watch state は memory-only で、サーバー再起動後は維持されない。",
+	Description: "Copilot review の background watch を開始し、即時 return する。同一ユーザー・同一 PR の active watch があればそれを再利用する。watch state は SQLite に保存されるが、worker 自体は memory-only のためサーバー再起動後の active watch は STALE として扱われる。",
 }
 
 var getWatchStatusTool = &mcp.Tool{
 	Name:        "get_copilot_review_watch_status",
-	Description: "background watch の現在状態を memory-only state から返す。watch_id を優先し、watch_id が無い場合は owner/repo/pr から同一ユーザーの最新 watch を引く。",
+	Description: "background watch の現在状態をローカル state から返す。まず in-memory worker state を見て、見つからなければ SQLite に保存された watch snapshot を返す。watch_id を優先し、watch_id が無い場合は owner/repo/pr から同一ユーザーの最新 watch を引く。",
 }
 
 func startWatchHandler(

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -86,9 +87,17 @@ type Options struct {
 	Now              func() time.Time
 }
 
+type watchStore interface {
+	GetLatest(owner, repo string, pr int) (*store.TriggerEntry, error)
+	UpdateCompletedAt(id int64) error
+	GetReviewWatchByID(id string) (*store.ReviewWatchEntry, error)
+	GetLatestReviewWatch(login, owner, repo string, pr int) (*store.ReviewWatchEntry, error)
+	UpsertReviewWatch(entry store.ReviewWatchEntry) error
+}
+
 // Manager owns background review-watch workers for the current server process.
 type Manager struct {
-	db               *store.DB
+	db               watchStore
 	threshold        time.Duration
 	pollInterval     time.Duration
 	pollTimeout      time.Duration
@@ -138,7 +147,7 @@ type watchState struct {
 }
 
 // NewManager creates a process-local, memory-only watch manager.
-func NewManager(db *store.DB, opts Options) *Manager {
+func NewManager(db watchStore, opts Options) *Manager {
 	pollInterval := opts.PollInterval
 	if pollInterval <= 0 {
 		pollInterval = defaultPollInterval
@@ -206,7 +215,7 @@ func (m *Manager) Close() {
 		w.clientMu.Unlock()
 		errText := "watch manager closed before the watch could finish"
 		w.lastError = &errText
-		_ = m.persistLocked(w)
+		_ = m.persistOrDegradeLocked(w, StatusStale, now)
 		watches = append(watches, w)
 		delete(m.activeByKey, key)
 	}
@@ -504,7 +513,10 @@ func (m *Manager) pollOnce(watchID string) bool {
 	}
 	current.status = StatusWatching
 	current.workerRunning = true
-	_ = m.persistLocked(current)
+	if err := m.persistOrDegradeLocked(current, StatusWatching, now); err != nil {
+		m.mu.Unlock()
+		return true
+	}
 	m.mu.Unlock()
 	return false
 }
@@ -581,7 +593,7 @@ func (m *Manager) finishLocked(w *watchState, status Status, reason *FailureReas
 		w.lastError = &errText
 	}
 	delete(m.activeByKey, w.key)
-	_ = m.persistLocked(w)
+	_ = m.persistOrDegradeLocked(w, status, now)
 	w.cancel()
 }
 
@@ -666,6 +678,53 @@ func (m *Manager) persistLocked(w *watchState) error {
 		RateLimitResetAt: cloneTimePtr(w.rateLimitResetAt),
 	}
 	return m.db.UpsertReviewWatch(reviewWatch)
+}
+
+func (m *Manager) persistOrDegradeLocked(w *watchState, intended Status, now time.Time) error {
+	err := m.persistLocked(w)
+	if err == nil {
+		return nil
+	}
+
+	msg := fmt.Sprintf("failed to persist review_watch while recording %s: %v", intended, err)
+	slog.Error(
+		"failed to persist review_watch",
+		"watch_id", w.id,
+		"login", w.key.login,
+		"owner", w.key.owner,
+		"repo", w.key.repo,
+		"pr", w.key.pr,
+		"intended_status", intended,
+		"err", err,
+	)
+
+	w.updatedAt = now
+	if w.completedAt == nil {
+		w.completedAt = timePtr(now)
+	}
+	w.lastError = &msg
+	w.terminal = true
+	w.workerRunning = false
+	w.token = ""
+	w.clientMu.Lock()
+	w.client = nil
+	w.clientMu.Unlock()
+	delete(m.activeByKey, w.key)
+
+	if intended == StatusStale {
+		w.status = StatusStale
+		w.failureReason = nil
+		if w.staleAt == nil {
+			w.staleAt = timePtr(now)
+		}
+	} else {
+		reason := FailureReasonInternal
+		w.status = StatusFailed
+		w.failureReason = &reason
+	}
+
+	w.cancel()
+	return err
 }
 
 func reviewStatusPtr(status ghclient.ReviewStatus) *ghclient.ReviewStatus {

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -113,24 +113,28 @@ type watchKey struct {
 }
 
 type watchState struct {
-	id            string
-	key           watchKey
-	token         string
-	ctx           context.Context
-	cancel        context.CancelFunc
-	clientMu      sync.RWMutex
-	client        ReviewDataFetcher
-	status        Status
-	reviewStatus  *ghclient.ReviewStatus
-	failureReason *FailureReason
-	terminal      bool
-	workerRunning bool
-	pollsDone     int
-	startedAt     time.Time
-	updatedAt     time.Time
-	completedAt   *time.Time
-	lastPolledAt  *time.Time
-	lastError     *string
+	id               string
+	key              watchKey
+	triggerLogID     *int64
+	resourceURI      *string
+	token            string
+	ctx              context.Context
+	cancel           context.CancelFunc
+	clientMu         sync.RWMutex
+	client           ReviewDataFetcher
+	status           Status
+	reviewStatus     *ghclient.ReviewStatus
+	failureReason    *FailureReason
+	terminal         bool
+	workerRunning    bool
+	pollsDone        int
+	startedAt        time.Time
+	updatedAt        time.Time
+	completedAt      *time.Time
+	staleAt          *time.Time
+	lastPolledAt     *time.Time
+	lastError        *string
+	rateLimitResetAt *time.Time
 }
 
 // NewManager creates a process-local, memory-only watch manager.
@@ -195,12 +199,14 @@ func (m *Manager) Close() {
 		w.workerRunning = false
 		w.updatedAt = now
 		w.completedAt = timePtr(now)
+		w.staleAt = timePtr(now)
 		w.token = ""
 		w.clientMu.Lock()
 		w.client = nil
 		w.clientMu.Unlock()
 		errText := "watch manager closed before the watch could finish"
 		w.lastError = &errText
+		_ = m.persistLocked(w)
 		watches = append(watches, w)
 		delete(m.activeByKey, key)
 	}
@@ -216,6 +222,18 @@ func (m *Manager) Close() {
 func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 	if in.Login == "" || in.Token == "" || in.Owner == "" || in.Repo == "" || in.PR <= 0 {
 		return Snapshot{}, false, fmt.Errorf("login, token, owner, repo, and pr are required")
+	}
+
+	var triggerLogID *int64
+	if m.db != nil {
+		entry, err := m.db.GetLatest(in.Owner, in.Repo, in.PR)
+		if err != nil {
+			return Snapshot{}, false, fmt.Errorf("failed to read trigger_log: %w", err)
+		}
+		if entry != nil {
+			id := entry.ID
+			triggerLogID = &id
+		}
 	}
 
 	key := watchKey{
@@ -234,12 +252,22 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 
 	if id, ok := m.activeByKey[key]; ok {
 		if existing := m.watchesByID[id]; existing != nil && !existing.terminal {
-			if existing.token != in.Token {
+			tokenChanged := existing.token != in.Token
+			triggerLinked := existing.triggerLogID == nil && triggerLogID != nil
+			if tokenChanged {
 				existing.token = in.Token
 				existing.clientMu.Lock()
 				existing.client = m.clientFactory(existing.ctx, in.Token)
 				existing.clientMu.Unlock()
 				existing.updatedAt = m.now().UTC()
+			}
+			if triggerLinked {
+				existing.triggerLogID = cloneInt64Ptr(triggerLogID)
+			}
+			if tokenChanged || triggerLinked {
+				if err := m.persistLocked(existing); err != nil {
+					return Snapshot{}, false, fmt.Errorf("failed to persist review_watch: %w", err)
+				}
 			}
 			return snapshotFromState(existing), true, nil
 		}
@@ -252,6 +280,7 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 	state := &watchState{
 		id:            id,
 		key:           key,
+		triggerLogID:  cloneInt64Ptr(triggerLogID),
 		token:         in.Token,
 		ctx:           watchCtx,
 		cancel:        cancel,
@@ -260,6 +289,10 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 		workerRunning: true,
 		startedAt:     now,
 		updatedAt:     now,
+	}
+	if err := m.persistLocked(state); err != nil {
+		cancel()
+		return Snapshot{}, false, fmt.Errorf("failed to persist review_watch: %w", err)
 	}
 	m.watchesByID[id] = state
 	m.activeByKey[key] = id
@@ -273,30 +306,47 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 // GetByID returns the latest snapshot for a watch ID.
 func (m *Manager) GetByID(watchID string) (Snapshot, bool) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	w := m.watchesByID[watchID]
-	if w == nil {
+	if w != nil {
+		snapshot := snapshotFromState(w)
+		m.mu.RUnlock()
+		return snapshot, true
+	}
+	m.mu.RUnlock()
+
+	if m.db == nil {
 		return Snapshot{}, false
 	}
-	return snapshotFromState(w), true
+	entry, err := m.db.GetReviewWatchByID(watchID)
+	if err != nil || entry == nil {
+		return Snapshot{}, false
+	}
+	return snapshotFromReviewWatchEntry(entry), true
 }
 
 // GetLatest returns the latest watch snapshot for a given user/PR key.
 func (m *Manager) GetLatest(login, owner, repo string, pr int) (Snapshot, bool) {
 	key := watchKey{login: login, owner: owner, repo: repo, pr: pr}
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	id, ok := m.latestByKey[key]
-	if !ok {
+	if ok {
+		w := m.watchesByID[id]
+		if w != nil {
+			snapshot := snapshotFromState(w)
+			m.mu.RUnlock()
+			return snapshot, true
+		}
+	}
+	m.mu.RUnlock()
+
+	if m.db == nil {
 		return Snapshot{}, false
 	}
-	w := m.watchesByID[id]
-	if w == nil {
+	entry, err := m.db.GetLatestReviewWatch(login, owner, repo, pr)
+	if err != nil || entry == nil {
 		return Snapshot{}, false
 	}
-	return snapshotFromState(w), true
+	return snapshotFromReviewWatchEntry(entry), true
 }
 
 func (m *Manager) run(w *watchState) {
@@ -375,10 +425,14 @@ func (m *Manager) pollOnce(watchID string) bool {
 		return true
 	}
 
-	entry, err := m.db.GetLatest(w.key.owner, w.key.repo, w.key.pr)
-	if err != nil {
-		m.finishFailureWithPoll(w.id, now, FailureReasonInternal, fmt.Sprintf("failed to read trigger_log: %v", err))
-		return true
+	var entry *store.TriggerEntry
+	if m.db != nil {
+		var err error
+		entry, err = m.db.GetLatest(w.key.owner, w.key.repo, w.key.pr)
+		if err != nil {
+			m.finishFailureWithPoll(w.id, now, FailureReasonInternal, fmt.Sprintf("failed to read trigger_log: %v", err))
+			return true
+		}
 	}
 
 	var requestedAt *time.Time
@@ -397,6 +451,11 @@ func (m *Manager) pollOnce(watchID string) bool {
 		m.markPollLocked(current, now)
 		current.reviewStatus = reviewStatusPtr(reviewStatus)
 		current.lastError = nil
+		if data.RateLimitReset.IsZero() {
+			current.rateLimitResetAt = nil
+		} else {
+			current.rateLimitResetAt = cloneTimePtr(&data.RateLimitReset)
+		}
 		m.finishLocked(current, StatusRateLimited, nil, now, formatRateLimitMessage(data.RateLimitRemaining, data.RateLimitReset))
 		m.mu.Unlock()
 		return true
@@ -404,7 +463,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 
 	terminalStatus, terminal := watchStatusForReview(reviewStatus)
 	if terminal {
-		if entry != nil && entry.CompletedAt == nil {
+		if m.db != nil && entry != nil && entry.CompletedAt == nil {
 			if err := m.db.UpdateCompletedAt(entry.ID); err != nil {
 				m.finishFailureWithPoll(w.id, now, FailureReasonInternal, fmt.Sprintf("failed to update trigger_log completed_at: %v", err))
 				return true
@@ -419,6 +478,11 @@ func (m *Manager) pollOnce(watchID string) bool {
 		m.markPollLocked(current, now)
 		current.reviewStatus = reviewStatusPtr(reviewStatus)
 		current.lastError = nil
+		current.rateLimitResetAt = nil
+		if current.triggerLogID == nil && entry != nil {
+			id := entry.ID
+			current.triggerLogID = &id
+		}
 		m.finishLocked(current, terminalStatus, nil, now, "")
 		m.mu.Unlock()
 		return true
@@ -433,8 +497,14 @@ func (m *Manager) pollOnce(watchID string) bool {
 	m.markPollLocked(current, now)
 	current.reviewStatus = reviewStatusPtr(reviewStatus)
 	current.lastError = nil
+	current.rateLimitResetAt = nil
+	if current.triggerLogID == nil && entry != nil {
+		id := entry.ID
+		current.triggerLogID = &id
+	}
 	current.status = StatusWatching
 	current.workerRunning = true
+	_ = m.persistLocked(current)
 	m.mu.Unlock()
 	return false
 }
@@ -500,6 +570,9 @@ func (m *Manager) finishLocked(w *watchState, status Status, reason *FailureReas
 	w.workerRunning = false
 	w.updatedAt = now
 	w.completedAt = timePtr(now)
+	if status == StatusStale {
+		w.staleAt = timePtr(now)
+	}
 	w.token = ""
 	w.clientMu.Lock()
 	w.client = nil
@@ -508,6 +581,7 @@ func (m *Manager) finishLocked(w *watchState, status Status, reason *FailureReas
 		w.lastError = &errText
 	}
 	delete(m.activeByKey, w.key)
+	_ = m.persistLocked(w)
 	w.cancel()
 }
 
@@ -537,9 +611,82 @@ func snapshotFromState(w *watchState) Snapshot {
 	}
 }
 
+func snapshotFromReviewWatchEntry(entry *store.ReviewWatchEntry) Snapshot {
+	var reviewStatus *ghclient.ReviewStatus
+	if entry.ReviewStatus != nil {
+		status := ghclient.ReviewStatus(*entry.ReviewStatus)
+		reviewStatus = &status
+	}
+	var failureReason *FailureReason
+	if entry.FailureReason != nil {
+		reason := FailureReason(*entry.FailureReason)
+		failureReason = &reason
+	}
+	return Snapshot{
+		WatchID:       entry.ID,
+		Login:         entry.GitHubLogin,
+		Owner:         entry.Owner,
+		Repo:          entry.Repo,
+		PR:            entry.PR,
+		WatchStatus:   Status(entry.WatchStatus),
+		ReviewStatus:  reviewStatus,
+		FailureReason: failureReason,
+		Terminal:      !entry.IsActive,
+		WorkerRunning: false,
+		PollsDone:     0,
+		StartedAt:     entry.StartedAt,
+		UpdatedAt:     entry.UpdatedAt,
+		CompletedAt:   cloneTimePtr(entry.CompletedAt),
+		LastPolledAt:  nil,
+		LastError:     cloneStringPtr(entry.LastError),
+	}
+}
+
+func (m *Manager) persistLocked(w *watchState) error {
+	if m.db == nil {
+		return nil
+	}
+	reviewWatch := store.ReviewWatchEntry{
+		ID:               w.id,
+		GitHubLogin:      w.key.login,
+		Owner:            w.key.owner,
+		Repo:             w.key.repo,
+		PR:               w.key.pr,
+		TriggerLogID:     cloneInt64Ptr(w.triggerLogID),
+		ResourceURI:      cloneStringPtr(w.resourceURI),
+		WatchStatus:      string(w.status),
+		ReviewStatus:     reviewStatusStringPtr(w.reviewStatus),
+		FailureReason:    failureReasonStringPtr(w.failureReason),
+		IsActive:         !w.terminal,
+		StartedAt:        w.startedAt,
+		UpdatedAt:        w.updatedAt,
+		CompletedAt:      cloneTimePtr(w.completedAt),
+		StaleAt:          cloneTimePtr(w.staleAt),
+		LastError:        cloneStringPtr(w.lastError),
+		RateLimitResetAt: cloneTimePtr(w.rateLimitResetAt),
+	}
+	return m.db.UpsertReviewWatch(reviewWatch)
+}
+
 func reviewStatusPtr(status ghclient.ReviewStatus) *ghclient.ReviewStatus {
 	s := status
 	return &s
+}
+
+func reviewStatusStringPtr(status *ghclient.ReviewStatus) *string {
+	if status == nil {
+		return nil
+	}
+	value := string(*status)
+	return &value
+}
+
+func failureReasonStringPtr(reason *FailureReason) *string {
+	if reason == nil {
+		return nil
+	}
+	value := string(*reason)
+	return &value
 }
 
 func cloneReviewStatusPtr(status *ghclient.ReviewStatus) *ghclient.ReviewStatus {
@@ -572,6 +719,14 @@ func cloneStringPtr(s *string) *string {
 	}
 	v := *s
 	return &v
+}
+
+func cloneInt64Ptr(v *int64) *int64 {
+	if v == nil {
+		return nil
+	}
+	value := *v
+	return &value
 }
 
 func timePtr(t time.Time) *time.Time {

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -263,12 +263,14 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 		if existing := m.watchesByID[id]; existing != nil && !existing.terminal {
 			tokenChanged := existing.token != in.Token
 			triggerLinked := existing.triggerLogID == nil && triggerLogID != nil
+			if tokenChanged || triggerLinked {
+				existing.updatedAt = m.now().UTC()
+			}
 			if tokenChanged {
 				existing.token = in.Token
 				existing.clientMu.Lock()
 				existing.client = m.clientFactory(existing.ctx, in.Token)
 				existing.clientMu.Unlock()
-				existing.updatedAt = m.now().UTC()
 			}
 			if triggerLinked {
 				existing.triggerLogID = cloneInt64Ptr(triggerLogID)
@@ -327,7 +329,11 @@ func (m *Manager) GetByID(watchID string) (Snapshot, bool) {
 		return Snapshot{}, false
 	}
 	entry, err := m.db.GetReviewWatchByID(watchID)
-	if err != nil || entry == nil {
+	if err != nil {
+		slog.Warn("failed to load persisted review_watch by id", "watch_id", watchID, "err", err)
+		return Snapshot{}, false
+	}
+	if entry == nil {
 		return Snapshot{}, false
 	}
 	return snapshotFromReviewWatchEntry(entry), true
@@ -352,7 +358,18 @@ func (m *Manager) GetLatest(login, owner, repo string, pr int) (Snapshot, bool) 
 		return Snapshot{}, false
 	}
 	entry, err := m.db.GetLatestReviewWatch(login, owner, repo, pr)
-	if err != nil || entry == nil {
+	if err != nil {
+		slog.Warn(
+			"failed to load latest persisted review_watch",
+			"login", login,
+			"owner", owner,
+			"repo", repo,
+			"pr", pr,
+			"err", err,
+		)
+		return Snapshot{}, false
+	}
+	if entry == nil {
 		return Snapshot{}, false
 	}
 	return snapshotFromReviewWatchEntry(entry), true

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -63,6 +63,47 @@ func TestManagerStartReusesActiveWatch(t *testing.T) {
 	}
 }
 
+func TestManagerStartPersistsActiveWatch(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    41,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	persisted, err := db.GetReviewWatchByID(started.WatchID)
+	if err != nil {
+		t.Fatalf("GetReviewWatchByID() error = %v", err)
+	}
+	if persisted == nil {
+		t.Fatal("GetReviewWatchByID() = nil, want persisted watch")
+	}
+	if persisted.WatchStatus != string(StatusWatching) {
+		t.Fatalf("WatchStatus = %q, want %q", persisted.WatchStatus, StatusWatching)
+	}
+	if !persisted.IsActive {
+		t.Fatal("IsActive = false, want true")
+	}
+}
+
 func TestManagerMarksCompletedAndClearsActiveKey(t *testing.T) {
 	db := openTestDB(t)
 	if _, err := db.Insert("octo", "demo", 7, "MANUAL"); err != nil {
@@ -206,6 +247,77 @@ func TestManagerCloseMarksActiveWatchStale(t *testing.T) {
 	}
 	if snapshot.WorkerRunning {
 		t.Fatal("WorkerRunning = true, want false")
+	}
+
+	persisted, err := db.GetReviewWatchByID(started.WatchID)
+	if err != nil {
+		t.Fatalf("GetReviewWatchByID() error = %v", err)
+	}
+	if persisted == nil {
+		t.Fatal("GetReviewWatchByID() = nil, want persisted watch")
+	}
+	if persisted.WatchStatus != string(StatusStale) {
+		t.Fatalf("persisted WatchStatus = %q, want %q", persisted.WatchStatus, StatusStale)
+	}
+	if persisted.IsActive {
+		t.Fatal("persisted IsActive = true, want false")
+	}
+	if persisted.StaleAt == nil {
+		t.Fatal("persisted StaleAt = nil, want timestamp")
+	}
+}
+
+func TestManagerGetLatestFallsBackToPersistedWatch(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := db.Insert("octo", "demo", 55, "MANUAL"); err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+	reviewTime := time.Now().Add(time.Minute)
+	manager := NewManager(db, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{
+						data: &ghclient.ReviewData{
+							LatestCopilotReview: newReview("APPROVED", &reviewTime),
+							RateLimitRemaining:  100,
+						},
+					},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    55,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool { return s.Terminal })
+
+	restarted := NewManager(db, Options{Threshold: 30 * time.Second})
+	t.Cleanup(restarted.Close)
+
+	snapshot, ok := restarted.GetLatest("alice", "octo", "demo", 55)
+	if !ok {
+		t.Fatal("GetLatest() = not found, want persisted watch")
+	}
+	if snapshot.WatchID != started.WatchID {
+		t.Fatalf("GetLatest().WatchID = %q, want %q", snapshot.WatchID, started.WatchID)
+	}
+	if snapshot.WatchStatus != StatusCompleted {
+		t.Fatalf("GetLatest().WatchStatus = %q, want %q", snapshot.WatchStatus, StatusCompleted)
+	}
+	if snapshot.WorkerRunning {
+		t.Fatal("GetLatest().WorkerRunning = true, want false for DB fallback")
 	}
 }
 

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -264,6 +265,144 @@ func TestManagerCloseMarksActiveWatchStale(t *testing.T) {
 	}
 	if persisted.StaleAt == nil {
 		t.Fatal("persisted StaleAt = nil, want timestamp")
+	}
+}
+
+func TestManagerPersistFailureDuringPollingFailsWatch(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(&persistFailDB{
+		DB:        db,
+		failAfter: 1,
+		err:       errors.New("forced persist failure"),
+	}, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    124,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusFailed {
+		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusFailed)
+	}
+	if snapshot.FailureReason == nil || *snapshot.FailureReason != FailureReasonInternal {
+		t.Fatalf("FailureReason = %v, want %q", snapshot.FailureReason, FailureReasonInternal)
+	}
+	if snapshot.LastError == nil || !strings.Contains(*snapshot.LastError, "failed to persist review_watch while recording WATCHING") {
+		t.Fatalf("LastError = %v, want persist failure detail", snapshot.LastError)
+	}
+}
+
+func TestManagerPersistFailureDuringTerminalTransitionFailsWatch(t *testing.T) {
+	db := openTestDB(t)
+	reviewTime := time.Now().Add(time.Minute)
+	manager := NewManager(&persistFailDB{
+		DB:        db,
+		failAfter: 1,
+		err:       errors.New("forced persist failure"),
+	}, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{
+						data: &ghclient.ReviewData{
+							LatestCopilotReview: newReview("APPROVED", &reviewTime),
+							RateLimitRemaining:  100,
+						},
+					},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    125,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusFailed {
+		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusFailed)
+	}
+	if snapshot.ReviewStatus == nil || *snapshot.ReviewStatus != ghclient.StatusCompleted {
+		t.Fatalf("ReviewStatus = %v, want %q", snapshot.ReviewStatus, ghclient.StatusCompleted)
+	}
+	if snapshot.FailureReason == nil || *snapshot.FailureReason != FailureReasonInternal {
+		t.Fatalf("FailureReason = %v, want %q", snapshot.FailureReason, FailureReasonInternal)
+	}
+	if snapshot.LastError == nil || !strings.Contains(*snapshot.LastError, "failed to persist review_watch while recording COMPLETED") {
+		t.Fatalf("LastError = %v, want persist failure detail", snapshot.LastError)
+	}
+}
+
+func TestManagerCloseKeepsStaleStatusWhenPersistenceFails(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(&persistFailDB{
+		DB:        db,
+		failAfter: 1,
+		err:       errors.New("forced persist failure"),
+	}, Options{
+		PollInterval: 50 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    126,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	manager.Close()
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusStale {
+		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusStale)
+	}
+	if snapshot.LastError == nil || !strings.Contains(*snapshot.LastError, "failed to persist review_watch while recording STALE") {
+		t.Fatalf("LastError = %v, want persist failure detail", snapshot.LastError)
 	}
 }
 
@@ -601,6 +740,21 @@ type fakeFetcher struct {
 }
 
 type blockingFetcher struct{}
+
+type persistFailDB struct {
+	*store.DB
+	failAfter int
+	upserts   int
+	err       error
+}
+
+func (d *persistFailDB) UpsertReviewWatch(entry store.ReviewWatchEntry) error {
+	d.upserts++
+	if d.upserts > d.failAfter {
+		return d.err
+	}
+	return d.DB.UpsertReviewWatch(entry)
+}
 
 func (f *fakeFetcher) GetReviewData(_ context.Context, _, _ string, _ int) (*ghclient.ReviewData, error) {
 	f.mu.Lock()

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -105,6 +105,90 @@ func TestManagerStartPersistsActiveWatch(t *testing.T) {
 	}
 }
 
+func TestManagerReuseWithTriggerLinkUpdatesTimestamp(t *testing.T) {
+	db := openTestDB(t)
+	base := time.Now().UTC().Truncate(time.Second)
+	nowValues := []time.Time{
+		base,
+		base.Add(2 * time.Minute),
+	}
+	var nowMu sync.Mutex
+	nowIndex := 0
+	nowFn := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		if nowIndex >= len(nowValues) {
+			return nowValues[len(nowValues)-1]
+		}
+		value := nowValues[nowIndex]
+		nowIndex++
+		return value
+	}
+	manager := NewManager(db, Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		Now:          nowFn,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, reused, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    43,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if reused {
+		t.Fatalf("Start() reused = %v, want false", reused)
+	}
+
+	triggerLogID, err := db.Insert("octo", "demo", 43, "MANUAL")
+	if err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+
+	reusedSnapshot, reused, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    43,
+	})
+	if err != nil {
+		t.Fatalf("Start() reuse error = %v", err)
+	}
+	if !reused {
+		t.Fatalf("Start() reused = %v, want true", reused)
+	}
+	if reusedSnapshot.WatchID != started.WatchID {
+		t.Fatalf("WatchID = %q, want %q", reusedSnapshot.WatchID, started.WatchID)
+	}
+
+	persisted, err := db.GetReviewWatchByID(started.WatchID)
+	if err != nil {
+		t.Fatalf("GetReviewWatchByID() error = %v", err)
+	}
+	if persisted == nil {
+		t.Fatal("GetReviewWatchByID() = nil, want persisted watch")
+	}
+	if persisted.TriggerLogID == nil || *persisted.TriggerLogID != triggerLogID {
+		t.Fatalf("TriggerLogID = %v, want %d", persisted.TriggerLogID, triggerLogID)
+	}
+	if !persisted.UpdatedAt.Equal(base.Add(2 * time.Minute)) {
+		t.Fatalf("UpdatedAt = %v, want %v", persisted.UpdatedAt, base.Add(2*time.Minute))
+	}
+}
+
 func TestManagerMarksCompletedAndClearsActiveKey(t *testing.T) {
 	db := openTestDB(t)
 	if _, err := db.Insert("octo", "demo", 7, "MANUAL"); err != nil {


### PR DESCRIPTION
## What changed
- added a `review_watch` table and indexes to persist Copilot review watch snapshots in SQLite
- persisted active, terminal, and stale watch state from the watch manager, including local-state-first status lookup
- updated watch tool descriptions to reflect SQLite-backed local state and added store/manager tests for uniqueness, latest snapshot lookup, and restart stale handling

## Why
- ISSUE #65 requires watch state to survive process restarts enough for status inspection and traceability
- active workers still live only in memory, so any active rows are marked `STALE` on restart to avoid pretending polling is still running

## Impact
- `get_copilot_review_watch_status` can now return the latest persisted snapshot even after the in-memory worker is gone
- SQLite now enforces one active watch per login/repo/PR combination at the DB level
- failed/auth-expired/stale states remain traceable through persisted metadata

## Validation
- `go test ./... -count=1` in `services/copilot-review-mcp`

Refs #65