### PR TITLE
[codex] add copilot review watch tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ curl -i "http://127.0.0.1:${GITHUB_OAUTH_PROXY_PORT:-8084}/.well-known/oauth-aut
 - callback URL は `GITHUB_OAUTH_PROXY_BASE_URL` と一致させてください（末尾 `/callback` を付与）。
 - `copilot-review-mcp` で使っている OAuth App を共有しても問題ありません。
 
-## copilot-review-mcp Async Watch Flow
+## copilot-review-mcp 非同期 Watch フロー
 
 `services/copilot-review-mcp` では、Copilot review の待機を `wait_for_copilot_review` の blocking call ではなく、
 watch 系ツールで進めるのを主経路とします。

--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ curl -i "http://127.0.0.1:${GITHUB_OAUTH_PROXY_PORT:-8084}/.well-known/oauth-aut
 - callback URL は `GITHUB_OAUTH_PROXY_BASE_URL` と一致させてください（末尾 `/callback` を付与）。
 - `copilot-review-mcp` で使っている OAuth App を共有しても問題ありません。
 
+## copilot-review-mcp Async Watch Flow
+
+`services/copilot-review-mcp` では、Copilot review の待機を `wait_for_copilot_review` の blocking call ではなく、
+watch 系ツールで進めるのを主経路とします。
+
+推奨フロー:
+
+1. `get_copilot_review_status` で GitHub 上の即時 snapshot を確認する
+2. 未完了なら `start_copilot_review_watch` を呼ぶ
+3. 他の作業を進めながら `get_copilot_review_watch_status` で cheap read する
+4. `watch_id` を見失ったら `list_copilot_review_watches` で回復する
+5. 不要になった watch は `cancel_copilot_review_watch` で止める
+
+`wait_for_copilot_review` は host 都合で blocking wait が必要な場合だけ使う legacy fallback です。
+
+詳細は [docs/copilot-review-watch-tools.md](docs/copilot-review-watch-tools.md) を参照してください。
+
 ## HTTPエンドポイント
 
 - 既定でホストに公開されるURL（OAuthプロキシ経由）: `http://127.0.0.1:8084`

--- a/docs/copilot-review-mcp-tasks.md
+++ b/docs/copilot-review-mcp-tasks.md
@@ -18,6 +18,10 @@ LLM 向けの async watch + notification モデルへ置き換える大きめの
 
 `docs/design/copilot-review-watch-redesign.md`
 
+現在の watch tool 運用メモ:
+
+`docs/copilot-review-watch-tools.md`
+
 > この redesign は既存の局所修正（#55, #56, #57, #58）とは別トラックで進める想定。
 > 実装に着手する際は、`wait_for_copilot_review` 周辺の重複改修を避けるため、
 > 先にどちらの路線で進めるかを決める。

--- a/docs/copilot-review-watch-tools.md
+++ b/docs/copilot-review-watch-tools.md
@@ -1,4 +1,4 @@
-# copilot-review-mcp Watch Tool Flow
+# copilot-review-mcp Watch ツールフロー
 
 `services/copilot-review-mcp` の主経路は、blocking wait ではなく async watch です。
 このドキュメントは #67 時点の推奨フローと各 tool の役割をまとめます。
@@ -12,7 +12,7 @@
 5. `watch_id` を見失ったら `list_copilot_review_watches(...)` で回復する
 6. watch が不要になったら `cancel_copilot_review_watch(...)` を呼ぶ
 
-## Tool Roles
+## 各ツールの役割
 
 - `get_copilot_review_status`
   GitHub API から即時 snapshot を取る。watch を始める前や、watch が `STALE` / `TIMEOUT` / `CANCELLED` になった後の再確認に使う。
@@ -27,7 +27,7 @@
 - `wait_for_copilot_review`
   legacy fallback。host の都合で blocking wait が必要な場合だけ使う。
 
-## LLM Hints
+## LLM 向けヒント
 
 watch 系ツールは `recommended_next_action` と、必要に応じて `next_poll_seconds` を返します。
 
@@ -43,7 +43,7 @@ watch 系ツールは `recommended_next_action` と、必要に応じて `next_p
 - `CHECK_FAILURE`
   `last_error` / `failure_reason` を確認し、原因を解消してから次のアクションを決める。
 
-## Notes
+## 補足
 
 - `resource_uri` は将来の resource 公開フェーズに備えた安定 ID です。#67 時点では read/subscribe は未提供です。
 - watch state は SQLite に保存されますが、worker 自体は memory-only です。プロセス再起動後の active watch は `STALE` になります。

--- a/docs/copilot-review-watch-tools.md
+++ b/docs/copilot-review-watch-tools.md
@@ -1,0 +1,50 @@
+# copilot-review-mcp Watch Tool Flow
+
+`services/copilot-review-mcp` の主経路は、blocking wait ではなく async watch です。
+このドキュメントは #67 時点の推奨フローと各 tool の役割をまとめます。
+
+## 推奨フロー
+
+1. `get_copilot_review_status(owner, repo, pr)`
+2. status が `COMPLETED` / `BLOCKED` でなければ `start_copilot_review_watch(owner, repo, pr)`
+3. 他の作業を進める
+4. 次の判断点で `get_copilot_review_watch_status(watch_id)` を呼ぶ
+5. `watch_id` を見失ったら `list_copilot_review_watches(...)` で回復する
+6. watch が不要になったら `cancel_copilot_review_watch(...)` を呼ぶ
+
+## Tool Roles
+
+- `get_copilot_review_status`
+  GitHub API から即時 snapshot を取る。watch を始める前や、watch が `STALE` / `TIMEOUT` / `CANCELLED` になった後の再確認に使う。
+- `start_copilot_review_watch`
+  background watch を開始する。active watch が既にあれば idempotent に再利用する。
+- `get_copilot_review_watch_status`
+  ローカル state を返す cheap read。`watch_id` 優先、なければ `(owner, repo, pr)` lookup が使える。
+- `list_copilot_review_watches`
+  active / recent watch を一覧する。human debug と watch 回復用。
+- `cancel_copilot_review_watch`
+  不要な active watch を止める。
+- `wait_for_copilot_review`
+  legacy fallback。host の都合で blocking wait が必要な場合だけ使う。
+
+## LLM Hints
+
+watch 系ツールは `recommended_next_action` と、必要に応じて `next_poll_seconds` を返します。
+
+- `POLL_AFTER`
+  watch はまだ進行中。`next_poll_seconds` 秒後に同じ watch を再確認する。
+- `READ_REVIEW_THREADS`
+  Copilot review が `COMPLETED` または `BLOCKED` に到達した。次は `get_review_threads` などへ進む。
+- `START_NEW_WATCH`
+  現在の watch は継続しない。必要なら `get_copilot_review_status` を再確認してから、新しい watch を開始する。
+  `RATE_LIMITED` の場合は `next_poll_seconds` が再開目安になる。
+- `REAUTH_AND_START_NEW_WATCH`
+  token の再取得後に watch を作り直す。
+- `CHECK_FAILURE`
+  `last_error` / `failure_reason` を確認し、原因を解消してから次のアクションを決める。
+
+## Notes
+
+- `resource_uri` は将来の resource 公開フェーズに備えた安定 ID です。#67 時点では read/subscribe は未提供です。
+- watch state は SQLite に保存されますが、worker 自体は memory-only です。プロセス再起動後の active watch は `STALE` になります。
+- 一覧系は同一 `github_login` の watch だけを返します。

--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -67,8 +67,8 @@ func main() {
 
 	addr := ":" + cfg.port
 	slog.Info("copilot-review-mcp starting", "addr", addr, "base_url", cfg.baseURL)
-	// WriteTimeout is set to 0 (unlimited) because wait_for_copilot_review may block
-	// for up to (max_polls−1) × poll_interval_seconds + API latency (at most 30 minutes).
+	// WriteTimeout remains unlimited because legacy wait_for_copilot_review still exists
+	// as a blocking fallback and may occupy one tool call for up to 30 minutes.
 	server := &http.Server{
 		Addr:              addr,
 		Handler:           mux,

--- a/services/copilot-review-mcp/internal/store/db.go
+++ b/services/copilot-review-mcp/internal/store/db.go
@@ -120,6 +120,16 @@ type ReviewWatchEntry struct {
 	RateLimitResetAt *time.Time
 }
 
+// ReviewWatchFilter scopes a review_watch listing query.
+type ReviewWatchFilter struct {
+	GitHubLogin string
+	Owner       string
+	Repo        string
+	PR          int
+	ActiveOnly  bool
+	Limit       int
+}
+
 // Insert adds a new trigger_log entry and returns the assigned ID.
 func (d *DB) Insert(owner, repo string, pr int, trigger string) (int64, error) {
 	res, err := d.db.Exec(
@@ -251,6 +261,60 @@ func (d *DB) GetLatestReviewWatch(login, owner, repo string, pr int) (*ReviewWat
 		login, owner, repo, pr,
 	)
 	return scanReviewWatch(row)
+}
+
+// ListReviewWatches returns persisted review_watch snapshots for one GitHub login.
+func (d *DB) ListReviewWatches(filter ReviewWatchFilter) ([]ReviewWatchEntry, error) {
+	query := `SELECT id, github_login, owner, repo, pr, trigger_log_id, resource_uri,
+	                 watch_status, review_status, failure_reason, is_active,
+	                 started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at
+	            FROM review_watch
+	           WHERE github_login = ?`
+	args := []any{filter.GitHubLogin}
+
+	if filter.Owner != "" {
+		query += ` AND owner = ?`
+		args = append(args, filter.Owner)
+	}
+	if filter.Repo != "" {
+		query += ` AND repo = ?`
+		args = append(args, filter.Repo)
+	}
+	if filter.PR > 0 {
+		query += ` AND pr = ?`
+		args = append(args, filter.PR)
+	}
+	if filter.ActiveOnly {
+		query += ` AND is_active = 1`
+	}
+
+	query += ` ORDER BY is_active DESC, updated_at DESC, started_at DESC, rowid DESC`
+
+	if filter.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, filter.Limit)
+	}
+
+	rows, err := d.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []ReviewWatchEntry
+	for rows.Next() {
+		entry, err := scanReviewWatch(rows)
+		if err != nil {
+			return nil, err
+		}
+		if entry != nil {
+			entries = append(entries, *entry)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
 }
 
 // MarkActiveReviewWatchesStale deactivates any persisted active watches.

--- a/services/copilot-review-mcp/internal/store/db_test.go
+++ b/services/copilot-review-mcp/internal/store/db_test.go
@@ -214,6 +214,98 @@ func TestGetLatestReviewWatchIgnoresLexicographicIDTies(t *testing.T) {
 	}
 }
 
+func TestListReviewWatchesOrdersActiveThenRecentAndFilters(t *testing.T) {
+	db := openTestDB(t, filepath.Join(t.TempDir(), "review-watch-list.db"))
+
+	base := time.Now().UTC().Truncate(time.Second)
+	entries := []ReviewWatchEntry{
+		{
+			ID:          "cw_terminal_recent",
+			GitHubLogin: "alice",
+			Owner:       "octo",
+			Repo:        "demo",
+			PR:          11,
+			WatchStatus: "COMPLETED",
+			IsActive:    false,
+			StartedAt:   base,
+			UpdatedAt:   base.Add(4 * time.Minute),
+		},
+		{
+			ID:          "cw_active",
+			GitHubLogin: "alice",
+			Owner:       "octo",
+			Repo:        "demo",
+			PR:          10,
+			WatchStatus: "WATCHING",
+			IsActive:    true,
+			StartedAt:   base.Add(time.Minute),
+			UpdatedAt:   base.Add(3 * time.Minute),
+		},
+		{
+			ID:          "cw_terminal_old",
+			GitHubLogin: "alice",
+			Owner:       "octo",
+			Repo:        "demo",
+			PR:          12,
+			WatchStatus: "FAILED",
+			IsActive:    false,
+			StartedAt:   base.Add(2 * time.Minute),
+			UpdatedAt:   base.Add(2 * time.Minute),
+		},
+		{
+			ID:          "cw_other_user",
+			GitHubLogin: "bob",
+			Owner:       "octo",
+			Repo:        "demo",
+			PR:          13,
+			WatchStatus: "WATCHING",
+			IsActive:    true,
+			StartedAt:   base,
+			UpdatedAt:   base.Add(5 * time.Minute),
+		},
+	}
+	for _, entry := range entries {
+		if err := db.UpsertReviewWatch(entry); err != nil {
+			t.Fatalf("UpsertReviewWatch(%q) error = %v", entry.ID, err)
+		}
+	}
+
+	got, err := db.ListReviewWatches(ReviewWatchFilter{
+		GitHubLogin: "alice",
+		Owner:       "octo",
+		Repo:        "demo",
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("ListReviewWatches() error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(ListReviewWatches()) = %d, want 3", len(got))
+	}
+	if got[0].ID != "cw_active" {
+		t.Fatalf("got[0].ID = %q, want active watch first", got[0].ID)
+	}
+	if got[1].ID != "cw_terminal_recent" {
+		t.Fatalf("got[1].ID = %q, want newest terminal watch second", got[1].ID)
+	}
+	if got[2].ID != "cw_terminal_old" {
+		t.Fatalf("got[2].ID = %q, want oldest terminal watch last", got[2].ID)
+	}
+
+	activeOnly, err := db.ListReviewWatches(ReviewWatchFilter{
+		GitHubLogin: "alice",
+		Owner:       "octo",
+		Repo:        "demo",
+		ActiveOnly:  true,
+	})
+	if err != nil {
+		t.Fatalf("ListReviewWatches(active_only) error = %v", err)
+	}
+	if len(activeOnly) != 1 || activeOnly[0].ID != "cw_active" {
+		t.Fatalf("active_only result = %+v, want only cw_active", activeOnly)
+	}
+}
+
 func TestOpenMarksActiveReviewWatchesStale(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "review-watch-open.db")
 	db := openTestDB(t, path)

--- a/services/copilot-review-mcp/internal/tools/status.go
+++ b/services/copilot-review-mcp/internal/tools/status.go
@@ -31,8 +31,10 @@ type GetStatusOutput struct {
 
 // statusTool is the MCP tool definition for get_copilot_review_status.
 var statusTool = &mcp.Tool{
-	Name:        "get_copilot_review_status",
-	Description: "Copilot が PR をレビューしているかどうかの現在のステータスを返す。ステータスは NOT_REQUESTED / PENDING / IN_PROGRESS / COMPLETED / BLOCKED のいずれか。",
+	Name: "get_copilot_review_status",
+	Description: "GitHub 上の Copilot review 状態を即時 snapshot として返す。" +
+		"推奨経路では、まずこの tool で現状確認し、未完了なら start_copilot_review_watch を開始する。" +
+		"ステータスは NOT_REQUESTED / PENDING / IN_PROGRESS / COMPLETED / BLOCKED のいずれか。",
 }
 
 // statusHandler handles a single get_copilot_review_status call.

--- a/services/copilot-review-mcp/internal/tools/wait.go
+++ b/services/copilot-review-mcp/internal/tools/wait.go
@@ -31,8 +31,11 @@ type WaitOutput struct {
 
 // waitTool is the MCP tool definition for wait_for_copilot_review.
 var waitTool = &mcp.Tool{
-	Name:        "wait_for_copilot_review",
-	Description: "Copilot のレビューが COMPLETED または BLOCKED になるまで定期的にポーリングして待機する。タイムアウト時は TIMEOUT を返す。レート制限時は RATE_LIMITED を返す。コンテキストキャンセル時は CANCELLED を返す。",
+	Name: "wait_for_copilot_review",
+	Description: "Legacy fallback。" +
+		"Copilot のレビューが COMPLETED または BLOCKED になるまで、この tool call 自体を block しながら定期ポーリングする。" +
+		"通常は get_copilot_review_status と watch 系ツールを優先し、この tool は host が通知や cheap status read を扱いにくい場合だけ使う。" +
+		"タイムアウト時は TIMEOUT、レート制限時は RATE_LIMITED、コンテキストキャンセル時は CANCELLED を返す。",
 }
 
 // waitHandler handles a single wait_for_copilot_review call.

--- a/services/copilot-review-mcp/internal/tools/watch.go
+++ b/services/copilot-review-mcp/internal/tools/watch.go
@@ -70,9 +70,9 @@ type GetReviewWatchStatusInput struct {
 
 // GetReviewWatchStatusOutput is the output schema for get_copilot_review_watch_status.
 type GetReviewWatchStatusOutput struct {
-	Found bool `json:"found"`
-	ReviewWatchView
-	Note string `json:"note"`
+	Found bool             `json:"found"`
+	Watch *ReviewWatchView `json:"watch,omitempty"`
+	Note  string           `json:"note"`
 }
 
 // ListReviewWatchesInput is the input schema for list_copilot_review_watches.
@@ -101,10 +101,10 @@ type CancelReviewWatchInput struct {
 
 // CancelReviewWatchOutput is the output schema for cancel_copilot_review_watch.
 type CancelReviewWatchOutput struct {
-	Found bool `json:"found"`
-	ReviewWatchView
-	Cancelled bool   `json:"cancelled"`
-	Note      string `json:"note"`
+	Found     bool             `json:"found"`
+	Watch     *ReviewWatchView `json:"watch,omitempty"`
+	Cancelled *bool            `json:"cancelled,omitempty"`
+	Note      string           `json:"note"`
 }
 
 var startWatchTool = &mcp.Tool{
@@ -306,19 +306,21 @@ func buildStartWatchOutput(snapshot watch.Snapshot, reused bool, pollInterval ti
 }
 
 func buildGetWatchStatusOutput(snapshot watch.Snapshot, pollInterval time.Duration) GetReviewWatchStatusOutput {
+	view := buildReviewWatchView(snapshot, pollInterval, time.Now().UTC())
 	return GetReviewWatchStatusOutput{
-		Found:           true,
-		ReviewWatchView: buildReviewWatchView(snapshot, pollInterval, time.Now().UTC()),
-		Note:            "watch の現在状態です。",
+		Found: true,
+		Watch: &view,
+		Note:  "watch の現在状態です。",
 	}
 }
 
 func buildCancelWatchOutput(result watch.CancelResult, pollInterval time.Duration) CancelReviewWatchOutput {
+	view := buildReviewWatchView(result.Snapshot, pollInterval, time.Now().UTC())
 	out := CancelReviewWatchOutput{
-		Found:           result.Found,
-		ReviewWatchView: buildReviewWatchView(result.Snapshot, pollInterval, time.Now().UTC()),
-		Cancelled:       result.Cancelled,
+		Found: result.Found,
+		Watch: &view,
 	}
+	out.Cancelled = boolPtr(result.Cancelled)
 	switch {
 	case result.Cancelled:
 		out.Note = "watch を停止しました。"
@@ -407,7 +409,7 @@ func secondsUntilNextPoll(lastPolledAt *time.Time, pollInterval time.Duration, n
 		pollInterval = 90 * time.Second
 	}
 	if lastPolledAt == nil {
-		return durationSecondsCeil(pollInterval)
+		return 1
 	}
 	remaining := lastPolledAt.UTC().Add(pollInterval).Sub(now.UTC())
 	if remaining <= 0 {
@@ -418,7 +420,7 @@ func secondsUntilNextPoll(lastPolledAt *time.Time, pollInterval time.Duration, n
 
 func secondsUntilRateLimitReset(resetAt *time.Time, fallback time.Duration, now time.Time) int {
 	if resetAt == nil {
-		return secondsUntilNextPoll(nil, fallback, now)
+		return durationSecondsCeil(fallback)
 	}
 	remaining := resetAt.UTC().Sub(now.UTC())
 	if remaining <= 0 {
@@ -436,4 +438,8 @@ func durationSecondsCeil(d time.Duration) int {
 		return 1
 	}
 	return seconds
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }

--- a/services/copilot-review-mcp/internal/tools/watch.go
+++ b/services/copilot-review-mcp/internal/tools/watch.go
@@ -11,6 +11,41 @@ import (
 	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
 )
 
+const (
+	defaultWatchListLimit = 20
+	maxWatchListLimit     = 100
+
+	nextActionPollAfter              = "POLL_AFTER"
+	nextActionReadReviewThreads      = "READ_REVIEW_THREADS"
+	nextActionStartNewWatch          = "START_NEW_WATCH"
+	nextActionReauthAndStartNewWatch = "REAUTH_AND_START_NEW_WATCH"
+	nextActionCheckFailure           = "CHECK_FAILURE"
+)
+
+// ReviewWatchView is the LLM-facing view of one watch snapshot.
+type ReviewWatchView struct {
+	WatchID               string  `json:"watch_id"`
+	Owner                 string  `json:"owner"`
+	Repo                  string  `json:"repo"`
+	PR                    int     `json:"pr"`
+	ResourceURI           *string `json:"resource_uri,omitempty"`
+	WatchStatus           string  `json:"watch_status"`
+	ReviewStatus          *string `json:"review_status,omitempty"`
+	FailureReason         *string `json:"failure_reason,omitempty"`
+	RecommendedNextAction string  `json:"recommended_next_action"`
+	NextPollSeconds       *int    `json:"next_poll_seconds,omitempty"`
+	Terminal              bool    `json:"terminal"`
+	WorkerRunning         bool    `json:"worker_running"`
+	PollsDone             int     `json:"polls_done"`
+	StartedAt             string  `json:"started_at"`
+	UpdatedAt             string  `json:"updated_at"`
+	LastPolledAt          *string `json:"last_polled_at,omitempty"`
+	CompletedAt           *string `json:"completed_at,omitempty"`
+	StaleAt               *string `json:"stale_at,omitempty"`
+	RateLimitResetAt      *string `json:"rate_limit_reset_at,omitempty"`
+	LastError             *string `json:"last_error,omitempty"`
+}
+
 // StartReviewWatchInput is the input schema for start_copilot_review_watch.
 type StartReviewWatchInput struct {
 	Owner string `json:"owner"`
@@ -20,20 +55,9 @@ type StartReviewWatchInput struct {
 
 // StartReviewWatchOutput is the output schema for start_copilot_review_watch.
 type StartReviewWatchOutput struct {
-	WatchID       string  `json:"watch_id"`
-	Reused        bool    `json:"reused"`
-	WatchStatus   string  `json:"watch_status"`
-	ReviewStatus  *string `json:"review_status,omitempty"`
-	FailureReason *string `json:"failure_reason,omitempty"`
-	Terminal      bool    `json:"terminal"`
-	WorkerRunning bool    `json:"worker_running"`
-	PollsDone     int     `json:"polls_done"`
-	StartedAt     string  `json:"started_at"`
-	UpdatedAt     string  `json:"updated_at"`
-	LastPolledAt  *string `json:"last_polled_at,omitempty"`
-	CompletedAt   *string `json:"completed_at,omitempty"`
-	LastError     *string `json:"last_error,omitempty"`
-	Note          string  `json:"note"`
+	ReviewWatchView
+	Reused bool   `json:"reused"`
+	Note   string `json:"note"`
 }
 
 // GetReviewWatchStatusInput is the input schema for get_copilot_review_watch_status.
@@ -46,30 +70,67 @@ type GetReviewWatchStatusInput struct {
 
 // GetReviewWatchStatusOutput is the output schema for get_copilot_review_watch_status.
 type GetReviewWatchStatusOutput struct {
-	Found         bool    `json:"found"`
-	WatchID       *string `json:"watch_id,omitempty"`
-	WatchStatus   *string `json:"watch_status,omitempty"`
-	ReviewStatus  *string `json:"review_status,omitempty"`
-	FailureReason *string `json:"failure_reason,omitempty"`
-	Terminal      bool    `json:"terminal"`
-	WorkerRunning bool    `json:"worker_running"`
-	PollsDone     int     `json:"polls_done"`
-	StartedAt     *string `json:"started_at,omitempty"`
-	UpdatedAt     *string `json:"updated_at,omitempty"`
-	LastPolledAt  *string `json:"last_polled_at,omitempty"`
-	CompletedAt   *string `json:"completed_at,omitempty"`
-	LastError     *string `json:"last_error,omitempty"`
-	Note          string  `json:"note"`
+	Found bool `json:"found"`
+	ReviewWatchView
+	Note string `json:"note"`
+}
+
+// ListReviewWatchesInput is the input schema for list_copilot_review_watches.
+type ListReviewWatchesInput struct {
+	Owner      string `json:"owner,omitempty"`
+	Repo       string `json:"repo,omitempty"`
+	PR         int    `json:"pr,omitempty"`
+	ActiveOnly bool   `json:"active_only,omitempty"`
+	Limit      int    `json:"limit,omitempty"`
+}
+
+// ListReviewWatchesOutput is the output schema for list_copilot_review_watches.
+type ListReviewWatchesOutput struct {
+	Watches []ReviewWatchView `json:"watches"`
+	Count   int               `json:"count"`
+	Note    string            `json:"note"`
+}
+
+// CancelReviewWatchInput is the input schema for cancel_copilot_review_watch.
+type CancelReviewWatchInput struct {
+	WatchID string `json:"watch_id,omitempty"`
+	Owner   string `json:"owner,omitempty"`
+	Repo    string `json:"repo,omitempty"`
+	PR      int    `json:"pr,omitempty"`
+}
+
+// CancelReviewWatchOutput is the output schema for cancel_copilot_review_watch.
+type CancelReviewWatchOutput struct {
+	Found bool `json:"found"`
+	ReviewWatchView
+	Cancelled bool   `json:"cancelled"`
+	Note      string `json:"note"`
 }
 
 var startWatchTool = &mcp.Tool{
-	Name:        "start_copilot_review_watch",
-	Description: "Copilot review の background watch を開始し、即時 return する。同一ユーザー・同一 PR の active watch があればそれを再利用する。watch state は SQLite に保存されるが、worker 自体は memory-only のためサーバー再起動後の active watch は STALE として扱われる。",
+	Name: "start_copilot_review_watch",
+	Description: "推奨経路の開始点。Copilot review の background watch を開始し、即時 return する。" +
+		"同一ユーザー・同一 PR の active watch があればそれを再利用する。" +
+		"まず get_copilot_review_status で GitHub 上の即時 snapshot を確認し、未完了ならこの tool を使う。",
 }
 
 var getWatchStatusTool = &mcp.Tool{
-	Name:        "get_copilot_review_watch_status",
-	Description: "background watch の現在状態をローカル state から返す。まず in-memory worker state を見て、見つからなければ SQLite に保存された watch snapshot を返す。watch_id を優先し、watch_id が無い場合は owner/repo/pr から同一ユーザーの最新 watch を引く。",
+	Name: "get_copilot_review_watch_status",
+	Description: "background watch の現在状態をローカル state から返す cheap read。" +
+		"watch_id を優先し、watch_id が無い場合は owner/repo/pr から同一ユーザーの最新 watch を引く。" +
+		"recommended_next_action と next_poll_seconds を返すため、通知が弱い host の主経路として使える。",
+}
+
+var listWatchTool = &mcp.Tool{
+	Name: "list_copilot_review_watches",
+	Description: "同一ユーザーの active / recent watch 一覧を返す。" +
+		"watch_id を見失った場合の回復や、人手デバッグ時の状況確認に使う。",
+}
+
+var cancelWatchTool = &mcp.Tool{
+	Name: "cancel_copilot_review_watch",
+	Description: "不要になった background watch を停止する。" +
+		"watch_id を優先し、watch_id が無い場合は owner/repo/pr の active watch を対象にする。",
 }
 
 func startWatchHandler(
@@ -97,7 +158,7 @@ func startWatchHandler(
 			return nil, StartReviewWatchOutput{}, err
 		}
 
-		out := buildStartWatchOutput(snapshot, reused)
+		out := buildStartWatchOutput(snapshot, reused, manager.PollInterval())
 		if reused {
 			out.Note = "既存の active watch を再利用しました。"
 		} else {
@@ -111,6 +172,11 @@ func getWatchStatusHandler(
 	manager *watch.Manager,
 ) func(context.Context, *mcp.CallToolRequest, GetReviewWatchStatusInput) (*mcp.CallToolResult, GetReviewWatchStatusOutput, error) {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, in GetReviewWatchStatusInput) (*mcp.CallToolResult, GetReviewWatchStatusOutput, error) {
+		login := middleware.LoginFromContext(ctx)
+		if login == "" {
+			return nil, GetReviewWatchStatusOutput{}, fmt.Errorf("authenticated GitHub login is required")
+		}
+
 		var (
 			snapshot watch.Snapshot
 			ok       bool
@@ -118,19 +184,11 @@ func getWatchStatusHandler(
 
 		switch {
 		case in.WatchID != "":
-			login := middleware.LoginFromContext(ctx)
-			if login == "" {
-				return nil, GetReviewWatchStatusOutput{}, fmt.Errorf("authenticated GitHub login is required")
-			}
 			snapshot, ok = manager.GetByID(in.WatchID)
 			if ok && snapshot.Login != login {
 				ok = false
 			}
 		case in.Owner != "" && in.Repo != "" && in.PR > 0:
-			login := middleware.LoginFromContext(ctx)
-			if login == "" {
-				return nil, GetReviewWatchStatusOutput{}, fmt.Errorf("authenticated GitHub login is required")
-			}
 			snapshot, ok = manager.GetLatest(login, in.Owner, in.Repo, in.PR)
 		default:
 			return nil, GetReviewWatchStatusOutput{}, fmt.Errorf("watch_id or owner, repo, and pr are required")
@@ -143,7 +201,92 @@ func getWatchStatusHandler(
 			}, nil
 		}
 
-		return nil, buildGetWatchStatusOutput(snapshot), nil
+		return nil, buildGetWatchStatusOutput(snapshot, manager.PollInterval()), nil
+	}
+}
+
+func listWatchesHandler(
+	manager *watch.Manager,
+) func(context.Context, *mcp.CallToolRequest, ListReviewWatchesInput) (*mcp.CallToolResult, ListReviewWatchesOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, in ListReviewWatchesInput) (*mcp.CallToolResult, ListReviewWatchesOutput, error) {
+		login := middleware.LoginFromContext(ctx)
+		if login == "" {
+			return nil, ListReviewWatchesOutput{}, fmt.Errorf("authenticated GitHub login is required")
+		}
+		if in.Repo != "" && in.Owner == "" {
+			return nil, ListReviewWatchesOutput{}, fmt.Errorf("owner is required when repo is specified")
+		}
+		if in.PR > 0 && (in.Owner == "" || in.Repo == "") {
+			return nil, ListReviewWatchesOutput{}, fmt.Errorf("owner and repo are required when pr is specified")
+		}
+
+		limit := in.Limit
+		if limit <= 0 {
+			limit = defaultWatchListLimit
+		}
+		if limit > maxWatchListLimit {
+			return nil, ListReviewWatchesOutput{}, fmt.Errorf("limit must not exceed %d", maxWatchListLimit)
+		}
+
+		snapshots, err := manager.List(login, watch.ListOptions{
+			Owner:      in.Owner,
+			Repo:       in.Repo,
+			PR:         in.PR,
+			ActiveOnly: in.ActiveOnly,
+			Limit:      limit,
+		})
+		if err != nil {
+			return nil, ListReviewWatchesOutput{}, err
+		}
+
+		now := time.Now().UTC()
+		out := ListReviewWatchesOutput{
+			Watches: make([]ReviewWatchView, 0, len(snapshots)),
+			Count:   len(snapshots),
+			Note:    "active watch を先頭に、updated_at の新しい順で返します。",
+		}
+		for _, snapshot := range snapshots {
+			out.Watches = append(out.Watches, buildReviewWatchView(snapshot, manager.PollInterval(), now))
+		}
+		if len(out.Watches) == 0 {
+			out.Note = "watch は見つかりませんでした。"
+		}
+		return nil, out, nil
+	}
+}
+
+func cancelWatchHandler(
+	manager *watch.Manager,
+) func(context.Context, *mcp.CallToolRequest, CancelReviewWatchInput) (*mcp.CallToolResult, CancelReviewWatchOutput, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, in CancelReviewWatchInput) (*mcp.CallToolResult, CancelReviewWatchOutput, error) {
+		login := middleware.LoginFromContext(ctx)
+		if login == "" {
+			return nil, CancelReviewWatchOutput{}, fmt.Errorf("authenticated GitHub login is required")
+		}
+
+		var (
+			result watch.CancelResult
+			err    error
+		)
+
+		switch {
+		case in.WatchID != "":
+			result, err = manager.CancelByID(login, in.WatchID)
+		case in.Owner != "" && in.Repo != "" && in.PR > 0:
+			result, err = manager.CancelLatest(login, in.Owner, in.Repo, in.PR)
+		default:
+			return nil, CancelReviewWatchOutput{}, fmt.Errorf("watch_id or owner, repo, and pr are required")
+		}
+		if err != nil {
+			return nil, CancelReviewWatchOutput{}, err
+		}
+		if !result.Found {
+			return nil, CancelReviewWatchOutput{
+				Found: false,
+				Note:  "watch が見つかりませんでした。",
+			}, nil
+		}
+		return nil, buildCancelWatchOutput(result, manager.PollInterval()), nil
 	}
 }
 
@@ -151,19 +294,60 @@ func getWatchStatusHandler(
 func RegisterWatchTools(server *mcp.Server, manager *watch.Manager) {
 	mcp.AddTool(server, startWatchTool, startWatchHandler(manager))
 	mcp.AddTool(server, getWatchStatusTool, getWatchStatusHandler(manager))
+	mcp.AddTool(server, listWatchTool, listWatchesHandler(manager))
+	mcp.AddTool(server, cancelWatchTool, cancelWatchHandler(manager))
 }
 
-func buildStartWatchOutput(snapshot watch.Snapshot, reused bool) StartReviewWatchOutput {
-	out := StartReviewWatchOutput{
-		WatchID:       snapshot.WatchID,
-		Reused:        reused,
-		WatchStatus:   string(snapshot.WatchStatus),
-		Terminal:      snapshot.Terminal,
-		WorkerRunning: snapshot.WorkerRunning,
-		PollsDone:     snapshot.PollsDone,
-		StartedAt:     snapshot.StartedAt.UTC().Format(time.RFC3339),
-		UpdatedAt:     snapshot.UpdatedAt.UTC().Format(time.RFC3339),
-		LastError:     snapshot.LastError,
+func buildStartWatchOutput(snapshot watch.Snapshot, reused bool, pollInterval time.Duration) StartReviewWatchOutput {
+	return StartReviewWatchOutput{
+		ReviewWatchView: buildReviewWatchView(snapshot, pollInterval, time.Now().UTC()),
+		Reused:          reused,
+	}
+}
+
+func buildGetWatchStatusOutput(snapshot watch.Snapshot, pollInterval time.Duration) GetReviewWatchStatusOutput {
+	return GetReviewWatchStatusOutput{
+		Found:           true,
+		ReviewWatchView: buildReviewWatchView(snapshot, pollInterval, time.Now().UTC()),
+		Note:            "watch の現在状態です。",
+	}
+}
+
+func buildCancelWatchOutput(result watch.CancelResult, pollInterval time.Duration) CancelReviewWatchOutput {
+	out := CancelReviewWatchOutput{
+		Found:           result.Found,
+		ReviewWatchView: buildReviewWatchView(result.Snapshot, pollInterval, time.Now().UTC()),
+		Cancelled:       result.Cancelled,
+	}
+	switch {
+	case result.Cancelled:
+		out.Note = "watch を停止しました。"
+	case result.Snapshot.Terminal:
+		out.Note = "対象 watch は既に停止しています。"
+	default:
+		out.Note = "watch は見つかりましたが、現在の worker は停止しています。"
+	}
+	return out
+}
+
+func buildReviewWatchView(snapshot watch.Snapshot, pollInterval time.Duration, now time.Time) ReviewWatchView {
+	recommendedAction, nextPollSeconds := deriveRecommendedNextAction(snapshot, pollInterval, now)
+
+	out := ReviewWatchView{
+		WatchID:               snapshot.WatchID,
+		Owner:                 snapshot.Owner,
+		Repo:                  snapshot.Repo,
+		PR:                    snapshot.PR,
+		ResourceURI:           snapshot.ResourceURI,
+		WatchStatus:           string(snapshot.WatchStatus),
+		RecommendedNextAction: recommendedAction,
+		NextPollSeconds:       nextPollSeconds,
+		Terminal:              snapshot.Terminal,
+		WorkerRunning:         snapshot.WorkerRunning,
+		PollsDone:             snapshot.PollsDone,
+		StartedAt:             snapshot.StartedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:             snapshot.UpdatedAt.UTC().Format(time.RFC3339),
+		LastError:             snapshot.LastError,
 	}
 	if snapshot.ReviewStatus != nil {
 		status := string(*snapshot.ReviewStatus)
@@ -181,42 +365,75 @@ func buildStartWatchOutput(snapshot watch.Snapshot, reused bool) StartReviewWatc
 		ts := snapshot.CompletedAt.UTC().Format(time.RFC3339)
 		out.CompletedAt = &ts
 	}
+	if snapshot.StaleAt != nil {
+		ts := snapshot.StaleAt.UTC().Format(time.RFC3339)
+		out.StaleAt = &ts
+	}
+	if snapshot.RateLimitResetAt != nil {
+		ts := snapshot.RateLimitResetAt.UTC().Format(time.RFC3339)
+		out.RateLimitResetAt = &ts
+	}
 	return out
 }
 
-func buildGetWatchStatusOutput(snapshot watch.Snapshot) GetReviewWatchStatusOutput {
-	watchID := snapshot.WatchID
-	watchStatus := string(snapshot.WatchStatus)
-	startedAt := snapshot.StartedAt.UTC().Format(time.RFC3339)
-	updatedAt := snapshot.UpdatedAt.UTC().Format(time.RFC3339)
+func deriveRecommendedNextAction(snapshot watch.Snapshot, pollInterval time.Duration, now time.Time) (string, *int) {
+	switch snapshot.WatchStatus {
+	case watch.StatusWatching:
+		seconds := secondsUntilNextPoll(snapshot.LastPolledAt, pollInterval, now)
+		return nextActionPollAfter, &seconds
+	case watch.StatusCompleted, watch.StatusBlocked:
+		return nextActionReadReviewThreads, nil
+	case watch.StatusRateLimited:
+		seconds := secondsUntilRateLimitReset(snapshot.RateLimitResetAt, pollInterval, now)
+		return nextActionStartNewWatch, &seconds
+	case watch.StatusCancelled, watch.StatusStale, watch.StatusTimeout:
+		return nextActionStartNewWatch, nil
+	case watch.StatusFailed:
+		if snapshot.FailureReason != nil && *snapshot.FailureReason == watch.FailureReasonAuthExpired {
+			return nextActionReauthAndStartNewWatch, nil
+		}
+		return nextActionCheckFailure, nil
+	default:
+		if snapshot.Terminal {
+			return nextActionCheckFailure, nil
+		}
+		seconds := secondsUntilNextPoll(snapshot.LastPolledAt, pollInterval, now)
+		return nextActionPollAfter, &seconds
+	}
+}
 
-	out := GetReviewWatchStatusOutput{
-		Found:         true,
-		WatchID:       &watchID,
-		WatchStatus:   &watchStatus,
-		Terminal:      snapshot.Terminal,
-		WorkerRunning: snapshot.WorkerRunning,
-		PollsDone:     snapshot.PollsDone,
-		StartedAt:     &startedAt,
-		UpdatedAt:     &updatedAt,
-		LastError:     snapshot.LastError,
-		Note:          "watch の現在状態です。",
+func secondsUntilNextPoll(lastPolledAt *time.Time, pollInterval time.Duration, now time.Time) int {
+	if pollInterval <= 0 {
+		pollInterval = 90 * time.Second
 	}
-	if snapshot.ReviewStatus != nil {
-		status := string(*snapshot.ReviewStatus)
-		out.ReviewStatus = &status
+	if lastPolledAt == nil {
+		return durationSecondsCeil(pollInterval)
 	}
-	if snapshot.FailureReason != nil {
-		reason := string(*snapshot.FailureReason)
-		out.FailureReason = &reason
+	remaining := lastPolledAt.UTC().Add(pollInterval).Sub(now.UTC())
+	if remaining <= 0 {
+		return 1
 	}
-	if snapshot.LastPolledAt != nil {
-		ts := snapshot.LastPolledAt.UTC().Format(time.RFC3339)
-		out.LastPolledAt = &ts
+	return durationSecondsCeil(remaining)
+}
+
+func secondsUntilRateLimitReset(resetAt *time.Time, fallback time.Duration, now time.Time) int {
+	if resetAt == nil {
+		return secondsUntilNextPoll(nil, fallback, now)
 	}
-	if snapshot.CompletedAt != nil {
-		ts := snapshot.CompletedAt.UTC().Format(time.RFC3339)
-		out.CompletedAt = &ts
+	remaining := resetAt.UTC().Sub(now.UTC())
+	if remaining <= 0 {
+		return 1
 	}
-	return out
+	return durationSecondsCeil(remaining)
+}
+
+func durationSecondsCeil(d time.Duration) int {
+	if d <= 0 {
+		return 1
+	}
+	seconds := int((d + time.Second - 1) / time.Second)
+	if seconds < 1 {
+		return 1
+	}
+	return seconds
 }

--- a/services/copilot-review-mcp/internal/tools/watch_test.go
+++ b/services/copilot-review-mcp/internal/tools/watch_test.go
@@ -13,15 +13,7 @@ import (
 )
 
 func TestGetWatchStatusHandlerScopesWatchIDByLogin(t *testing.T) {
-	db, err := store.Open(filepath.Join(t.TempDir(), "watch-tools.db"))
-	if err != nil {
-		t.Fatalf("store.Open() error = %v", err)
-	}
-	t.Cleanup(func() {
-		if err := db.Close(); err != nil {
-			t.Fatalf("db.Close() error = %v", err)
-		}
-	})
+	db := openWatchToolsTestDB(t)
 
 	manager := watch.NewManager(db, watch.Options{
 		PollInterval: time.Hour,
@@ -53,6 +45,178 @@ func TestGetWatchStatusHandlerScopesWatchIDByLogin(t *testing.T) {
 	if out.Found {
 		t.Fatalf("Found = %v, want false", out.Found)
 	}
+}
+
+func TestGetWatchStatusHandlerReturnsLLMHints(t *testing.T) {
+	db := openWatchToolsTestDB(t)
+
+	manager := watch.NewManager(db, watch.Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+			return testStaticFetcher{}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(watch.StartInput{
+		Login: "owner-user",
+		Token: "token-a",
+		Owner: "scottlz0310",
+		Repo:  "Mcp-Docker",
+		PR:    72,
+	})
+	if err != nil {
+		t.Fatalf("manager.Start() error = %v", err)
+	}
+
+	handler := getWatchStatusHandler(manager)
+	ctx := context.WithValue(context.Background(), middleware.ContextKeyLogin, "owner-user")
+
+	_, out, err := handler(ctx, nil, GetReviewWatchStatusInput{Owner: "scottlz0310", Repo: "Mcp-Docker", PR: 72})
+	if err != nil {
+		t.Fatalf("getWatchStatusHandler() error = %v", err)
+	}
+	if !out.Found {
+		t.Fatal("Found = false, want true")
+	}
+	if out.WatchID != started.WatchID {
+		t.Fatalf("WatchID = %q, want %q", out.WatchID, started.WatchID)
+	}
+	if out.RecommendedNextAction != nextActionPollAfter {
+		t.Fatalf("RecommendedNextAction = %q, want %q", out.RecommendedNextAction, nextActionPollAfter)
+	}
+	if out.NextPollSeconds == nil || *out.NextPollSeconds <= 0 {
+		t.Fatalf("NextPollSeconds = %v, want positive poll hint", out.NextPollSeconds)
+	}
+	if out.ResourceURI == nil || *out.ResourceURI == "" {
+		t.Fatalf("ResourceURI = %v, want populated URI", out.ResourceURI)
+	}
+}
+
+func TestListWatchesHandlerReturnsSortedViews(t *testing.T) {
+	db := openWatchToolsTestDB(t)
+	base := time.Now().UTC().Truncate(time.Second)
+	manager := watch.NewManager(db, watch.Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		Now: func() time.Time {
+			return base
+		},
+		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+			return testStaticFetcher{}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(watch.StartInput{
+		Login: "owner-user",
+		Token: "token-a",
+		Owner: "scottlz0310",
+		Repo:  "Mcp-Docker",
+		PR:    73,
+	})
+	if err != nil {
+		t.Fatalf("manager.Start() error = %v", err)
+	}
+
+	reviewStatus := "COMPLETED"
+	if err := db.UpsertReviewWatch(store.ReviewWatchEntry{
+		ID:           "cw_terminal",
+		GitHubLogin:  "owner-user",
+		Owner:        "scottlz0310",
+		Repo:         "Mcp-Docker",
+		PR:           74,
+		WatchStatus:  "COMPLETED",
+		ReviewStatus: &reviewStatus,
+		IsActive:     false,
+		StartedAt:    base.Add(-time.Hour),
+		UpdatedAt:    base.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("UpsertReviewWatch() error = %v", err)
+	}
+
+	handler := listWatchesHandler(manager)
+	ctx := context.WithValue(context.Background(), middleware.ContextKeyLogin, "owner-user")
+
+	_, out, err := handler(ctx, nil, ListReviewWatchesInput{Owner: "scottlz0310", Repo: "Mcp-Docker", Limit: 10})
+	if err != nil {
+		t.Fatalf("listWatchesHandler() error = %v", err)
+	}
+	if out.Count != 2 {
+		t.Fatalf("Count = %d, want 2", out.Count)
+	}
+	if out.Watches[0].WatchID != started.WatchID {
+		t.Fatalf("Watches[0].WatchID = %q, want active watch %q", out.Watches[0].WatchID, started.WatchID)
+	}
+	if out.Watches[0].RecommendedNextAction != nextActionPollAfter {
+		t.Fatalf("Watches[0].RecommendedNextAction = %q, want %q", out.Watches[0].RecommendedNextAction, nextActionPollAfter)
+	}
+	if out.Watches[1].WatchID != "cw_terminal" {
+		t.Fatalf("Watches[1].WatchID = %q, want %q", out.Watches[1].WatchID, "cw_terminal")
+	}
+	if out.Watches[1].RecommendedNextAction != nextActionReadReviewThreads {
+		t.Fatalf("Watches[1].RecommendedNextAction = %q, want %q", out.Watches[1].RecommendedNextAction, nextActionReadReviewThreads)
+	}
+}
+
+func TestCancelWatchHandlerCancelsByPRKey(t *testing.T) {
+	db := openWatchToolsTestDB(t)
+
+	manager := watch.NewManager(db, watch.Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+			return testStaticFetcher{}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	_, _, err := manager.Start(watch.StartInput{
+		Login: "owner-user",
+		Token: "token-a",
+		Owner: "scottlz0310",
+		Repo:  "Mcp-Docker",
+		PR:    75,
+	})
+	if err != nil {
+		t.Fatalf("manager.Start() error = %v", err)
+	}
+
+	handler := cancelWatchHandler(manager)
+	ctx := context.WithValue(context.Background(), middleware.ContextKeyLogin, "owner-user")
+
+	_, out, err := handler(ctx, nil, CancelReviewWatchInput{Owner: "scottlz0310", Repo: "Mcp-Docker", PR: 75})
+	if err != nil {
+		t.Fatalf("cancelWatchHandler() error = %v", err)
+	}
+	if !out.Found {
+		t.Fatal("Found = false, want true")
+	}
+	if !out.Cancelled {
+		t.Fatal("Cancelled = false, want true")
+	}
+	if out.WatchStatus != string(watch.StatusCancelled) {
+		t.Fatalf("WatchStatus = %q, want %q", out.WatchStatus, watch.StatusCancelled)
+	}
+	if out.RecommendedNextAction != nextActionStartNewWatch {
+		t.Fatalf("RecommendedNextAction = %q, want %q", out.RecommendedNextAction, nextActionStartNewWatch)
+	}
+}
+
+func openWatchToolsTestDB(t *testing.T) *store.DB {
+	t.Helper()
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "watch-tools.db"))
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+	return db
 }
 
 type testStaticFetcher struct{}

--- a/services/copilot-review-mcp/internal/tools/watch_test.go
+++ b/services/copilot-review-mcp/internal/tools/watch_test.go
@@ -80,17 +80,20 @@ func TestGetWatchStatusHandlerReturnsLLMHints(t *testing.T) {
 	if !out.Found {
 		t.Fatal("Found = false, want true")
 	}
-	if out.WatchID != started.WatchID {
-		t.Fatalf("WatchID = %q, want %q", out.WatchID, started.WatchID)
+	if out.Watch == nil {
+		t.Fatal("Watch = nil, want payload")
 	}
-	if out.RecommendedNextAction != nextActionPollAfter {
-		t.Fatalf("RecommendedNextAction = %q, want %q", out.RecommendedNextAction, nextActionPollAfter)
+	if out.Watch.WatchID != started.WatchID {
+		t.Fatalf("Watch.WatchID = %q, want %q", out.Watch.WatchID, started.WatchID)
 	}
-	if out.NextPollSeconds == nil || *out.NextPollSeconds <= 0 {
-		t.Fatalf("NextPollSeconds = %v, want positive poll hint", out.NextPollSeconds)
+	if out.Watch.RecommendedNextAction != nextActionPollAfter {
+		t.Fatalf("Watch.RecommendedNextAction = %q, want %q", out.Watch.RecommendedNextAction, nextActionPollAfter)
 	}
-	if out.ResourceURI == nil || *out.ResourceURI == "" {
-		t.Fatalf("ResourceURI = %v, want populated URI", out.ResourceURI)
+	if out.Watch.NextPollSeconds == nil || *out.Watch.NextPollSeconds != 1 {
+		t.Fatalf("Watch.NextPollSeconds = %v, want initial delay 1s", out.Watch.NextPollSeconds)
+	}
+	if out.Watch.ResourceURI == nil || *out.Watch.ResourceURI == "" {
+		t.Fatalf("Watch.ResourceURI = %v, want populated URI", out.Watch.ResourceURI)
 	}
 }
 
@@ -193,14 +196,60 @@ func TestCancelWatchHandlerCancelsByPRKey(t *testing.T) {
 	if !out.Found {
 		t.Fatal("Found = false, want true")
 	}
-	if !out.Cancelled {
-		t.Fatal("Cancelled = false, want true")
+	if out.Cancelled == nil || !*out.Cancelled {
+		t.Fatalf("Cancelled = %v, want true", out.Cancelled)
 	}
-	if out.WatchStatus != string(watch.StatusCancelled) {
-		t.Fatalf("WatchStatus = %q, want %q", out.WatchStatus, watch.StatusCancelled)
+	if out.Watch == nil {
+		t.Fatal("Watch = nil, want payload")
 	}
-	if out.RecommendedNextAction != nextActionStartNewWatch {
-		t.Fatalf("RecommendedNextAction = %q, want %q", out.RecommendedNextAction, nextActionStartNewWatch)
+	if out.Watch.WatchStatus != string(watch.StatusCancelled) {
+		t.Fatalf("Watch.WatchStatus = %q, want %q", out.Watch.WatchStatus, watch.StatusCancelled)
+	}
+	if out.Watch.RecommendedNextAction != nextActionStartNewWatch {
+		t.Fatalf("Watch.RecommendedNextAction = %q, want %q", out.Watch.RecommendedNextAction, nextActionStartNewWatch)
+	}
+}
+
+func TestGetWatchStatusHandlerNotFoundOmitsWatchPayload(t *testing.T) {
+	db := openWatchToolsTestDB(t)
+	manager := watch.NewManager(db, watch.Options{Threshold: 30 * time.Second})
+	t.Cleanup(manager.Close)
+
+	handler := getWatchStatusHandler(manager)
+	ctx := context.WithValue(context.Background(), middleware.ContextKeyLogin, "owner-user")
+
+	_, out, err := handler(ctx, nil, GetReviewWatchStatusInput{Owner: "scottlz0310", Repo: "Mcp-Docker", PR: 999})
+	if err != nil {
+		t.Fatalf("getWatchStatusHandler() error = %v", err)
+	}
+	if out.Found {
+		t.Fatal("Found = true, want false")
+	}
+	if out.Watch != nil {
+		t.Fatalf("Watch = %+v, want nil", out.Watch)
+	}
+}
+
+func TestCancelWatchHandlerNotFoundOmitsWatchPayload(t *testing.T) {
+	db := openWatchToolsTestDB(t)
+	manager := watch.NewManager(db, watch.Options{Threshold: 30 * time.Second})
+	t.Cleanup(manager.Close)
+
+	handler := cancelWatchHandler(manager)
+	ctx := context.WithValue(context.Background(), middleware.ContextKeyLogin, "owner-user")
+
+	_, out, err := handler(ctx, nil, CancelReviewWatchInput{Owner: "scottlz0310", Repo: "Mcp-Docker", PR: 999})
+	if err != nil {
+		t.Fatalf("cancelWatchHandler() error = %v", err)
+	}
+	if out.Found {
+		t.Fatal("Found = true, want false")
+	}
+	if out.Watch != nil {
+		t.Fatalf("Watch = %+v, want nil", out.Watch)
+	}
+	if out.Cancelled != nil {
+		t.Fatalf("Cancelled = %v, want nil", out.Cancelled)
 	}
 }
 

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -44,22 +45,25 @@ const (
 
 // Snapshot is the externally visible state of a watch at a point in time.
 type Snapshot struct {
-	WatchID       string
-	Login         string
-	Owner         string
-	Repo          string
-	PR            int
-	WatchStatus   Status
-	ReviewStatus  *ghclient.ReviewStatus
-	FailureReason *FailureReason
-	Terminal      bool
-	WorkerRunning bool
-	PollsDone     int
-	StartedAt     time.Time
-	UpdatedAt     time.Time
-	CompletedAt   *time.Time
-	LastPolledAt  *time.Time
-	LastError     *string
+	WatchID          string
+	Login            string
+	Owner            string
+	Repo             string
+	PR               int
+	ResourceURI      *string
+	WatchStatus      Status
+	ReviewStatus     *ghclient.ReviewStatus
+	FailureReason    *FailureReason
+	Terminal         bool
+	WorkerRunning    bool
+	PollsDone        int
+	StartedAt        time.Time
+	UpdatedAt        time.Time
+	CompletedAt      *time.Time
+	StaleAt          *time.Time
+	LastPolledAt     *time.Time
+	RateLimitResetAt *time.Time
+	LastError        *string
 }
 
 // StartInput identifies a PR watch owned by one authenticated GitHub user.
@@ -87,11 +91,28 @@ type Options struct {
 	Now              func() time.Time
 }
 
+// CancelResult reports the outcome of a manual watch cancellation request.
+type CancelResult struct {
+	Snapshot  Snapshot
+	Found     bool
+	Cancelled bool
+}
+
+// ListOptions scopes a watch listing query.
+type ListOptions struct {
+	Owner      string
+	Repo       string
+	PR         int
+	ActiveOnly bool
+	Limit      int
+}
+
 type watchStore interface {
 	GetLatest(owner, repo string, pr int) (*store.TriggerEntry, error)
 	UpdateCompletedAt(id int64) error
 	GetReviewWatchByID(id string) (*store.ReviewWatchEntry, error)
 	GetLatestReviewWatch(login, owner, repo string, pr int) (*store.ReviewWatchEntry, error)
+	ListReviewWatches(filter store.ReviewWatchFilter) ([]store.ReviewWatchEntry, error)
 	UpsertReviewWatch(entry store.ReviewWatchEntry) error
 }
 
@@ -288,10 +309,12 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 	now := m.now().UTC()
 	watchCtx, cancel := context.WithCancel(m.ctx)
 	id := m.nextID()
+	resourceURI := resourceURIForWatch(id)
 	state := &watchState{
 		id:            id,
 		key:           key,
 		triggerLogID:  cloneInt64Ptr(triggerLogID),
+		resourceURI:   stringPtr(resourceURI),
 		token:         in.Token,
 		ctx:           watchCtx,
 		cancel:        cancel,
@@ -373,6 +396,175 @@ func (m *Manager) GetLatest(login, owner, repo string, pr int) (Snapshot, bool) 
 		return Snapshot{}, false
 	}
 	return snapshotFromReviewWatchEntry(entry), true
+}
+
+// List returns active and/or recent watch snapshots for one GitHub login.
+func (m *Manager) List(login string, opts ListOptions) ([]Snapshot, error) {
+	if login == "" {
+		return nil, fmt.Errorf("login is required")
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	byID := make(map[string]Snapshot)
+
+	m.mu.RLock()
+	for _, state := range m.watchesByID {
+		if state == nil || state.key.login != login {
+			continue
+		}
+		snapshot := snapshotFromState(state)
+		if !matchesListOptions(snapshot, opts) {
+			continue
+		}
+		byID[snapshot.WatchID] = snapshot
+	}
+	m.mu.RUnlock()
+
+	if m.db != nil {
+		entries, err := m.db.ListReviewWatches(store.ReviewWatchFilter{
+			GitHubLogin: login,
+			Owner:       opts.Owner,
+			Repo:        opts.Repo,
+			PR:          opts.PR,
+			ActiveOnly:  opts.ActiveOnly,
+			Limit:       limit,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list review_watch: %w", err)
+		}
+		for _, entry := range entries {
+			if _, exists := byID[entry.ID]; exists {
+				continue
+			}
+			snapshot := snapshotFromReviewWatchEntry(&entry)
+			if !matchesListOptions(snapshot, opts) {
+				continue
+			}
+			byID[snapshot.WatchID] = snapshot
+		}
+	}
+
+	snapshots := make([]Snapshot, 0, len(byID))
+	for _, snapshot := range byID {
+		snapshots = append(snapshots, snapshot)
+	}
+	sort.Slice(snapshots, func(i, j int) bool {
+		activeI := !snapshots[i].Terminal
+		activeJ := !snapshots[j].Terminal
+		if activeI != activeJ {
+			return activeI
+		}
+		if !snapshots[i].UpdatedAt.Equal(snapshots[j].UpdatedAt) {
+			return snapshots[i].UpdatedAt.After(snapshots[j].UpdatedAt)
+		}
+		if !snapshots[i].StartedAt.Equal(snapshots[j].StartedAt) {
+			return snapshots[i].StartedAt.After(snapshots[j].StartedAt)
+		}
+		return snapshots[i].WatchID > snapshots[j].WatchID
+	})
+	if len(snapshots) > limit {
+		snapshots = snapshots[:limit]
+	}
+	return snapshots, nil
+}
+
+// CancelByID stops a running watch by watch ID when it belongs to the caller.
+func (m *Manager) CancelByID(login, watchID string) (CancelResult, error) {
+	if login == "" || watchID == "" {
+		return CancelResult{}, fmt.Errorf("login and watch_id are required")
+	}
+
+	m.mu.Lock()
+	if state := m.watchesByID[watchID]; state != nil {
+		if state.key.login != login {
+			m.mu.Unlock()
+			return CancelResult{}, nil
+		}
+		if state.terminal {
+			snapshot := snapshotFromState(state)
+			m.mu.Unlock()
+			return CancelResult{Snapshot: snapshot, Found: true}, nil
+		}
+		now := m.now().UTC()
+		m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
+		snapshot := snapshotFromState(state)
+		m.mu.Unlock()
+		return CancelResult{Snapshot: snapshot, Found: true, Cancelled: true}, nil
+	}
+	m.mu.Unlock()
+
+	if m.db == nil {
+		return CancelResult{}, nil
+	}
+	entry, err := m.db.GetReviewWatchByID(watchID)
+	if err != nil {
+		return CancelResult{}, fmt.Errorf("failed to load review_watch: %w", err)
+	}
+	if entry == nil || entry.GitHubLogin != login {
+		return CancelResult{}, nil
+	}
+	return CancelResult{
+		Snapshot: snapshotFromReviewWatchEntry(entry),
+		Found:    true,
+	}, nil
+}
+
+// CancelLatest stops the active watch for one user/PR key when present.
+func (m *Manager) CancelLatest(login, owner, repo string, pr int) (CancelResult, error) {
+	if login == "" || owner == "" || repo == "" || pr <= 0 {
+		return CancelResult{}, fmt.Errorf("login, owner, repo, and pr are required")
+	}
+
+	key := watchKey{login: login, owner: owner, repo: repo, pr: pr}
+
+	m.mu.Lock()
+	if id, ok := m.activeByKey[key]; ok {
+		if state := m.watchesByID[id]; state != nil {
+			if state.terminal {
+				snapshot := snapshotFromState(state)
+				m.mu.Unlock()
+				return CancelResult{Snapshot: snapshot, Found: true}, nil
+			}
+			now := m.now().UTC()
+			m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
+			snapshot := snapshotFromState(state)
+			m.mu.Unlock()
+			return CancelResult{Snapshot: snapshot, Found: true, Cancelled: true}, nil
+		}
+		delete(m.activeByKey, key)
+	}
+	if id, ok := m.latestByKey[key]; ok {
+		if state := m.watchesByID[id]; state != nil {
+			snapshot := snapshotFromState(state)
+			m.mu.Unlock()
+			return CancelResult{Snapshot: snapshot, Found: true}, nil
+		}
+	}
+	m.mu.Unlock()
+
+	if m.db == nil {
+		return CancelResult{}, nil
+	}
+	entry, err := m.db.GetLatestReviewWatch(login, owner, repo, pr)
+	if err != nil {
+		return CancelResult{}, fmt.Errorf("failed to load latest review_watch: %w", err)
+	}
+	if entry == nil {
+		return CancelResult{}, nil
+	}
+	return CancelResult{
+		Snapshot: snapshotFromReviewWatchEntry(entry),
+		Found:    true,
+	}, nil
+}
+
+// PollInterval returns the manager's configured polling cadence.
+func (m *Manager) PollInterval() time.Duration {
+	return m.pollInterval
 }
 
 func (m *Manager) run(w *watchState) {
@@ -621,22 +813,25 @@ func (m *Manager) nextID() string {
 
 func snapshotFromState(w *watchState) Snapshot {
 	return Snapshot{
-		WatchID:       w.id,
-		Login:         w.key.login,
-		Owner:         w.key.owner,
-		Repo:          w.key.repo,
-		PR:            w.key.pr,
-		WatchStatus:   w.status,
-		ReviewStatus:  cloneReviewStatusPtr(w.reviewStatus),
-		FailureReason: cloneFailureReasonPtr(w.failureReason),
-		Terminal:      w.terminal,
-		WorkerRunning: w.workerRunning,
-		PollsDone:     w.pollsDone,
-		StartedAt:     w.startedAt,
-		UpdatedAt:     w.updatedAt,
-		CompletedAt:   cloneTimePtr(w.completedAt),
-		LastPolledAt:  cloneTimePtr(w.lastPolledAt),
-		LastError:     cloneStringPtr(w.lastError),
+		WatchID:          w.id,
+		Login:            w.key.login,
+		Owner:            w.key.owner,
+		Repo:             w.key.repo,
+		PR:               w.key.pr,
+		ResourceURI:      cloneStringPtr(w.resourceURI),
+		WatchStatus:      w.status,
+		ReviewStatus:     cloneReviewStatusPtr(w.reviewStatus),
+		FailureReason:    cloneFailureReasonPtr(w.failureReason),
+		Terminal:         w.terminal,
+		WorkerRunning:    w.workerRunning,
+		PollsDone:        w.pollsDone,
+		StartedAt:        w.startedAt,
+		UpdatedAt:        w.updatedAt,
+		CompletedAt:      cloneTimePtr(w.completedAt),
+		StaleAt:          cloneTimePtr(w.staleAt),
+		LastPolledAt:     cloneTimePtr(w.lastPolledAt),
+		RateLimitResetAt: cloneTimePtr(w.rateLimitResetAt),
+		LastError:        cloneStringPtr(w.lastError),
 	}
 }
 
@@ -652,22 +847,25 @@ func snapshotFromReviewWatchEntry(entry *store.ReviewWatchEntry) Snapshot {
 		failureReason = &reason
 	}
 	return Snapshot{
-		WatchID:       entry.ID,
-		Login:         entry.GitHubLogin,
-		Owner:         entry.Owner,
-		Repo:          entry.Repo,
-		PR:            entry.PR,
-		WatchStatus:   Status(entry.WatchStatus),
-		ReviewStatus:  reviewStatus,
-		FailureReason: failureReason,
-		Terminal:      !entry.IsActive,
-		WorkerRunning: false,
-		PollsDone:     0,
-		StartedAt:     entry.StartedAt,
-		UpdatedAt:     entry.UpdatedAt,
-		CompletedAt:   cloneTimePtr(entry.CompletedAt),
-		LastPolledAt:  nil,
-		LastError:     cloneStringPtr(entry.LastError),
+		WatchID:          entry.ID,
+		Login:            entry.GitHubLogin,
+		Owner:            entry.Owner,
+		Repo:             entry.Repo,
+		PR:               entry.PR,
+		ResourceURI:      cloneStringPtr(entry.ResourceURI),
+		WatchStatus:      Status(entry.WatchStatus),
+		ReviewStatus:     reviewStatus,
+		FailureReason:    failureReason,
+		Terminal:         !entry.IsActive,
+		WorkerRunning:    false,
+		PollsDone:        0,
+		StartedAt:        entry.StartedAt,
+		UpdatedAt:        entry.UpdatedAt,
+		CompletedAt:      cloneTimePtr(entry.CompletedAt),
+		StaleAt:          cloneTimePtr(entry.StaleAt),
+		LastPolledAt:     nil,
+		RateLimitResetAt: cloneTimePtr(entry.RateLimitResetAt),
+		LastError:        cloneStringPtr(entry.LastError),
 	}
 }
 
@@ -809,6 +1007,10 @@ func timePtr(t time.Time) *time.Time {
 	return &t
 }
 
+func stringPtr(v string) *string {
+	return &v
+}
+
 func formatRateLimitMessage(remaining int, reset time.Time) string {
 	resetText := "unknown"
 	if !reset.IsZero() {
@@ -819,6 +1021,10 @@ func formatRateLimitMessage(remaining int, reset time.Time) string {
 		remaining,
 		resetText,
 	)
+}
+
+func resourceURIForWatch(watchID string) string {
+	return fmt.Sprintf("copilot-review://watch/%s", watchID)
 }
 
 // IsRateLimitHTTPError reports whether err is a GitHub rate-limit HTTP failure.
@@ -843,4 +1049,20 @@ func watchStatusForReview(status ghclient.ReviewStatus) (Status, bool) {
 	default:
 		return "", false
 	}
+}
+
+func matchesListOptions(snapshot Snapshot, opts ListOptions) bool {
+	if opts.Owner != "" && snapshot.Owner != opts.Owner {
+		return false
+	}
+	if opts.Repo != "" && snapshot.Repo != opts.Repo {
+		return false
+	}
+	if opts.PR > 0 && snapshot.PR != opts.PR {
+		return false
+	}
+	if opts.ActiveOnly && snapshot.Terminal {
+		return false
+	}
+	return true
 }

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -436,11 +436,11 @@ func (m *Manager) List(login string, opts ListOptions) ([]Snapshot, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to list review_watch: %w", err)
 		}
-		for _, entry := range entries {
-			if _, exists := byID[entry.ID]; exists {
+		for i := range entries {
+			if _, exists := byID[entries[i].ID]; exists {
 				continue
 			}
-			snapshot := snapshotFromReviewWatchEntry(&entry)
+			snapshot := snapshotFromReviewWatchEntry(&entries[i])
 			if !matchesListOptions(snapshot, opts) {
 				continue
 			}

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -544,6 +544,133 @@ func TestManagerGetLatestFallsBackToPersistedWatch(t *testing.T) {
 	}
 }
 
+func TestManagerListReturnsActiveFirstAndIncludesPersistedWatch(t *testing.T) {
+	db := openTestDB(t)
+	base := time.Now().UTC().Truncate(time.Second)
+	manager := NewManager(db, Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		Now: func() time.Time {
+			return base
+		},
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    70,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	persisted := store.ReviewWatchEntry{
+		ID:          "cw_persisted_terminal",
+		GitHubLogin: "alice",
+		Owner:       "octo",
+		Repo:        "demo",
+		PR:          71,
+		WatchStatus: "COMPLETED",
+		IsActive:    false,
+		StartedAt:   base.Add(-2 * time.Hour),
+		UpdatedAt:   base.Add(-time.Minute),
+	}
+	if err := db.UpsertReviewWatch(persisted); err != nil {
+		t.Fatalf("UpsertReviewWatch() error = %v", err)
+	}
+
+	snapshots, err := manager.List("alice", ListOptions{Owner: "octo", Repo: "demo", Limit: 10})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("len(List()) = %d, want 2", len(snapshots))
+	}
+	if snapshots[0].WatchID != started.WatchID {
+		t.Fatalf("snapshots[0].WatchID = %q, want active watch %q first", snapshots[0].WatchID, started.WatchID)
+	}
+	if snapshots[1].WatchID != persisted.ID {
+		t.Fatalf("snapshots[1].WatchID = %q, want persisted watch %q", snapshots[1].WatchID, persisted.ID)
+	}
+	if snapshots[0].ResourceURI == nil || *snapshots[0].ResourceURI == "" {
+		t.Fatalf("active snapshot ResourceURI = %v, want populated resource URI", snapshots[0].ResourceURI)
+	}
+}
+
+func TestManagerCancelLatestMarksWatchCancelled(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    72,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	result, err := manager.CancelLatest("alice", "octo", "demo", 72)
+	if err != nil {
+		t.Fatalf("CancelLatest() error = %v", err)
+	}
+	if !result.Found {
+		t.Fatal("CancelLatest().Found = false, want true")
+	}
+	if !result.Cancelled {
+		t.Fatal("CancelLatest().Cancelled = false, want true")
+	}
+	if result.Snapshot.WatchStatus != StatusCancelled {
+		t.Fatalf("CancelLatest().WatchStatus = %q, want %q", result.Snapshot.WatchStatus, StatusCancelled)
+	}
+	if !result.Snapshot.Terminal {
+		t.Fatal("CancelLatest().Terminal = false, want true")
+	}
+	if result.Snapshot.WorkerRunning {
+		t.Fatal("CancelLatest().WorkerRunning = true, want false")
+	}
+	if result.Snapshot.LastError == nil || !strings.Contains(*result.Snapshot.LastError, "cancelled manually") {
+		t.Fatalf("CancelLatest().LastError = %v, want cancellation detail", result.Snapshot.LastError)
+	}
+
+	persisted, err := db.GetReviewWatchByID(started.WatchID)
+	if err != nil {
+		t.Fatalf("GetReviewWatchByID() error = %v", err)
+	}
+	if persisted == nil {
+		t.Fatal("GetReviewWatchByID() = nil, want row")
+	}
+	if persisted.WatchStatus != string(StatusCancelled) {
+		t.Fatalf("persisted WatchStatus = %q, want %q", persisted.WatchStatus, StatusCancelled)
+	}
+	if persisted.IsActive {
+		t.Fatal("persisted IsActive = true, want false")
+	}
+}
+
 func TestManagerPollTimeoutFailsWatch(t *testing.T) {
 	db := openTestDB(t)
 	manager := NewManager(db, Options{


### PR DESCRIPTION
## Summary
- add list_copilot_review_watches and cancel_copilot_review_watch
- extend watch outputs with esource_uri, ecommended_next_action, and 
ext_poll_seconds
- persist and expose stable watch resource URIs, plus manual cancel/list support in the manager and store
- reposition wait_for_copilot_review as a legacy fallback and document the async watch flow

## Why
Issue #67 moves the main LLM path off the blocking wait tool. The watch manager and SQLite persistence were already in place, but the public tool surface was still incomplete and the recommended migration path was not documented.

## Impact
LLMs and humans can now start a watch, poll cheap local state, recover lost watch_id values through a list call, and explicitly cancel unneeded watches. The returned hints now tell the caller whether to poll again, read review threads, restart a watch, or reauthenticate first.

## Validation
- go test ./... -count=1 in services/copilot-review-mcp

Closes #67
