### PR TITLE
[codex] refactor copilot-review-mcp stateful sessions

### DIFF
--- a/docs/copilot-review-watch-tools.md
+++ b/docs/copilot-review-watch-tools.md
@@ -48,3 +48,21 @@ watch 系ツールは `recommended_next_action` と、必要に応じて `next_p
 - `resource_uri` は将来の resource 公開フェーズに備えた安定 ID です。#67 時点では read/subscribe は未提供です。
 - watch state は SQLite に保存されますが、worker 自体は memory-only です。プロセス再起動後の active watch は `STALE` になります。
 - 一覧系は同一 `github_login` の watch だけを返します。
+
+## Stateful Session 基盤（#64）
+
+#64 以降、`copilot-review-mcp` の Streamable HTTP は stateless ではなく stateful session として扱います。
+
+- 初回 initialize で発行された `Mcp-Session-Id` を後続 request で再利用します。
+- MCP server は request ごとに作成されず、プロセス内の長寿命 server が複数 stateful session を保持します。
+- GitHub client は長寿命 server へ閉じ込めず、各 tool request の認証済み header から作成します。
+- `Mcp-Session-Id` は GitHub login と対応付け、別 login から同じ session ID が使われた場合は拒否します。
+- idle session は server 側 timeout で閉じられます。
+- `EventStore` は memory store を使い、future resource notification / SSE replay の土台を用意しています。
+
+テスト観点:
+
+- initialize 後の複数 request が同一 stateful session と長寿命 server を再利用すること。
+- 別 GitHub login が既存 `Mcp-Session-Id` を使うと 403 になること。
+- handler shutdown で active session と background watch manager が停止すること。
+- resource notification 追加時は `resources/subscribe` 済み session に `notifications/resources/updated` が届き、通知不可 host では watch status read fallback が維持されること。

--- a/docs/copilot-review-watch-tools.md
+++ b/docs/copilot-review-watch-tools.md
@@ -63,6 +63,7 @@ watch 系ツールは `recommended_next_action` と、必要に応じて `next_p
 テスト観点:
 
 - initialize 後の複数 request が同一 stateful session と長寿命 server を再利用すること。
-- 別 GitHub login が既存 `Mcp-Session-Id` を使うと 403 になること。
+- 別 GitHub login が既存 `Mcp-Session-Id` を使うと JSON error body 付きの 403 になること。
+- timeout などで server から消えた session の login binding が periodic pruning で消えること。
 - handler shutdown で active session と background watch manager が停止すること。
 - resource notification 追加時は `resources/subscribe` 済み session に `notifications/resources/updated` が届き、通知不可 host では watch status read fallback が維持されること。

--- a/services/copilot-review-mcp/cmd/server/main.go
+++ b/services/copilot-review-mcp/cmd/server/main.go
@@ -58,7 +58,7 @@ func main() {
 		fmt.Fprintln(w, `{"status":"ok"}`)
 	})
 
-	// MCP endpoints (auth required) — Streamable HTTP transport (stateless, per-request server)
+	// MCP endpoints (auth required) — Streamable HTTP transport (stateful, shared server)
 	threshold := time.Duration(cfg.inProgressThresholdSec) * time.Second
 	mcpHandler := tools.BuildStreamableHandler(db, threshold, oauthHandler)
 	defer mcpHandler.Close()

--- a/services/copilot-review-mcp/internal/tools/auth_request.go
+++ b/services/copilot-review-mcp/internal/tools/auth_request.go
@@ -1,0 +1,53 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
+	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
+)
+
+type githubClientProvider func(context.Context, *mcp.CallToolRequest) (*ghclient.Client, error)
+
+func newGitHubClientProvider(threshold time.Duration, invalidate func(string)) githubClientProvider {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*ghclient.Client, error) {
+		token := tokenFromToolRequest(ctx, req)
+		if token == "" {
+			return nil, fmt.Errorf("authenticated GitHub token is required")
+		}
+		return ghclient.NewClient(ctx, token, threshold, invalidate), nil
+	}
+}
+
+func loginFromToolRequest(ctx context.Context, req *mcp.CallToolRequest) string {
+	if req != nil && req.Extra != nil && req.Extra.TokenInfo != nil && req.Extra.TokenInfo.UserID != "" {
+		return req.Extra.TokenInfo.UserID
+	}
+	return middleware.LoginFromContext(ctx)
+}
+
+func tokenFromToolRequest(ctx context.Context, req *mcp.CallToolRequest) string {
+	if req != nil && req.Extra != nil {
+		if token := bearerTokenFromHeader(req.Extra.Header); token != "" {
+			return token
+		}
+	}
+	return middleware.TokenFromContext(ctx)
+}
+
+func bearerTokenFromHeader(header http.Header) string {
+	if header == nil {
+		return ""
+	}
+	fields := strings.Fields(header.Get("Authorization"))
+	if len(fields) == 2 && strings.EqualFold(fields[0], "bearer") {
+		return fields[1]
+	}
+	return ""
+}

--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -86,10 +86,10 @@ var cycleTool = &mcp.Tool{
 }
 
 func cycleStatusHandler(
-	gh *ghclient.Client,
+	clientProvider githubClientProvider,
 	db *store.DB,
 ) func(context.Context, *mcp.CallToolRequest, CycleStatusInput) (*mcp.CallToolResult, CycleStatusOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in CycleStatusInput) (*mcp.CallToolResult, CycleStatusOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CycleStatusInput) (*mcp.CallToolResult, CycleStatusOutput, error) {
 		// Input validation
 		if in.Owner == "" || in.Repo == "" || in.PR <= 0 {
 			return nil, CycleStatusOutput{}, fmt.Errorf("owner, repo, and pr are required")
@@ -112,6 +112,11 @@ func cycleStatusHandler(
 			return nil, CycleStatusOutput{}, fmt.Errorf(
 				"fix_type must be one of: logic, spec_change, trivial, none (got %q)", in.FixType,
 			)
+		}
+
+		gh, err := clientProvider(ctx, req)
+		if err != nil {
+			return nil, CycleStatusOutput{}, err
 		}
 
 		// Resolve max_cycles (input → env → default)
@@ -346,8 +351,8 @@ func cycleStatusHandler(
 }
 
 // RegisterCycleTool adds get_pr_review_cycle_status to the MCP server.
-func RegisterCycleTool(server *mcp.Server, gh *ghclient.Client, db *store.DB) {
-	mcp.AddTool(server, cycleTool, cycleStatusHandler(gh, db))
+func RegisterCycleTool(server *mcp.Server, clientProvider githubClientProvider, db *store.DB) {
+	mcp.AddTool(server, cycleTool, cycleStatusHandler(clientProvider, db))
 }
 
 // findLatestCommentAt returns the most recent CreatedAt across Copilot-authored

--- a/services/copilot-review-mcp/internal/tools/request.go
+++ b/services/copilot-review-mcp/internal/tools/request.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
 	"github.com/scottlz0310/copilot-review-mcp/internal/store"
 )
 
@@ -33,12 +32,16 @@ var requestTool = &mcp.Tool{
 
 // requestHandler handles a single request_copilot_review call.
 func requestHandler(
-	ghClient *ghclient.Client,
+	clientProvider githubClientProvider,
 	db *store.DB,
 ) func(context.Context, *mcp.CallToolRequest, RequestInput) (*mcp.CallToolResult, RequestOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in RequestInput) (*mcp.CallToolResult, RequestOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in RequestInput) (*mcp.CallToolResult, RequestOutput, error) {
 		if in.Owner == "" || in.Repo == "" || in.PR <= 0 {
 			return nil, RequestOutput{}, fmt.Errorf("owner, repo, and pr are required")
+		}
+		ghClient, err := clientProvider(ctx, req)
+		if err != nil {
+			return nil, RequestOutput{}, err
 		}
 
 		// Guard: check for an in-progress trigger_log entry.
@@ -89,6 +92,6 @@ func requestHandler(
 }
 
 // RegisterRequestTool adds request_copilot_review to the MCP server.
-func RegisterRequestTool(server *mcp.Server, gh *ghclient.Client, db *store.DB) {
-	mcp.AddTool(server, requestTool, requestHandler(gh, db))
+func RegisterRequestTool(server *mcp.Server, clientProvider githubClientProvider, db *store.DB) {
+	mcp.AddTool(server, requestTool, requestHandler(clientProvider, db))
 }

--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -3,17 +3,22 @@ package tools
 import (
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
 	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
 	"github.com/scottlz0310/copilot-review-mcp/internal/store"
 	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
 )
 
 var schemaCache = mcp.NewSchemaCache()
+
+const (
+	defaultStreamableSessionTimeout = 30 * time.Minute
+	mcpSessionIDHeader              = "Mcp-Session-Id"
+)
 
 // TokenInvalidator is implemented by auth.Handler to clear a token from the
 // validation cache when a downstream GitHub API call returns HTTP 401.
@@ -25,24 +30,63 @@ type TokenInvalidator interface {
 type StreamableHandler struct {
 	handler      http.Handler
 	watchManager *watch.Manager
+	server       *mcp.Server
+
+	mu sync.Mutex
+
+	sessionLogins map[string]string
 }
 
 // ServeHTTP proxies requests to the underlying MCP streamable handler.
 func (h *StreamableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.handler.ServeHTTP(w, r)
+	login := middleware.LoginFromContext(r.Context())
+	sessionID := r.Header.Get(mcpSessionIDHeader)
+	if sessionID != "" && login != "" && !h.authorizeSession(sessionID, login) {
+		http.Error(w, "session user mismatch", http.StatusForbidden)
+		return
+	}
+
+	rw := &statusCaptureResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	h.handler.ServeHTTP(rw, r)
+
+	if responseSessionID := rw.Header().Get(mcpSessionIDHeader); responseSessionID != "" &&
+		login != "" &&
+		rw.statusCode < http.StatusBadRequest {
+		h.rememberSession(responseSessionID, login)
+	}
+	if r.Method == http.MethodDelete &&
+		sessionID != "" &&
+		rw.statusCode >= http.StatusOK &&
+		rw.statusCode < http.StatusMultipleChoices {
+		h.forgetSession(sessionID)
+	}
 }
 
 // Close stops background review watches owned by this handler.
 func (h *StreamableHandler) Close() {
-	if h == nil || h.watchManager == nil {
+	if h == nil {
 		return
 	}
-	h.watchManager.Close()
+
+	h.mu.Lock()
+	server := h.server
+	h.sessionLogins = make(map[string]string)
+	h.mu.Unlock()
+
+	if server != nil {
+		for session := range server.Sessions() {
+			session.Close()
+		}
+	}
+	if h.watchManager != nil {
+		h.watchManager.Close()
+	}
 }
 
 // BuildStreamableHandler returns a handler that serves MCP over Streamable HTTP.
-// getServer is called for each request (stateless mode) to produce a fresh *mcp.Server
-// bound to the caller's GitHub access token.
+// getServer is called for new stateful MCP sessions and returns the shared
+// long-lived *mcp.Server. GitHub clients are created per tool call from the
+// authenticated request headers.
 // inv is called to invalidate the cached token when GitHub returns HTTP 401.
 func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInvalidator) *StreamableHandler {
 	var invalidate func(string)
@@ -54,31 +98,77 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 		InvalidateToken: invalidate,
 	})
 
+	clientProvider := newGitHubClientProvider(threshold, invalidate)
+	srv := mcp.NewServer(
+		&mcp.Implementation{Name: "copilot-review-mcp", Version: "1.0.0"},
+		&mcp.ServerOptions{SchemaCache: schemaCache},
+	)
+	RegisterStatusTool(srv, clientProvider, db)
+	RegisterWatchTools(srv, watchManager)
+	RegisterWaitTool(srv, clientProvider, db)
+	RegisterRequestTool(srv, clientProvider, db)
+	RegisterThreadTools(srv, clientProvider)
+	RegisterCycleTool(srv, clientProvider, db)
+
+	streamableHandler := &StreamableHandler{
+		watchManager:  watchManager,
+		server:        srv,
+		sessionLogins: make(map[string]string),
+	}
+
 	getServer := func(r *http.Request) *mcp.Server {
-		token := middleware.TokenFromContext(r.Context())
-		if token == "" {
+		if middleware.TokenFromContext(r.Context()) == "" {
 			return nil
 		}
-		gh := ghclient.NewClient(r.Context(), token, threshold, invalidate)
-		srv := mcp.NewServer(
-			&mcp.Implementation{Name: "copilot-review-mcp", Version: "1.0.0"},
-			&mcp.ServerOptions{SchemaCache: schemaCache},
-		)
-		RegisterStatusTool(srv, gh, db)
-		RegisterWatchTools(srv, watchManager)
-		RegisterWaitTool(srv, gh, db)
-		RegisterRequestTool(srv, gh, db)
-		RegisterThreadTools(srv, gh)
-		RegisterCycleTool(srv, gh, db)
 		return srv
 	}
-	return &StreamableHandler{
-		handler: mcp.NewStreamableHTTPHandler(getServer, &mcp.StreamableHTTPOptions{
-			Stateless: true,
-			// DisableLocalhostProtection is opt-in via MCP_DISABLE_LOCALHOST_PROTECTION=true.
-			// Enable when the server runs behind a reverse proxy or inside a Docker network.
-			DisableLocalhostProtection: os.Getenv("MCP_DISABLE_LOCALHOST_PROTECTION") == "true",
-		}),
-		watchManager: watchManager,
+	streamableHandler.handler = mcp.NewStreamableHTTPHandler(getServer, &mcp.StreamableHTTPOptions{
+		EventStore:     mcp.NewMemoryEventStore(nil),
+		SessionTimeout: defaultStreamableSessionTimeout,
+		// DisableLocalhostProtection is opt-in via MCP_DISABLE_LOCALHOST_PROTECTION=true.
+		// Enable when the server runs behind a reverse proxy or inside a Docker network.
+		DisableLocalhostProtection: os.Getenv("MCP_DISABLE_LOCALHOST_PROTECTION") == "true",
+	})
+	return streamableHandler
+}
+
+func (h *StreamableHandler) rememberSession(sessionID, login string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.sessionLogins[sessionID] = login
+}
+
+func (h *StreamableHandler) forgetSession(sessionID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.sessionLogins, sessionID)
+}
+
+func (h *StreamableHandler) authorizeSession(sessionID, login string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	expected, ok := h.sessionLogins[sessionID]
+	return !ok || expected == login
+}
+
+type statusCaptureResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (w *statusCaptureResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *statusCaptureResponseWriter) Write(p []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.WriteHeader(http.StatusOK)
 	}
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *statusCaptureResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
 }

--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -17,6 +17,7 @@ var schemaCache = mcp.NewSchemaCache()
 
 const (
 	defaultStreamableSessionTimeout = 30 * time.Minute
+	defaultSessionPruneInterval     = 5 * time.Minute
 	mcpSessionIDHeader              = "Mcp-Session-Id"
 )
 
@@ -35,6 +36,8 @@ type StreamableHandler struct {
 	mu sync.Mutex
 
 	sessionLogins map[string]string
+	stopPruner    chan struct{}
+	closeOnce     sync.Once
 }
 
 // ServeHTTP proxies requests to the underlying MCP streamable handler.
@@ -46,20 +49,15 @@ func (h *StreamableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rw := &statusCaptureResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
-	h.handler.ServeHTTP(rw, r)
+	h.handler.ServeHTTP(w, r)
 
-	if responseSessionID := rw.Header().Get(mcpSessionIDHeader); responseSessionID != "" &&
-		login != "" &&
-		rw.statusCode < http.StatusBadRequest {
+	if responseSessionID := w.Header().Get(mcpSessionIDHeader); responseSessionID != "" && login != "" {
 		h.rememberSession(responseSessionID, login)
 	}
-	if r.Method == http.MethodDelete &&
-		sessionID != "" &&
-		rw.statusCode >= http.StatusOK &&
-		rw.statusCode < http.StatusMultipleChoices {
+	if r.Method == http.MethodDelete && sessionID != "" {
 		h.forgetSession(sessionID)
 	}
+	h.pruneSessionLogins()
 }
 
 // Close stops background review watches owned by this handler.
@@ -68,19 +66,23 @@ func (h *StreamableHandler) Close() {
 		return
 	}
 
-	h.mu.Lock()
-	server := h.server
-	h.sessionLogins = make(map[string]string)
-	h.mu.Unlock()
+	h.closeOnce.Do(func() {
+		close(h.stopPruner)
 
-	if server != nil {
-		for session := range server.Sessions() {
-			session.Close()
+		h.mu.Lock()
+		server := h.server
+		h.sessionLogins = make(map[string]string)
+		h.mu.Unlock()
+
+		if server != nil {
+			for session := range server.Sessions() {
+				session.Close()
+			}
 		}
-	}
-	if h.watchManager != nil {
-		h.watchManager.Close()
-	}
+		if h.watchManager != nil {
+			h.watchManager.Close()
+		}
+	})
 }
 
 // BuildStreamableHandler returns a handler that serves MCP over Streamable HTTP.
@@ -114,6 +116,7 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 		watchManager:  watchManager,
 		server:        srv,
 		sessionLogins: make(map[string]string),
+		stopPruner:    make(chan struct{}),
 	}
 
 	getServer := func(r *http.Request) *mcp.Server {
@@ -129,6 +132,7 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 		// Enable when the server runs behind a reverse proxy or inside a Docker network.
 		DisableLocalhostProtection: os.Getenv("MCP_DISABLE_LOCALHOST_PROTECTION") == "true",
 	})
+	go streamableHandler.pruneSessionLoginsLoop(defaultSessionPruneInterval)
 	return streamableHandler
 }
 
@@ -152,23 +156,41 @@ func (h *StreamableHandler) authorizeSession(sessionID, login string) bool {
 	return !ok || expected == login
 }
 
-type statusCaptureResponseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (w *statusCaptureResponseWriter) WriteHeader(statusCode int) {
-	w.statusCode = statusCode
-	w.ResponseWriter.WriteHeader(statusCode)
-}
-
-func (w *statusCaptureResponseWriter) Write(p []byte) (int, error) {
-	if w.statusCode == 0 {
-		w.WriteHeader(http.StatusOK)
+func (h *StreamableHandler) pruneSessionLoginsLoop(interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultSessionPruneInterval
 	}
-	return w.ResponseWriter.Write(p)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			h.pruneSessionLogins()
+		case <-h.stopPruner:
+			return
+		}
+	}
 }
 
-func (w *statusCaptureResponseWriter) Unwrap() http.ResponseWriter {
-	return w.ResponseWriter
+func (h *StreamableHandler) pruneSessionLogins() {
+	server := h.server
+	if server == nil {
+		return
+	}
+
+	active := make(map[string]struct{})
+	for session := range server.Sessions() {
+		if id := session.ID(); id != "" {
+			active[id] = struct{}{}
+		}
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for sessionID := range h.sessionLogins {
+		if _, ok := active[sessionID]; !ok {
+			delete(h.sessionLogins, sessionID)
+		}
+	}
 }

--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -1,6 +1,8 @@
 package tools
 
 import (
+	"encoding/json"
+	"log/slog"
 	"net/http"
 	"os"
 	"sync"
@@ -19,6 +21,7 @@ const (
 	defaultStreamableSessionTimeout = 30 * time.Minute
 	defaultSessionPruneInterval     = 5 * time.Minute
 	mcpSessionIDHeader              = "Mcp-Session-Id"
+	sessionUserMismatchError        = "session_user_mismatch"
 )
 
 // TokenInvalidator is implemented by auth.Handler to clear a token from the
@@ -45,7 +48,7 @@ func (h *StreamableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	login := middleware.LoginFromContext(r.Context())
 	sessionID := r.Header.Get(mcpSessionIDHeader)
 	if sessionID != "" && login != "" && !h.authorizeSession(sessionID, login) {
-		http.Error(w, "session user mismatch", http.StatusForbidden)
+		writeJSONError(w, http.StatusForbidden, sessionUserMismatchError)
 		return
 	}
 
@@ -57,7 +60,6 @@ func (h *StreamableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodDelete && sessionID != "" {
 		h.forgetSession(sessionID)
 	}
-	h.pruneSessionLogins()
 }
 
 // Close stops background review watches owned by this handler.
@@ -76,7 +78,10 @@ func (h *StreamableHandler) Close() {
 
 		if server != nil {
 			for session := range server.Sessions() {
-				session.Close()
+				sessionID := session.ID()
+				if err := session.Close(); err != nil {
+					slog.Warn("failed to close MCP session", "session_id", sessionID, "err", err)
+				}
 			}
 		}
 		if h.watchManager != nil {
@@ -154,6 +159,12 @@ func (h *StreamableHandler) authorizeSession(sessionID, login string) bool {
 
 	expected, ok := h.sessionLogins[sessionID]
 	return !ok || expected == login
+}
+
+func writeJSONError(w http.ResponseWriter, status int, code string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code})
 }
 
 func (h *StreamableHandler) pruneSessionLoginsLoop(interval time.Duration) {

--- a/services/copilot-review-mcp/internal/tools/server_test.go
+++ b/services/copilot-review-mcp/internal/tools/server_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -119,6 +120,17 @@ func TestStreamableHandlerRejectsSessionUserMismatch(t *testing.T) {
 	if resp.StatusCode != http.StatusForbidden {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("mismatched session status = %d, want 403; body=%s", resp.StatusCode, string(body))
+	}
+	if contentType := resp.Header.Get("Content-Type"); contentType != "application/json" {
+		t.Fatalf("mismatched session content type = %q, want application/json", contentType)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode mismatched session response error = %v", err)
+	}
+	if got := body["error"]; got != sessionUserMismatchError {
+		t.Fatalf("mismatched session error = %q, want %q", got, sessionUserMismatchError)
 	}
 }
 

--- a/services/copilot-review-mcp/internal/tools/server_test.go
+++ b/services/copilot-review-mcp/internal/tools/server_test.go
@@ -1,10 +1,19 @@
 package tools
 
 import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
 	"github.com/scottlz0310/copilot-review-mcp/internal/store"
 	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
 )
@@ -37,4 +46,170 @@ func TestStreamableHandlerCloseClosesWatchManager(t *testing.T) {
 	if err.Error() != "watch manager is closed" {
 		t.Fatalf("Start() after Close() error = %q, want %q", err.Error(), "watch manager is closed")
 	}
+}
+
+func TestStreamableHandlerReusesStatefulSessionServer(t *testing.T) {
+	db := openServerTestDB(t)
+	handler := BuildStreamableHandler(db, 30*time.Second, nil)
+	t.Cleanup(handler.Close)
+
+	httpServer := httptest.NewServer(withAuthContext(handler, map[string]string{
+		"token-a": "alice",
+	}))
+	t.Cleanup(httpServer.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{
+		Endpoint:             httpServer.URL,
+		HTTPClient:           bearerTokenHTTPClient("token-a"),
+		DisableStandaloneSSE: true,
+		MaxRetries:           -1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Fatalf("session.Close() error = %v", err)
+		}
+	})
+
+	if _, err := session.ListTools(context.Background(), nil); err != nil {
+		t.Fatalf("first ListTools() error = %v", err)
+	}
+	if _, err := session.ListTools(context.Background(), nil); err != nil {
+		t.Fatalf("second ListTools() error = %v", err)
+	}
+
+	if got := handlerServerSessionCount(handler); got != 1 {
+		t.Fatalf("server session count = %d, want 1 stateful session reused across requests", got)
+	}
+	if got := handlerSessionLoginCount(handler); got != 1 {
+		t.Fatalf("session login count = %d, want 1", got)
+	}
+}
+
+func TestStreamableHandlerRejectsSessionUserMismatch(t *testing.T) {
+	db := openServerTestDB(t)
+	handler := BuildStreamableHandler(db, 30*time.Second, nil)
+	t.Cleanup(handler.Close)
+
+	httpServer := httptest.NewServer(withAuthContext(handler, map[string]string{
+		"token-a": "alice",
+		"token-b": "bob",
+	}))
+	t.Cleanup(httpServer.Close)
+
+	initBody := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}`)
+	resp := postMCP(t, httpServer.URL, "token-a", "", initBody)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("initialize status = %d, want 200; body=%s", resp.StatusCode, string(body))
+	}
+	sessionID := resp.Header.Get(mcpSessionIDHeader)
+	resp.Body.Close()
+	if sessionID == "" {
+		t.Fatal("initialize response missing Mcp-Session-Id")
+	}
+
+	initializedBody := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`)
+	resp = postMCP(t, httpServer.URL, "token-b", sessionID, initializedBody)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("mismatched session status = %d, want 403; body=%s", resp.StatusCode, string(body))
+	}
+}
+
+func TestTokenFromToolRequestPrefersCurrentAuthorizationHeader(t *testing.T) {
+	ctx := context.WithValue(context.Background(), middleware.ContextKeyToken, "old-token")
+	req := &mcp.CallToolRequest{
+		Extra: &mcp.RequestExtra{
+			Header: http.Header{"Authorization": {"Bearer fresh-token"}},
+		},
+	}
+
+	if got := tokenFromToolRequest(ctx, req); got != "fresh-token" {
+		t.Fatalf("tokenFromToolRequest() = %q, want fresh-token", got)
+	}
+}
+
+func openServerTestDB(t *testing.T) *store.DB {
+	t.Helper()
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "server-test.db"))
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+	return db
+}
+
+func withAuthContext(next http.Handler, tokenLogins map[string]string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		login := tokenLogins[token]
+		ctx := context.WithValue(r.Context(), middleware.ContextKeyToken, token)
+		ctx = context.WithValue(ctx, middleware.ContextKeyLogin, login)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func postMCP(t *testing.T, endpoint, token, sessionID string, body []byte) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Content-Type", "application/json")
+	if sessionID != "" {
+		req.Header.Set(mcpSessionIDHeader, sessionID)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http.Do() error = %v", err)
+	}
+	return resp
+}
+
+func bearerTokenHTTPClient(token string) *http.Client {
+	return &http.Client{
+		Transport: bearerTokenRoundTripper{
+			token: token,
+			base:  http.DefaultTransport,
+		},
+	}
+}
+
+type bearerTokenRoundTripper struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (rt bearerTokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	return rt.base.RoundTrip(req)
+}
+
+func handlerServerSessionCount(handler *StreamableHandler) int {
+	count := 0
+	for range handler.server.Sessions() {
+		count++
+	}
+	return count
+}
+
+func handlerSessionLoginCount(handler *StreamableHandler) int {
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+	return len(handler.sessionLogins)
 }

--- a/services/copilot-review-mcp/internal/tools/server_test.go
+++ b/services/copilot-review-mcp/internal/tools/server_test.go
@@ -135,6 +135,19 @@ func TestTokenFromToolRequestPrefersCurrentAuthorizationHeader(t *testing.T) {
 	}
 }
 
+func TestStreamableHandlerPrunesStaleSessionLogins(t *testing.T) {
+	db := openServerTestDB(t)
+	handler := BuildStreamableHandler(db, 30*time.Second, nil)
+	t.Cleanup(handler.Close)
+
+	handler.rememberSession("stale-session", "alice")
+	handler.pruneSessionLogins()
+
+	if got := handlerSessionLoginCount(handler); got != 0 {
+		t.Fatalf("session login count = %d, want stale session pruned", got)
+	}
+}
+
 func openServerTestDB(t *testing.T) *store.DB {
 	t.Helper()
 

--- a/services/copilot-review-mcp/internal/tools/status.go
+++ b/services/copilot-review-mcp/internal/tools/status.go
@@ -39,12 +39,17 @@ var statusTool = &mcp.Tool{
 
 // statusHandler handles a single get_copilot_review_status call.
 func statusHandler(
-	ghClient *ghclient.Client,
+	clientProvider githubClientProvider,
 	db *store.DB,
 ) func(context.Context, *mcp.CallToolRequest, GetStatusInput) (*mcp.CallToolResult, GetStatusOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in GetStatusInput) (*mcp.CallToolResult, GetStatusOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetStatusInput) (*mcp.CallToolResult, GetStatusOutput, error) {
 		if in.Owner == "" || in.Repo == "" || in.PR <= 0 {
 			return nil, GetStatusOutput{}, fmt.Errorf("owner, repo, and pr are required")
+		}
+
+		ghClient, err := clientProvider(ctx, req)
+		if err != nil {
+			return nil, GetStatusOutput{}, err
 		}
 
 		data, err := ghClient.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
@@ -110,8 +115,8 @@ func statusHandler(
 }
 
 // RegisterStatusTool adds get_copilot_review_status to the MCP server.
-func RegisterStatusTool(server *mcp.Server, gh *ghclient.Client, db *store.DB) {
-	mcp.AddTool(server, statusTool, statusHandler(gh, db))
+func RegisterStatusTool(server *mcp.Server, clientProvider githubClientProvider, db *store.DB) {
+	mcp.AddTool(server, statusTool, statusHandler(clientProvider, db))
 }
 
 // fmtDuration formats a duration as a human-readable string.

--- a/services/copilot-review-mcp/internal/tools/threads.go
+++ b/services/copilot-review-mcp/internal/tools/threads.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-
-	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
 )
 
 // ─── Tool 4: get_review_threads ───────────────────────────────────────────────
@@ -53,11 +51,15 @@ var getReviewThreadsTool = &mcp.Tool{
 }
 
 func getReviewThreadsHandler(
-	gh *ghclient.Client,
+	clientProvider githubClientProvider,
 ) func(context.Context, *mcp.CallToolRequest, GetReviewThreadsInput) (*mcp.CallToolResult, GetReviewThreadsOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in GetReviewThreadsInput) (*mcp.CallToolResult, GetReviewThreadsOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetReviewThreadsInput) (*mcp.CallToolResult, GetReviewThreadsOutput, error) {
 		if in.Owner == "" || in.Repo == "" || in.PR <= 0 {
 			return nil, GetReviewThreadsOutput{}, fmt.Errorf("owner, repo, and pr are required")
+		}
+		gh, err := clientProvider(ctx, req)
+		if err != nil {
+			return nil, GetReviewThreadsOutput{}, err
 		}
 
 		rawThreads, err := gh.GetReviewThreads(ctx, in.Owner, in.Repo, in.PR)
@@ -93,8 +95,8 @@ func getReviewThreadsHandler(
 }
 
 // RegisterGetReviewThreadsTool adds get_review_threads to the MCP server.
-func RegisterGetReviewThreadsTool(server *mcp.Server, gh *ghclient.Client) {
-	mcp.AddTool(server, getReviewThreadsTool, getReviewThreadsHandler(gh))
+func RegisterGetReviewThreadsTool(server *mcp.Server, clientProvider githubClientProvider) {
+	mcp.AddTool(server, getReviewThreadsTool, getReviewThreadsHandler(clientProvider))
 }
 
 // ─── Tool 5: reply_to_review_thread ──────────────────────────────────────────
@@ -118,14 +120,18 @@ var replyToThreadTool = &mcp.Tool{
 }
 
 func replyToThreadHandler(
-	gh *ghclient.Client,
+	clientProvider githubClientProvider,
 ) func(context.Context, *mcp.CallToolRequest, ReplyToThreadInput) (*mcp.CallToolResult, ReplyToThreadOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in ReplyToThreadInput) (*mcp.CallToolResult, ReplyToThreadOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in ReplyToThreadInput) (*mcp.CallToolResult, ReplyToThreadOutput, error) {
 		if in.ThreadID == "" {
 			return nil, ReplyToThreadOutput{}, fmt.Errorf("threadId is required")
 		}
 		if strings.TrimSpace(in.Body) == "" {
 			return nil, ReplyToThreadOutput{}, fmt.Errorf("body must not be empty or whitespace-only")
+		}
+		gh, err := clientProvider(ctx, req)
+		if err != nil {
+			return nil, ReplyToThreadOutput{}, err
 		}
 
 		alreadyResolved, err := gh.IsThreadResolved(ctx, in.ThreadID)
@@ -151,8 +157,8 @@ func replyToThreadHandler(
 }
 
 // RegisterReplyToThreadTool adds reply_to_review_thread to the MCP server.
-func RegisterReplyToThreadTool(server *mcp.Server, gh *ghclient.Client) {
-	mcp.AddTool(server, replyToThreadTool, replyToThreadHandler(gh))
+func RegisterReplyToThreadTool(server *mcp.Server, clientProvider githubClientProvider) {
+	mcp.AddTool(server, replyToThreadTool, replyToThreadHandler(clientProvider))
 }
 
 // ─── Tool 6: resolve_review_thread ───────────────────────────────────────────
@@ -174,11 +180,15 @@ var resolveThreadTool = &mcp.Tool{
 }
 
 func resolveThreadHandler(
-	gh *ghclient.Client,
+	clientProvider githubClientProvider,
 ) func(context.Context, *mcp.CallToolRequest, ResolveThreadInput) (*mcp.CallToolResult, ResolveThreadOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in ResolveThreadInput) (*mcp.CallToolResult, ResolveThreadOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in ResolveThreadInput) (*mcp.CallToolResult, ResolveThreadOutput, error) {
 		if in.ThreadID == "" {
 			return nil, ResolveThreadOutput{}, fmt.Errorf("threadId is required")
+		}
+		gh, err := clientProvider(ctx, req)
+		if err != nil {
+			return nil, ResolveThreadOutput{}, err
 		}
 
 		alreadyResolved, err := gh.ResolveThread(ctx, in.ThreadID)
@@ -193,8 +203,8 @@ func resolveThreadHandler(
 }
 
 // RegisterResolveThreadTool adds resolve_review_thread to the MCP server.
-func RegisterResolveThreadTool(server *mcp.Server, gh *ghclient.Client) {
-	mcp.AddTool(server, resolveThreadTool, resolveThreadHandler(gh))
+func RegisterResolveThreadTool(server *mcp.Server, clientProvider githubClientProvider) {
+	mcp.AddTool(server, resolveThreadTool, resolveThreadHandler(clientProvider))
 }
 
 // ─── Tool 7: reply_and_resolve_review_thread ──────────────────────────────────
@@ -221,14 +231,18 @@ var replyAndResolveTool = &mcp.Tool{
 }
 
 func replyAndResolveHandler(
-	gh *ghclient.Client,
+	clientProvider githubClientProvider,
 ) func(context.Context, *mcp.CallToolRequest, ReplyAndResolveInput) (*mcp.CallToolResult, ReplyAndResolveOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in ReplyAndResolveInput) (*mcp.CallToolResult, ReplyAndResolveOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in ReplyAndResolveInput) (*mcp.CallToolResult, ReplyAndResolveOutput, error) {
 		if in.ThreadID == "" {
 			return nil, ReplyAndResolveOutput{}, fmt.Errorf("threadId is required")
 		}
 		if strings.TrimSpace(in.Body) == "" {
 			return nil, ReplyAndResolveOutput{}, fmt.Errorf("body must not be empty or whitespace-only")
+		}
+		gh, err := clientProvider(ctx, req)
+		if err != nil {
+			return nil, ReplyAndResolveOutput{}, err
 		}
 
 		out := ReplyAndResolveOutput{}
@@ -260,14 +274,14 @@ func replyAndResolveHandler(
 }
 
 // RegisterReplyAndResolveTool adds reply_and_resolve_review_thread to the MCP server.
-func RegisterReplyAndResolveTool(server *mcp.Server, gh *ghclient.Client) {
-	mcp.AddTool(server, replyAndResolveTool, replyAndResolveHandler(gh))
+func RegisterReplyAndResolveTool(server *mcp.Server, clientProvider githubClientProvider) {
+	mcp.AddTool(server, replyAndResolveTool, replyAndResolveHandler(clientProvider))
 }
 
 // RegisterThreadTools registers Tools 4–7 (ISSUE#26) on the MCP server.
-func RegisterThreadTools(server *mcp.Server, gh *ghclient.Client) {
-	RegisterGetReviewThreadsTool(server, gh)
-	RegisterReplyToThreadTool(server, gh)
-	RegisterResolveThreadTool(server, gh)
-	RegisterReplyAndResolveTool(server, gh)
+func RegisterThreadTools(server *mcp.Server, clientProvider githubClientProvider) {
+	RegisterGetReviewThreadsTool(server, clientProvider)
+	RegisterReplyToThreadTool(server, clientProvider)
+	RegisterResolveThreadTool(server, clientProvider)
+	RegisterReplyAndResolveTool(server, clientProvider)
 }

--- a/services/copilot-review-mcp/internal/tools/wait.go
+++ b/services/copilot-review-mcp/internal/tools/wait.go
@@ -40,10 +40,10 @@ var waitTool = &mcp.Tool{
 
 // waitHandler handles a single wait_for_copilot_review call.
 func waitHandler(
-	ghClient *ghclient.Client,
+	clientProvider githubClientProvider,
 	db *store.DB,
 ) func(context.Context, *mcp.CallToolRequest, WaitInput) (*mcp.CallToolResult, WaitOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in WaitInput) (*mcp.CallToolResult, WaitOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in WaitInput) (*mcp.CallToolResult, WaitOutput, error) {
 		if in.Owner == "" || in.Repo == "" || in.PR <= 0 {
 			return nil, WaitOutput{}, fmt.Errorf("owner, repo, and pr are required")
 		}
@@ -75,6 +75,10 @@ func waitHandler(
 
 		pollInterval := time.Duration(in.PollIntervalSeconds) * time.Second
 		start := time.Now()
+		ghClient, err := clientProvider(ctx, req)
+		if err != nil {
+			return nil, WaitOutput{}, err
+		}
 
 		// lastData/lastEntry/lastStatus hold the most recent successful poll result.
 		// Reused by TIMEOUT and CANCELLED paths to avoid an extra API call.
@@ -230,6 +234,6 @@ func buildStatusOutput(data *ghclient.ReviewData, entry *store.TriggerEntry, sta
 }
 
 // RegisterWaitTool adds wait_for_copilot_review to the MCP server.
-func RegisterWaitTool(server *mcp.Server, gh *ghclient.Client, db *store.DB) {
-	mcp.AddTool(server, waitTool, waitHandler(gh, db))
+func RegisterWaitTool(server *mcp.Server, clientProvider githubClientProvider, db *store.DB) {
+	mcp.AddTool(server, waitTool, waitHandler(clientProvider, db))
 }

--- a/services/copilot-review-mcp/internal/tools/watch.go
+++ b/services/copilot-review-mcp/internal/tools/watch.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
 	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
 )
 
@@ -136,13 +135,13 @@ var cancelWatchTool = &mcp.Tool{
 func startWatchHandler(
 	manager *watch.Manager,
 ) func(context.Context, *mcp.CallToolRequest, StartReviewWatchInput) (*mcp.CallToolResult, StartReviewWatchOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in StartReviewWatchInput) (*mcp.CallToolResult, StartReviewWatchOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in StartReviewWatchInput) (*mcp.CallToolResult, StartReviewWatchOutput, error) {
 		if in.Owner == "" || in.Repo == "" || in.PR <= 0 {
 			return nil, StartReviewWatchOutput{}, fmt.Errorf("owner, repo, and pr are required")
 		}
 
-		login := middleware.LoginFromContext(ctx)
-		token := middleware.TokenFromContext(ctx)
+		login := loginFromToolRequest(ctx, req)
+		token := tokenFromToolRequest(ctx, req)
 		if login == "" || token == "" {
 			return nil, StartReviewWatchOutput{}, fmt.Errorf("authenticated GitHub login and token are required")
 		}
@@ -171,8 +170,8 @@ func startWatchHandler(
 func getWatchStatusHandler(
 	manager *watch.Manager,
 ) func(context.Context, *mcp.CallToolRequest, GetReviewWatchStatusInput) (*mcp.CallToolResult, GetReviewWatchStatusOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in GetReviewWatchStatusInput) (*mcp.CallToolResult, GetReviewWatchStatusOutput, error) {
-		login := middleware.LoginFromContext(ctx)
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetReviewWatchStatusInput) (*mcp.CallToolResult, GetReviewWatchStatusOutput, error) {
+		login := loginFromToolRequest(ctx, req)
 		if login == "" {
 			return nil, GetReviewWatchStatusOutput{}, fmt.Errorf("authenticated GitHub login is required")
 		}
@@ -208,8 +207,8 @@ func getWatchStatusHandler(
 func listWatchesHandler(
 	manager *watch.Manager,
 ) func(context.Context, *mcp.CallToolRequest, ListReviewWatchesInput) (*mcp.CallToolResult, ListReviewWatchesOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in ListReviewWatchesInput) (*mcp.CallToolResult, ListReviewWatchesOutput, error) {
-		login := middleware.LoginFromContext(ctx)
+	return func(ctx context.Context, req *mcp.CallToolRequest, in ListReviewWatchesInput) (*mcp.CallToolResult, ListReviewWatchesOutput, error) {
+		login := loginFromToolRequest(ctx, req)
 		if login == "" {
 			return nil, ListReviewWatchesOutput{}, fmt.Errorf("authenticated GitHub login is required")
 		}
@@ -258,8 +257,8 @@ func listWatchesHandler(
 func cancelWatchHandler(
 	manager *watch.Manager,
 ) func(context.Context, *mcp.CallToolRequest, CancelReviewWatchInput) (*mcp.CallToolResult, CancelReviewWatchOutput, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in CancelReviewWatchInput) (*mcp.CallToolResult, CancelReviewWatchOutput, error) {
-		login := middleware.LoginFromContext(ctx)
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CancelReviewWatchInput) (*mcp.CallToolResult, CancelReviewWatchOutput, error) {
+		login := loginFromToolRequest(ctx, req)
 		if login == "" {
 			return nil, CancelReviewWatchOutput{}, fmt.Errorf("authenticated GitHub login is required")
 		}


### PR DESCRIPTION
## Summary

- Refactor copilot-review-mcp Streamable HTTP from stateless request-scoped handling to a stateful shared server with MCP sessions.
- Add per-tool GitHub client creation from the current authenticated request header so long-lived sessions do not retain stale tokens.
- Add session/login binding, stateful session tests, and #64 lifecycle notes for the async notification foundation.

## Validation

- `go test ./...` in `services/copilot-review-mcp`
- `go test ./...` in `services/github-oauth-proxy`
- `git diff --check`

Closes #64