### PR TITLE
feat(copilot-review-mcp): watch resource と resources/updated 通知を追加する

### DIFF
--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -116,9 +117,15 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 				if watchManager == nil || req == nil || req.Params == nil {
 					return nil
 				}
-				watchID, err := parseWatchIDFromURI(req.Params.URI)
-				if err != nil {
+				uri := req.Params.URI
+				const watchPrefix = "copilot-review://watch/"
+				if !strings.HasPrefix(uri, watchPrefix) {
 					return nil // not a watch URI; allow subscription for other resource types
+				}
+				// URI has the watch prefix — parse it strictly so malformed URIs are rejected.
+				watchID, err := parseWatchIDFromURI(uri)
+				if err != nil {
+					return mcp.ResourceNotFoundError(uri)
 				}
 				login := middleware.LoginFromContext(ctx)
 				if login == "" {
@@ -126,7 +133,7 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 				}
 				snap, ok := watchManager.GetByID(watchID)
 				if !ok || snap.Login != login {
-					return mcp.ResourceNotFoundError(req.Params.URI)
+					return mcp.ResourceNotFoundError(uri)
 				}
 				return nil
 			},

--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -100,18 +101,32 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 	if inv != nil {
 		invalidate = inv.InvalidateCachedToken
 	}
-	watchManager := watch.NewManager(db, watch.Options{
-		Threshold:       threshold,
-		InvalidateToken: invalidate,
-	})
 
 	clientProvider := newGitHubClientProvider(threshold, invalidate)
 	srv := mcp.NewServer(
 		&mcp.Implementation{Name: "copilot-review-mcp", Version: "1.0.0"},
-		&mcp.ServerOptions{SchemaCache: schemaCache},
+		&mcp.ServerOptions{
+			SchemaCache: schemaCache,
+			SubscribeHandler: func(_ context.Context, _ *mcp.SubscribeRequest) error {
+				return nil
+			},
+			UnsubscribeHandler: func(_ context.Context, _ *mcp.UnsubscribeRequest) error {
+				return nil
+			},
+		},
 	)
+	watchManager := watch.NewManager(db, watch.Options{
+		Threshold:       threshold,
+		InvalidateToken: invalidate,
+		NotifyResourceUpdated: func(uri string) {
+			if err := srv.ResourceUpdated(context.Background(), &mcp.ResourceUpdatedNotificationParams{URI: uri}); err != nil {
+				slog.Warn("resource updated notification failed", "uri", uri, "err", err)
+			}
+		},
+	})
 	RegisterStatusTool(srv, clientProvider, db)
 	RegisterWatchTools(srv, watchManager)
+	RegisterWatchResources(srv, watchManager)
 	RegisterWaitTool(srv, clientProvider, db)
 	RegisterRequestTool(srv, clientProvider, db)
 	RegisterThreadTools(srv, clientProvider)

--- a/services/copilot-review-mcp/internal/tools/server.go
+++ b/services/copilot-review-mcp/internal/tools/server.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -103,11 +104,30 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 	}
 
 	clientProvider := newGitHubClientProvider(threshold, invalidate)
+	// watchManager is declared before srv so the SubscribeHandler closure can reference it
+	// for authorization. At the time any subscribe request arrives the server is already
+	// fully initialized, so watchManager is always non-nil.
+	var watchManager *watch.Manager
 	srv := mcp.NewServer(
 		&mcp.Implementation{Name: "copilot-review-mcp", Version: "1.0.0"},
 		&mcp.ServerOptions{
 			SchemaCache: schemaCache,
-			SubscribeHandler: func(_ context.Context, _ *mcp.SubscribeRequest) error {
+			SubscribeHandler: func(ctx context.Context, req *mcp.SubscribeRequest) error {
+				if watchManager == nil || req == nil || req.Params == nil {
+					return nil
+				}
+				watchID, err := parseWatchIDFromURI(req.Params.URI)
+				if err != nil {
+					return nil // not a watch URI; allow subscription for other resource types
+				}
+				login := middleware.LoginFromContext(ctx)
+				if login == "" {
+					return fmt.Errorf("authenticated GitHub login is required to subscribe")
+				}
+				snap, ok := watchManager.GetByID(watchID)
+				if !ok || snap.Login != login {
+					return mcp.ResourceNotFoundError(req.Params.URI)
+				}
 				return nil
 			},
 			UnsubscribeHandler: func(_ context.Context, _ *mcp.UnsubscribeRequest) error {
@@ -115,7 +135,7 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 			},
 		},
 	)
-	watchManager := watch.NewManager(db, watch.Options{
+	watchManager = watch.NewManager(db, watch.Options{
 		Threshold:       threshold,
 		InvalidateToken: invalidate,
 		NotifyResourceUpdated: func(uri string) {

--- a/services/copilot-review-mcp/internal/tools/watch.go
+++ b/services/copilot-review-mcp/internal/tools/watch.go
@@ -2,11 +2,14 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
 	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
 )
 
@@ -441,4 +444,55 @@ func durationSecondsCeil(d time.Duration) int {
 
 func boolPtr(v bool) *bool {
 	return &v
+}
+
+// RegisterWatchResources registers the watch resource template on the MCP server.
+// Resources are accessible at copilot-review://watch/{watch_id} and return the
+// full ReviewWatchView JSON of the specified watch. Clients may subscribe to
+// receive resources/updated notifications whenever the watch state changes.
+func RegisterWatchResources(server *mcp.Server, manager *watch.Manager) {
+	server.AddResourceTemplate(&mcp.ResourceTemplate{
+		URITemplate: "copilot-review://watch/{watch_id}",
+		Name:        "Copilot Review Watch",
+		Description: "Copilot レビュー watch の現在状態を JSON で返す MCP リソース。" +
+			"watch_id を URI に埋め込んでアクセスする。状態変化時に resources/updated 通知が届く。",
+		MIMEType: "application/json",
+	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		uri := req.Params.URI
+		watchID, err := parseWatchIDFromURI(uri)
+		if err != nil {
+			return nil, mcp.ResourceNotFoundError(uri)
+		}
+		login := middleware.LoginFromContext(ctx)
+		if login == "" {
+			return nil, fmt.Errorf("authenticated GitHub login is required")
+		}
+		snapshot, ok := manager.GetByID(watchID)
+		if !ok || snapshot.Login != login {
+			return nil, mcp.ResourceNotFoundError(uri)
+		}
+		view := buildReviewWatchView(snapshot, manager.PollInterval(), time.Now().UTC())
+		data, err := json.Marshal(view)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal watch view: %w", err)
+		}
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{
+				{URI: uri, Text: string(data), MIMEType: "application/json"},
+			},
+		}, nil
+	})
+}
+
+// parseWatchIDFromURI extracts the watch ID from a copilot-review://watch/{id} URI.
+func parseWatchIDFromURI(uri string) (string, error) {
+	const prefix = "copilot-review://watch/"
+	if !strings.HasPrefix(uri, prefix) {
+		return "", fmt.Errorf("invalid watch URI: %q", uri)
+	}
+	id := strings.TrimPrefix(uri, prefix)
+	if id == "" || strings.ContainsAny(id, "/?#") {
+		return "", fmt.Errorf("invalid watch ID in URI: %q", uri)
+	}
+	return id, nil
 }

--- a/services/copilot-review-mcp/internal/tools/watch.go
+++ b/services/copilot-review-mcp/internal/tools/watch.go
@@ -458,7 +458,13 @@ func RegisterWatchResources(server *mcp.Server, manager *watch.Manager) {
 			"watch_id を URI に埋め込んでアクセスする。状態変化時に resources/updated 通知が届く。",
 		MIMEType: "application/json",
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		if req == nil || req.Params == nil {
+			return nil, fmt.Errorf("missing read resource request params")
+		}
 		uri := req.Params.URI
+		if uri == "" {
+			return nil, fmt.Errorf("missing resource URI")
+		}
 		watchID, err := parseWatchIDFromURI(uri)
 		if err != nil {
 			return nil, mcp.ResourceNotFoundError(uri)

--- a/services/copilot-review-mcp/internal/tools/watch_test.go
+++ b/services/copilot-review-mcp/internal/tools/watch_test.go
@@ -2,9 +2,14 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
 	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
@@ -275,4 +280,150 @@ func (testStaticFetcher) GetReviewData(context.Context, string, string, int) (*g
 		IsCopilotInReviewers: true,
 		RateLimitRemaining:   100,
 	}, nil
+}
+
+// --- Resource tests ---
+
+func TestParseWatchIDFromURI(t *testing.T) {
+	tests := []struct {
+		uri     string
+		want    string
+		wantErr bool
+	}{
+		{uri: "copilot-review://watch/cw_123_1", want: "cw_123_1"},
+		{uri: "copilot-review://watch/abc", want: "abc"},
+		{uri: "copilot-review://watch/", wantErr: true},
+		{uri: "copilot-review://watch/a/b", wantErr: true},
+		{uri: "copilot-review://watch/a?x=1", wantErr: true},
+		{uri: "other://watch/abc", wantErr: true},
+	}
+	for _, tc := range tests {
+		got, err := parseWatchIDFromURI(tc.uri)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseWatchIDFromURI(%q) = %q, nil; want error", tc.uri, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseWatchIDFromURI(%q) error = %v", tc.uri, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseWatchIDFromURI(%q) = %q, want %q", tc.uri, got, tc.want)
+		}
+	}
+}
+
+func TestWatchResourceHandlerScopesWatchIDByLogin(t *testing.T) {
+	db := openWatchToolsTestDB(t)
+	manager := watch.NewManager(db, watch.Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+			return testStaticFetcher{}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(watch.StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    77,
+	})
+	if err != nil {
+		t.Fatalf("manager.Start() error = %v", err)
+	}
+
+	srv := mcp.NewServer(
+		&mcp.Implementation{Name: "test", Version: "0"},
+		&mcp.ServerOptions{
+			SubscribeHandler:   func(_ context.Context, _ *mcp.SubscribeRequest) error { return nil },
+			UnsubscribeHandler: func(_ context.Context, _ *mcp.UnsubscribeRequest) error { return nil },
+		},
+	)
+	RegisterWatchResources(srv, manager)
+
+	uri := *started.ResourceURI
+	ctx := context.WithValue(context.Background(), middleware.ContextKeyLogin, "bob") // different user
+	req := &mcp.ReadResourceRequest{Params: &mcp.ReadResourceParams{URI: uri}}
+	httpHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil)
+	_ = httpHandler
+
+	// Call the resource handler directly via the server's internal path.
+	// We use the MCP SDK's test approach: simulate via the HTTP handler endpoint.
+	// Simpler: verify via manager.GetByID that bob cannot see alice's watch.
+	_, ok := manager.GetByID(started.WatchID)
+	if !ok {
+		t.Fatal("GetByID() = false, want true")
+	}
+	_ = ctx
+	_ = req
+	// Cross-login guard is enforced inside the resource handler; tested indirectly
+	// by confirming that a different login would get ResourceNotFound.
+	// The actual guard is: snapshot.Login != login → ResourceNotFoundError.
+	snap, _ := manager.GetByID(started.WatchID)
+	if snap.Login != "alice" {
+		t.Fatalf("Login = %q, want alice", snap.Login)
+	}
+}
+
+func TestWatchResourceHandlerReturnsJSON(t *testing.T) {
+	db := openWatchToolsTestDB(t)
+	manager := watch.NewManager(db, watch.Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+			return testStaticFetcher{}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(watch.StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    78,
+	})
+	if err != nil {
+		t.Fatalf("manager.Start() error = %v", err)
+	}
+
+	srv := mcp.NewServer(
+		&mcp.Implementation{Name: "test", Version: "0"},
+		&mcp.ServerOptions{
+			SubscribeHandler:   func(_ context.Context, _ *mcp.SubscribeRequest) error { return nil },
+			UnsubscribeHandler: func(_ context.Context, _ *mcp.UnsubscribeRequest) error { return nil },
+		},
+	)
+	RegisterWatchResources(srv, manager)
+
+	uri := *started.ResourceURI
+	if !strings.HasPrefix(uri, "copilot-review://watch/") {
+		t.Fatalf("ResourceURI = %q, want copilot-review://watch/ prefix", uri)
+	}
+
+	// Verify the handler returns valid JSON by calling buildReviewWatchView.
+	snap, ok := manager.GetByID(started.WatchID)
+	if !ok {
+		t.Fatal("GetByID() = false")
+	}
+	view := buildReviewWatchView(snap, manager.PollInterval(), time.Now().UTC())
+	data, err := json.Marshal(view)
+	if err != nil {
+		t.Fatalf("json.Marshal(view) error = %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded["watch_id"] != started.WatchID {
+		t.Errorf("watch_id = %v, want %q", decoded["watch_id"], started.WatchID)
+	}
+	if decoded["owner"] != "octo" {
+		t.Errorf("owner = %v, want octo", decoded["owner"])
+	}
 }

--- a/services/copilot-review-mcp/internal/tools/watch_test.go
+++ b/services/copilot-review-mcp/internal/tools/watch_test.go
@@ -3,11 +3,13 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
@@ -367,6 +369,13 @@ func TestWatchResourceHandlerScopesWatchIDByLogin(t *testing.T) {
 	_, err = cs.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: uri})
 	if err == nil {
 		t.Fatal("ReadResource() = nil error; want ResourceNotFound for cross-login access")
+	}
+	var rpcErr *jsonrpc.Error
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("ReadResource() error type = %T, want *jsonrpc.Error; err = %v", err, err)
+	}
+	if rpcErr.Code != mcp.CodeResourceNotFound {
+		t.Errorf("ReadResource() error code = %d, want %d (CodeResourceNotFound)", rpcErr.Code, mcp.CodeResourceNotFound)
 	}
 }
 

--- a/services/copilot-review-mcp/internal/tools/watch_test.go
+++ b/services/copilot-review-mcp/internal/tools/watch_test.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"context"
 	"encoding/json"
-	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -347,26 +346,27 @@ func TestWatchResourceHandlerScopesWatchIDByLogin(t *testing.T) {
 	RegisterWatchResources(srv, manager)
 
 	uri := *started.ResourceURI
-	ctx := context.WithValue(context.Background(), middleware.ContextKeyLogin, "bob") // different user
-	req := &mcp.ReadResourceRequest{Params: &mcp.ReadResourceParams{URI: uri}}
-	httpHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil)
-	_ = httpHandler
 
-	// Call the resource handler directly via the server's internal path.
-	// We use the MCP SDK's test approach: simulate via the HTTP handler endpoint.
-	// Simpler: verify via manager.GetByID that bob cannot see alice's watch.
-	_, ok := manager.GetByID(started.WatchID)
-	if !ok {
-		t.Fatal("GetByID() = false, want true")
+	// Connect server with "bob" as the authenticated login.
+	ct, st := mcp.NewInMemoryTransports()
+	ctxBob := context.WithValue(context.Background(), middleware.ContextKeyLogin, "bob")
+	ss, err := srv.Connect(ctxBob, st, nil)
+	if err != nil {
+		t.Fatalf("srv.Connect() error = %v", err)
 	}
-	_ = ctx
-	_ = req
-	// Cross-login guard is enforced inside the resource handler; tested indirectly
-	// by confirming that a different login would get ResourceNotFound.
-	// The actual guard is: snapshot.Login != login → ResourceNotFoundError.
-	snap, _ := manager.GetByID(started.WatchID)
-	if snap.Login != "alice" {
-		t.Fatalf("Login = %q, want alice", snap.Login)
+	defer ss.Wait()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	cs, err := client.Connect(context.Background(), ct, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() error = %v", err)
+	}
+	defer cs.Close()
+
+	// Bob should not be able to read Alice's watch resource.
+	_, err = cs.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: uri})
+	if err == nil {
+		t.Fatal("ReadResource() = nil error; want ResourceNotFound for cross-login access")
 	}
 }
 
@@ -406,18 +406,39 @@ func TestWatchResourceHandlerReturnsJSON(t *testing.T) {
 		t.Fatalf("ResourceURI = %q, want copilot-review://watch/ prefix", uri)
 	}
 
-	// Verify the handler returns valid JSON by calling buildReviewWatchView.
-	snap, ok := manager.GetByID(started.WatchID)
-	if !ok {
-		t.Fatal("GetByID() = false")
-	}
-	view := buildReviewWatchView(snap, manager.PollInterval(), time.Now().UTC())
-	data, err := json.Marshal(view)
+	// Connect server with "alice" as the authenticated login.
+	ct, st := mcp.NewInMemoryTransports()
+	ctxAlice := context.WithValue(context.Background(), middleware.ContextKeyLogin, "alice")
+	ss, err := srv.Connect(ctxAlice, st, nil)
 	if err != nil {
-		t.Fatalf("json.Marshal(view) error = %v", err)
+		t.Fatalf("srv.Connect() error = %v", err)
+	}
+	defer ss.Wait()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	cs, err := client.Connect(context.Background(), ct, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() error = %v", err)
+	}
+	defer cs.Close()
+
+	// Alice reads her own watch resource.
+	result, err := cs.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: uri})
+	if err != nil {
+		t.Fatalf("ReadResource() error = %v", err)
+	}
+	if len(result.Contents) != 1 {
+		t.Fatalf("len(Contents) = %d, want 1", len(result.Contents))
+	}
+	c := result.Contents[0]
+	if c.MIMEType != "application/json" {
+		t.Errorf("MIMEType = %q, want application/json", c.MIMEType)
+	}
+	if c.URI != uri {
+		t.Errorf("URI = %q, want %q", c.URI, uri)
 	}
 	var decoded map[string]any
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	if err := json.Unmarshal([]byte(c.Text), &decoded); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 	if decoded["watch_id"] != started.WatchID {

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -731,7 +731,16 @@ func (m *Manager) pollOnce(watchID string) bool {
 	current.status = StatusWatching
 	current.workerRunning = true
 	if err := m.persistOrDegradeLocked(current, StatusWatching, now); err != nil {
+		// persistOrDegradeLocked transitions the watch to a terminal state on error.
+		// Notify subscribers so they don't miss the terminal transition.
+		var notifyURIOnError string
+		if m.notifyResourceUpdated != nil && current.resourceURI != nil {
+			notifyURIOnError = *current.resourceURI
+		}
 		m.mu.Unlock()
+		if notifyURIOnError != "" {
+			go m.notifyResourceUpdated(notifyURIOnError)
+		}
 		return true
 	}
 	var notifyURI string

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -89,6 +89,11 @@ type Options struct {
 	InvalidateToken  func(string)
 	ClientFactory    func(ctx context.Context, token string) ReviewDataFetcher
 	Now              func() time.Time
+	// NotifyResourceUpdated is called asynchronously whenever a watch transitions
+	// state. The uri argument is the resource URI of the changed watch
+	// (e.g. "copilot-review://watch/{id}"). It is safe to call srv.ResourceUpdated
+	// from this callback.
+	NotifyResourceUpdated func(uri string)
 }
 
 // CancelResult reports the outcome of a manual watch cancellation request.
@@ -118,21 +123,22 @@ type watchStore interface {
 
 // Manager owns background review-watch workers for the current server process.
 type Manager struct {
-	db               watchStore
-	threshold        time.Duration
-	pollInterval     time.Duration
-	pollTimeout      time.Duration
-	maxWatchDuration time.Duration
-	clientFactory    func(ctx context.Context, token string) ReviewDataFetcher
-	now              func() time.Time
-	ctx              context.Context
-	cancel           context.CancelFunc
-	idSeq            atomic.Uint64
-	mu               sync.RWMutex
-	watchesByID      map[string]*watchState
-	activeByKey      map[watchKey]string
-	latestByKey      map[watchKey]string
-	closed           bool
+	db                    watchStore
+	threshold             time.Duration
+	pollInterval          time.Duration
+	pollTimeout           time.Duration
+	maxWatchDuration      time.Duration
+	notifyResourceUpdated func(uri string)
+	clientFactory         func(ctx context.Context, token string) ReviewDataFetcher
+	now                   func() time.Time
+	ctx                   context.Context
+	cancel                context.CancelFunc
+	idSeq                 atomic.Uint64
+	mu                    sync.RWMutex
+	watchesByID           map[string]*watchState
+	activeByKey           map[watchKey]string
+	latestByKey           map[watchKey]string
+	closed                bool
 }
 
 type watchKey struct {
@@ -193,18 +199,19 @@ func NewManager(db watchStore, opts Options) *Manager {
 		}
 	}
 	return &Manager{
-		db:               db,
-		threshold:        opts.Threshold,
-		pollInterval:     pollInterval,
-		pollTimeout:      pollTimeout,
-		maxWatchDuration: maxWatchDuration,
-		clientFactory:    clientFactory,
-		now:              now,
-		ctx:              ctx,
-		cancel:           cancel,
-		watchesByID:      make(map[string]*watchState),
-		activeByKey:      make(map[watchKey]string),
-		latestByKey:      make(map[watchKey]string),
+		db:                    db,
+		threshold:             opts.Threshold,
+		pollInterval:          pollInterval,
+		pollTimeout:           pollTimeout,
+		maxWatchDuration:      maxWatchDuration,
+		notifyResourceUpdated: opts.NotifyResourceUpdated,
+		clientFactory:         clientFactory,
+		now:                   now,
+		ctx:                   ctx,
+		cancel:                cancel,
+		watchesByID:           make(map[string]*watchState),
+		activeByKey:           make(map[watchKey]string),
+		latestByKey:           make(map[watchKey]string),
 	}
 }
 
@@ -712,6 +719,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 		m.mu.Unlock()
 		return true
 	}
+	prevReviewStatus := current.reviewStatus
 	m.markPollLocked(current, now)
 	current.reviewStatus = reviewStatusPtr(reviewStatus)
 	current.lastError = nil
@@ -726,7 +734,14 @@ func (m *Manager) pollOnce(watchID string) bool {
 		m.mu.Unlock()
 		return true
 	}
+	var notifyURI string
+	if m.notifyResourceUpdated != nil && current.resourceURI != nil && reviewStatusChanged(prevReviewStatus, &reviewStatus) {
+		notifyURI = *current.resourceURI
+	}
 	m.mu.Unlock()
+	if notifyURI != "" {
+		go m.notifyResourceUpdated(notifyURI)
+	}
 	return false
 }
 
@@ -804,6 +819,10 @@ func (m *Manager) finishLocked(w *watchState, status Status, reason *FailureReas
 	delete(m.activeByKey, w.key)
 	_ = m.persistOrDegradeLocked(w, status, now)
 	w.cancel()
+	if m.notifyResourceUpdated != nil && w.resourceURI != nil {
+		uri := *w.resourceURI
+		go m.notifyResourceUpdated(uri)
+	}
 }
 
 func (m *Manager) nextID() string {
@@ -1038,6 +1057,17 @@ func IsRateLimitHTTPError(err error) bool {
 		return true
 	}
 	return false
+}
+
+// reviewStatusChanged reports whether the review status has changed between prev and curr.
+func reviewStatusChanged(prev *ghclient.ReviewStatus, curr *ghclient.ReviewStatus) bool {
+	if prev == nil && curr == nil {
+		return false
+	}
+	if prev == nil || curr == nil {
+		return true
+	}
+	return *prev != *curr
 }
 
 func watchStatusForReview(status ghclient.ReviewStatus) (Status, bool) {

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -1065,14 +1065,14 @@ func TestManagerNotifyResourceUpdatedCalledOnReviewStatusChange(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	if len(notifiedURIs) == 0 {
-		t.Fatal("NotifyResourceUpdated was never called on review_status change, want at least one call")
+		t.Fatal("NotifyResourceUpdated was never called on review_status change, want exactly one call")
 	}
 	wantURI := resourceURIForWatch(started.WatchID)
 	if notifiedURIs[0] != wantURI {
 		t.Errorf("NotifyResourceUpdated[0] = %q, want %q", notifiedURIs[0], wantURI)
 	}
-	if len(notifiedURIs) > 1 {
-		t.Logf("note: NotifyResourceUpdated called %d times (expected 1 for the nil→PENDING transition)", len(notifiedURIs))
+	if len(notifiedURIs) != 1 {
+		t.Fatalf("NotifyResourceUpdated called %d times, want exactly 1 for the nil→PENDING transition", len(notifiedURIs))
 	}
 }
 

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -939,6 +939,143 @@ func TestFinishFailureWithPollCountsExactlyOnce(t *testing.T) {
 	}
 }
 
+func TestManagerNotifyResourceUpdatedCalledOnTerminal(t *testing.T) {
+	db := openTestDB(t)
+	reviewTime := time.Now().Add(time.Minute)
+
+	var mu sync.Mutex
+	var notifiedURIs []string
+
+	manager := NewManager(db, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{
+						data: &ghclient.ReviewData{
+							LatestCopilotReview: newReview("APPROVED", &reviewTime),
+							RateLimitRemaining:  100,
+						},
+					},
+				},
+			}
+		},
+		NotifyResourceUpdated: func(uri string) {
+			mu.Lock()
+			notifiedURIs = append(notifiedURIs, uri)
+			mu.Unlock()
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    99,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool { return s.Terminal })
+
+	// Allow the goroutine fired inside finishLocked to deliver the notification.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(notifiedURIs)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(notifiedURIs) == 0 {
+		t.Fatal("NotifyResourceUpdated was never called, want at least one call")
+	}
+	wantURI := resourceURIForWatch(started.WatchID)
+	for _, uri := range notifiedURIs {
+		if uri != wantURI {
+			t.Errorf("NotifyResourceUpdated called with URI %q, want %q", uri, wantURI)
+		}
+	}
+}
+
+func TestManagerNotifyResourceUpdatedCalledOnReviewStatusChange(t *testing.T) {
+	db := openTestDB(t)
+
+	var mu sync.Mutex
+	var notifiedURIs []string
+
+	manager := NewManager(db, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					// First poll: PENDING (no review yet)
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+					// Second poll: still PENDING — no status change expected here, but state persisted
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+		NotifyResourceUpdated: func(uri string) {
+			mu.Lock()
+			notifiedURIs = append(notifiedURIs, uri)
+			mu.Unlock()
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    98,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Wait for at least 2 polls so the second non-terminal result is processed.
+	waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool { return s.PollsDone >= 2 })
+
+	// The first poll transitions review_status from nil → PENDING → triggers notification.
+	// The second poll keeps PENDING → no additional notification.
+	// Allow delivery.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(notifiedURIs)
+		mu.Unlock()
+		if n >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(notifiedURIs) == 0 {
+		t.Fatal("NotifyResourceUpdated was never called on review_status change, want at least one call")
+	}
+	wantURI := resourceURIForWatch(started.WatchID)
+	if notifiedURIs[0] != wantURI {
+		t.Errorf("NotifyResourceUpdated[0] = %q, want %q", notifiedURIs[0], wantURI)
+	}
+	if len(notifiedURIs) > 1 {
+		t.Logf("note: NotifyResourceUpdated called %d times (expected 1 for the nil→PENDING transition)", len(notifiedURIs))
+	}
+}
+
 type fetchResult struct {
 	data *ghclient.ReviewData
 	err  error


### PR DESCRIPTION
## 概要

issue #66 を実装する。`copilot-review-mcp` サービスに MCP リソーステンプレートとリソース更新通知を追加する。

## 変更内容

### `watch/manager.go`
- `Options` に `NotifyResourceUpdated func(uri string)` コールバックを追加
- `Manager` 構造体に `notifyResourceUpdated` フィールドを追加し `NewManager` で初期化
- `finishLocked`（terminal 遷移）の末尾でコールバックを goroutine から非同期起動
- `pollOnce` の non-terminal ブロックで `review_status` が変化した場合にコールバックを goroutine から非同期起動
- `reviewStatusChanged` ヘルパー関数を追加

### `tools/server.go`
- `BuildStreamableHandler` で `srv` を `watchManager` より先に生成するよう順序変更
- `ServerOptions` に `SubscribeHandler` / `UnsubscribeHandler` を追加（subscribe 機能を有効化）
- `watch.Options.NotifyResourceUpdated` に `srv.ResourceUpdated` を呼ぶクロージャをセット
- `RegisterWatchResources(srv, watchManager)` を追加

### `tools/watch.go`
- `RegisterWatchResources` 関数を追加
  - URI テンプレート `copilot-review://watch/{watch_id}` を MCP サーバーに登録
  - リソースハンドラで `middleware.LoginFromContext` による login スコープ制御を実装
  - watch 状態を `ReviewWatchView` JSON として返す
- `parseWatchIDFromURI` ヘルパー関数を追加

### テスト追加
- `manager_test.go`: terminal 遷移時の通知テスト、review_status 変化時の通知テスト
- `watch_test.go`: `parseWatchIDFromURI` テーブルテスト、`RegisterWatchResources` が panic しないことの確認、JSON 出力の検証

## 通知条件

| 条件 | 通知 |
|------|------|
| terminal 遷移（COMPLETED / BLOCKED / FAILED / STALE / TIMEOUT / CANCELLED / RATE_LIMITED） | ✅ |
| non-terminal: `review_status` が変化（nil→PENDING 等） | ✅ |
| non-terminal: 同一 `review_status` でポーリングのみ | ❌ (スパム抑制) |

## リソース URI

```
copilot-review://watch/{watch_id}
```

MCP クライアントは `resources/subscribe` で購読し、状態変化時に `notifications/resources/updated` を受け取れる。

Closes #66