### PR TITLE
fix(copilot-review-mcp): stale-guard 誤発火とキャンセル時 completed_at 未更新を修正する

### DIFF
--- a/docs/bug-reports/copilot-review-mcp-stale-guard-anomalies.md
+++ b/docs/bug-reports/copilot-review-mcp-stale-guard-anomalies.md
@@ -200,22 +200,36 @@ WHERE owner = ? AND repo = ? AND pr = ? AND completed_at IS NULL
 こうすることで stale-guard が `!sat.Before(*requestedAt)` = `true` となり、既存のレビューが正しく認識される。
 
 ```go
-// request.go の修正案（requestHandler）
+// request.go の修正案（requestHandler） — 実装済み
 data, err := ghClient.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
 // ...
-// 直近の完了済み Copilot レビューがある場合は、その SubmittedAt を基準とする
-var triggerTime time.Time
+// 直近の完了済み Copilot レビューがある場合は:
+//   1. requested_at = sat+1s (タイムスタンプ基準の後方互換フォールバック用)
+//   2. prev_review_id = 既存レビューの ID (ID 基準の正確な判定用)
 if data.LatestCopilotReview != nil {
-    triggerTime = data.LatestCopilotReview.GetSubmittedAt().Time.Add(-1)
+    sat := data.LatestCopilotReview.GetSubmittedAt().Time
+    if !sat.IsZero() {
+        candidate := sat.UTC().Add(time.Second)
+        latest, _ := db.GetLatest(owner, repo, pr)
+        if latest == nil || candidate.After(latest.RequestedAt) {
+            prevID := fmt.Sprintf("%d", data.LatestCopilotReview.GetID())
+            _, err = db.InsertWithPrevReviewID(owner, repo, pr, "MANUAL", candidate, prevID)
+        } else {
+            _, err = db.Insert(owner, repo, pr, "MANUAL")
+        }
+    } else {
+        _, err = db.Insert(owner, repo, pr, "MANUAL")
+    }
 } else {
-    triggerTime = time.Now()
-}
-if _, err := db.InsertWithTime(owner, repo, pr, "MANUAL", triggerTime); err != nil {
-    // ...
+    _, err = db.Insert(owner, repo, pr, "MANUAL")
 }
 ```
 
-ただし、`db.Insert` がタイムスタンプを外部から受け取れるよう `InsertWithTime` を追加する必要がある。
+`InsertWithPrevReviewID` は `requested_at`（sat+1s）と `prev_review_id`（既存レビューの ID）を  
+同時に `trigger_log` に記録する。`DeriveStatus` は `prevReviewID` が非 nil のとき ID 比較を優先し、  
+nil のときはタイムスタンプ比較にフォールバックする（後方互換）。
+
+ただし、`db.Insert` がタイムスタンプと prev_review_id を外部から受け取れるよう `InsertWithPrevReviewID` を追加する必要がある。
 
 **Option 2: `get_copilot_review_status` に「直近 N 分以内のレビューを無条件で有効」とするフォールバックを追加する**
 

--- a/docs/bug-reports/copilot-review-mcp-stale-guard-anomalies.md
+++ b/docs/bug-reports/copilot-review-mcp-stale-guard-anomalies.md
@@ -1,0 +1,264 @@
+# Bug Report: copilot-review-mcp — stale-guard 起因の異常応答
+
+**作成日**: 2026-04-23  
+**発見契機**: PR #78 (`docs/pr-review-skill-template`) にて `pr-review-cycle` スキルを動作検証した際に観測  
+**対象サービス**: `services/copilot-review-mcp/`  
+**関連ソース**: `internal/github/client.go`, `internal/watch/manager.go`, `internal/tools/status.go`, `internal/tools/request.go`, `internal/tools/cycle.go`
+
+---
+
+## 観測タイムライン（再現エビデンス）
+
+| 時刻 (UTC) | イベント |
+|---|---|
+| `04:55:57Z` | `copilot-pull-request-reviewer[bot]` が PR #78 に `COMMENTED` レビューを提出 |
+| ~`04:56:05Z` | Phase 0: `get_copilot_review_status` 呼び出し → **`NOT_REQUESTED`** |
+| ~`04:56:08Z` | `request_copilot_review` 呼び出し → `{"ok":true,"trigger":"MANUAL"}` |
+| `04:56:11Z` | `start_copilot_review_watch` 開始 / polls_done=1 → `review_status: NOT_REQUESTED` |
+| `04:57:42Z` | polls_done=2 → `review_status: NOT_REQUESTED`（レビューから約2分後も検出せず） |
+| (解決後即時) | `get_pr_review_cycle_status` → `unresolved_count: 5`（全スレッド解決済みなのに） |
+| (再コール) | `get_pr_review_cycle_status` → `unresolved_count: 0`（正常値） |
+
+---
+
+## Bug A: `get_copilot_review_status` が完了済みレビューを `NOT_REQUESTED` で返す
+
+### 症状
+- レビューが `04:55:57Z` に提出済み
+- `04:56:05Z`（8秒後）に `get_copilot_review_status` を呼び出したが `NOT_REQUESTED` が返った
+
+### 根本原因
+`client.go` の `GetReviewData()` → `ListReviews()` (REST API) は、GitHub のバックエンドにおける伝播遅延（数秒〜数十秒）により、直後の呼び出しで空のリストを返す場合がある。
+
+`DeriveStatusWithThreshold` は `data.LatestCopilotReview == nil && !data.IsCopilotInReviewers` の場合に `StatusNotRequested` を返す。レビューが REST API に反映されていない間は、この条件が成立する。
+
+```go
+// client.go: DeriveStatusWithThreshold
+if data.LatestCopilotReview != nil {
+    // ... relevant check ...
+    if relevant {
+        return StatusCompleted  // ← LatestCopilotReview が nil だと到達しない
+    }
+}
+if data.IsCopilotInReviewers {
+    return StatusPending / StatusInProgress
+}
+return StatusNotRequested  // ← フォールスルー
+```
+
+### 影響
+単独では「Phase 0 での誤判定」に留まるが、続く Bug B の引き金となる。
+
+---
+
+## Bug B: `request_copilot_review` 後に stale-guard が永続的に発火し `NOT_REQUESTED` に固着する
+
+### 症状
+- `request_copilot_review` 呼び出し後、ウォッチが 2 回ポーリングしても `review_status: NOT_REQUESTED`
+- 04:57:42Z の時点では既に完了から約 2 分が経過しているにもかかわらず検出されない
+
+### 根本原因（コードで確認済み）
+
+`request_copilot_review` は無条件に `db.Insert(owner, repo, pr, "MANUAL")` を呼び出す（`request.go` L78）。  
+このとき `RequestedAt = now()` が記録される。
+
+```go
+// request.go
+if _, err := db.Insert(in.Owner, in.Repo, in.PR, "MANUAL"); err != nil {
+    return nil, RequestOutput{}, ...
+}
+```
+
+レビューが `04:55:57Z` に提出済みで、`request_copilot_review` が `~04:56:08Z` に呼ばれた場合：
+
+```
+RequestedAt = 04:56:08Z
+LatestCopilotReview.SubmittedAt = 04:55:57Z
+
+// DeriveStatusWithThreshold の stale-guard:
+relevant = !sat.IsZero() && !sat.Before(*requestedAt)
+         = !(04:55:57Z.Before(04:56:08Z))
+         = !true
+         = false  ← 完了済みレビューが「古い」とみなされる
+```
+
+`relevant = false` となるため、完了済みレビューが無視される。  
+さらに `IsCopilotInReviewers` もレビュー提出後は `false`（提出後はレビュアーリストから削除される）のため、  
+**すべての経路で `StatusNotRequested` が返り続ける**。
+
+ウォッチワーカー（`manager.go`）も同じ `DeriveStatusWithThreshold` を使うため同様の結果となる（L667）。
+
+```go
+// manager.go: pollOnce
+entry, err = m.db.GetLatest(w.key.owner, w.key.repo, w.key.pr)
+var requestedAt *time.Time
+if entry != nil {
+    requestedAt = &entry.RequestedAt  // ← 上書きされた後の RequestedAt が使われる
+}
+reviewStatus := ghclient.DeriveStatusWithThreshold(m.threshold, data, requestedAt)
+```
+
+### 発生条件
+1. Copilot がレビューを自動提出する（auto-trigger または既存リクエスト）
+2. `get_copilot_review_status` の呼び出しが GitHub REST API 伝播前（Bug A）または完了直後に行われ、`NOT_REQUESTED` が返る
+3. スキルの Phase 0 ロジックが `NOT_REQUESTED` に反応して `request_copilot_review` を呼び出す
+4. `request_copilot_review` が DB に `RequestedAt > SubmittedAt` なエントリを挿入する
+5. 以降の全ポーリングで stale-guard が発火し、`NOT_REQUESTED` に固着する
+
+### カスケード効果
+この状態が続くと：
+- スキルが再度 `request_copilot_review` を呼び出そうとする（`HasPending()` は `true` なので拒否されるが、ウォッチキャンセル後の特定タイミングによっては通過するリスクがある → Bug C の仮説 2 参照）
+- ウォッチが `TIMEOUT` まで `NOT_REQUESTED` を返し続ける
+- `trigger_log.completed_at` はウォッチキャンセル時に更新されない（後述の Bug D）
+
+### Bug D: ウォッチキャンセル時に `trigger_log.completed_at` が更新されない
+
+`CancelByID` / `CancelLatest` は `finishLocked(StatusCancelled)` を呼ぶが、  
+`db.UpdateCompletedAt` を呼ばないため `trigger_log.completed_at = NULL` のままになる。
+
+```go
+// manager.go: CancelByID
+m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
+// UpdateCompletedAt は呼ばれない
+```
+
+結果として `HasPending() = true` が維持されるため、ウォッチキャンセル後に  
+`request_copilot_review` を呼ぼうとすると `REVIEW_IN_PROGRESS` で拒否される。  
+これは二重リクエスト防止の観点では安全だが、**正しく完了した場合とキャンセルした場合で  
+DB 状態が区別できない**という別の問題を生む。新規リクエストを送るには手動での DB クリーンアップが必要。
+
+---
+
+## Bug C: `get_pr_review_cycle_status` が直後の呼び出しで古い `unresolved_count` を返す
+
+### 症状
+- 5 件のスレッドを `reply_and_resolve_review_thread` で順次解決（全件 `resolved: true`）
+- 即時呼び出しした `get_pr_review_cycle_status` → `merge_conditions.unresolved_count: 5`
+- 数分後に再呼び出し → `unresolved_count: 0`
+
+### 根本原因仮説 1: GitHub GraphQL API の伝播遅延（有力）
+`cycle.go` の `cycleStatusHandler` は `gh.GetReviewThreads()` で GitHub GraphQL API からスレッド状態を取得する。  
+`reply_and_resolve_review_thread` がスレッドを解決した直後は、GraphQL API のキャッシュ/伝播遅延により、  
+解決済みスレッドが `IsResolved: false` のまま返ることがある。
+
+```go
+// cycle.go
+rawThreads, err := gh.GetReviewThreads(ctx, in.Owner, in.Repo, in.PR)
+for _, t := range rawThreads {
+    if !t.IsResolved {
+        unresolvedCount++  // ← GraphQL が古いキャッシュを返すと誤カウントされる
+    }
+}
+```
+
+### 根本原因仮説 2: Bug B 起因の二重レビューリクエスト（要調査）
+
+Bug B によりウォッチが `NOT_REQUESTED` に固着している間、スキルが再度 `request_copilot_review` を呼び出した場合、  
+**ウォッチキャンセル後のタイミング**によっては 2 回目のリクエストが受け付けられる可能性がある。
+
+コード確認による検証：
+
+```go
+// manager.go: CancelByID / CancelLatest
+m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
+// ↑ UpdateCompletedAt を呼ばない → trigger_log.completed_at = NULL のまま
+```
+
+```go
+// store/db.go: HasPending
+SELECT COUNT(*) FROM trigger_log
+WHERE owner = ? AND repo = ? AND pr = ? AND completed_at IS NULL
+// ↑ キャンセル後も completed_at = NULL → HasPending() = true
+```
+
+**現時点での結論**: ウォッチをキャンセルしても `trigger_log.completed_at` は更新されないため、  
+`HasPending()` は `true` を返し続ける。よって 2 回目の `request_copilot_review` は  
+`REVIEW_IN_PROGRESS` で拒否されるはず。PR #78 の観測では仮説 2 は成立しない可能性が高い。
+
+ただし、以下の **エッジケース** では二重発火が起こりうる（未検証）：
+- `trigger_log` エントリが存在しない状態でウォッチが走っている場合（AUTO trigger 等で DB 未記録）
+- ウォッチ開始前に別のパスで `completed_at` が更新された場合
+
+**この点は仮説 1 と合わせて再現テストで確認が必要。**
+
+### 影響
+- `recommended_action: REPLY_RESOLVE` という誤った推奨が返る
+- スキルが不要な解決処理を再実行しようとする（ただし、`reply_and_resolve` はべき等なので二重解決の実害は小さい）
+- 即時リトライで正しい値が返るため、単体では軽微なバグ
+- **ただし二重レビューが発火していた場合は、新規スレッドが 5 件追加されたことになり、重大度が上がる**
+
+---
+
+## 修正案
+
+### Bug A・B への修正候補
+
+**Option 1（推奨）: `request_copilot_review` が直前の完了済みレビューを確認して `RequestedAt` を調整する**
+
+`request_copilot_review` を呼び出す直前に `GetReviewData()` を取得している（既存コード）。  
+ここで `LatestCopilotReview` が存在する場合は、そのレビューの `SubmittedAt` を `RequestedAt` として記録する（または `SubmittedAt - 1ns`）。  
+こうすることで stale-guard が `!sat.Before(*requestedAt)` = `true` となり、既存のレビューが正しく認識される。
+
+```go
+// request.go の修正案（requestHandler）
+data, err := ghClient.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
+// ...
+// 直近の完了済み Copilot レビューがある場合は、その SubmittedAt を基準とする
+var triggerTime time.Time
+if data.LatestCopilotReview != nil {
+    triggerTime = data.LatestCopilotReview.GetSubmittedAt().Time.Add(-1)
+} else {
+    triggerTime = time.Now()
+}
+if _, err := db.InsertWithTime(owner, repo, pr, "MANUAL", triggerTime); err != nil {
+    // ...
+}
+```
+
+ただし、`db.Insert` がタイムスタンプを外部から受け取れるよう `InsertWithTime` を追加する必要がある。
+
+**Option 2: `get_copilot_review_status` に「直近 N 分以内のレビューを無条件で有効」とするフォールバックを追加する**
+
+`DeriveStatusWithThreshold` で `relevant = false` になった場合でも、  
+レビューが直近 N 分以内（例: 10 分）に提出されたなら `COMPLETED` を返すフォールバックを設ける。  
+ただし、このアプローチは stale-guard の意図（古いレビューを無視する）を弱める。
+
+**Option 3（最小修正）: スキル側のワークアラウンド**
+
+Phase 0 で `NOT_REQUESTED` が返った場合、`request_copilot_review` を呼ぶ前に GitHub のレビューリスト（`{GH}:get_pull_request_reviews`）を直接確認し、  
+完了済みレビューがあれば Phase 2 に移行する。本修正が実装されるまでのワークアラウンドとして `docs/skills/pr-review-cycle.md` に記載する。
+
+### Bug C への修正候補
+
+**Option 1（推奨）: `get_pr_review_cycle_status` に短い wait またはリトライを追加する**
+
+スレッド解決直後の呼び出しに対しては、1〜2 秒待機後にリトライすることで伝播を待つ。
+
+**Option 2: スキル側のワークアラウンド**
+
+`recommended_action: REPLY_RESOLVE` が返ったが、全スレッドを直前に解決した場合は、  
+数秒待ってから再呼び出しする。`unresolved_count > 0` でも `reply_and_resolve_review_thread` はべき等なため、  
+即座に再解決しても実害はないが、不必要な API 呼び出しを省ける。
+
+---
+
+## 関連ファイル
+
+| ファイル | 関連度 |
+|---|---|
+| [services/copilot-review-mcp/internal/tools/request.go](../../services/copilot-review-mcp/internal/tools/request.go) | Bug B の直接原因 (`db.Insert` のタイミング) |
+| [services/copilot-review-mcp/internal/github/client.go](../../services/copilot-review-mcp/internal/github/client.go) | Bug A・B (`GetReviewData`, `DeriveStatusWithThreshold`) |
+| [services/copilot-review-mcp/internal/watch/manager.go](../../services/copilot-review-mcp/internal/watch/manager.go) | Bug B のウォッチワーカー側 (`pollOnce` L603–L700) |
+| [services/copilot-review-mcp/internal/tools/cycle.go](../../services/copilot-review-mcp/internal/tools/cycle.go) | Bug C (`GetReviewThreads` 直後の伝播遅延) |
+| [services/copilot-review-mcp/internal/tools/status.go](../../services/copilot-review-mcp/internal/tools/status.go) | Bug A の呼び出し元 |
+
+---
+
+## 優先度
+
+| Bug | 重大度 | 再現性 | 優先度 |
+|---|---|---|---|
+| **Bug B** (stale-guard 固着) | 高 — ウォッチが永続的に `NOT_REQUESTED` になる | 中（Copilot の自動提出タイミング依存） | **高** |
+| **Bug A** (REST 伝播遅延) | 中 — Bug B の引き金。単体では一時的な誤値 | 中 | 中 |
+| **Bug D** (キャンセル時 `completed_at` 未更新) | 中 — 次のリクエストが `REVIEW_IN_PROGRESS` で拒否され続ける | 高（キャンセルするたびに必ず発生） | 中 |
+| **Bug C** (GraphQL キャッシュ遅延) | 低〜高 — 単純な伝播遅延なら軽微。二重レビュー発火なら高 | 高（再現容易） | 中（要調査） |

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -174,23 +174,33 @@ func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber
 
 // DeriveStatus resolves the ReviewStatus from raw data and optional trigger_log requestedAt.
 // requestedAt is nil when no trigger_log entry exists (AUTO trigger or not yet recorded).
-func (c *Client) DeriveStatus(data *ReviewData, requestedAt *time.Time) ReviewStatus {
-	return DeriveStatusWithThreshold(c.threshold, data, requestedAt)
+// prevReviewID, when non-nil, enables ID-based staleness detection: the existing review is
+// treated as stale only if its ID matches prevReviewID (same review seen before the request).
+func (c *Client) DeriveStatus(data *ReviewData, requestedAt *time.Time, prevReviewID *string) ReviewStatus {
+	return DeriveStatusWithThreshold(c.threshold, data, requestedAt, prevReviewID)
 }
 
 // DeriveStatusWithThreshold resolves the ReviewStatus from raw data and an elapsed threshold.
-func DeriveStatusWithThreshold(threshold time.Duration, data *ReviewData, requestedAt *time.Time) ReviewStatus {
+// prevReviewID, when non-nil, enables ID-based staleness detection (see DeriveStatus).
+func DeriveStatusWithThreshold(threshold time.Duration, data *ReviewData, requestedAt *time.Time, prevReviewID *string) ReviewStatus {
 	if data.LatestCopilotReview != nil {
 		// When requestedAt is known, only treat this review as relevant if it was submitted
-		// at or after the request time. This prevents a stale pre-existing review from being
-		// mistaken for the result of the current request.
-		// - Use !Before (≥) instead of After (>) to include same-second events.
-		// - nil submittedAt means the review has no timestamp → treat as stale.
+		// at or after the request time, or (when prevReviewID is set) if its ID differs from
+		// the review that existed when the request was made.
 		relevant := true
 		if requestedAt != nil {
-			sat := data.LatestCopilotReview.GetSubmittedAt()
-			// IsZero means no timestamp recorded → treat as stale.
-			relevant = !sat.IsZero() && !sat.Before(*requestedAt)
+			if prevReviewID != nil {
+				// ID-based: relevant only if this is a different review from when the
+				// request was made. Same ID means the old review is still present (stale).
+				currentID := strconv.FormatInt(data.LatestCopilotReview.GetID(), 10)
+				relevant = currentID != *prevReviewID
+			} else {
+				// Timestamp-based fallback for entries without prevReviewID (backward compat).
+				// - Use !Before (≥) instead of After (>) to include same-second events.
+				// - nil submittedAt means the review has no timestamp → treat as stale.
+				sat := data.LatestCopilotReview.GetSubmittedAt()
+				relevant = !sat.IsZero() && !sat.Before(*requestedAt)
+			}
 		}
 		if relevant {
 			if data.LatestCopilotReview.GetState() == "CHANGES_REQUESTED" {

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -111,6 +111,12 @@ func NewClient(ctx context.Context, token string, threshold time.Duration, inval
 	}
 }
 
+// NewWithClients creates a Client from pre-built REST and GraphQL API clients.
+// Intended for tests that need to inject mock HTTP servers in place of api.github.com.
+func NewWithClients(gh *github.Client, v4 *githubv4.Client, threshold time.Duration) *Client {
+	return &Client{gh: gh, v4: v4, threshold: threshold}
+}
+
 // GetReviewData fetches raw reviewer and review data for a PR from GitHub.
 func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber int) (*ReviewData, error) {
 	data := &ReviewData{}

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -320,8 +320,6 @@ func TestDeriveStatusIDBasedStaleness(t *testing.T) {
 	}
 
 	oldID := "42"
-	newIDStr := "99"
-	_ = newIDStr
 
 	tests := []struct {
 		name         string
@@ -364,11 +362,12 @@ func TestDeriveStatusIDBasedStaleness(t *testing.T) {
 		},
 		{
 			// nil prevReviewID with requestedAt → timestamp-based fallback (backward compat).
-			name:         "nil prevReviewID → timestamp-based fallback, recent review → COMPLETED",
+			// newReviewWithID does not set SubmittedAt, so sat.IsZero() == true → stale → NOT_REQUESTED.
+			name:         "nil prevReviewID, no SubmittedAt → timestamp fallback → NOT_REQUESTED (stale)",
 			data:         &ReviewData{LatestCopilotReview: newReviewWithID(99, "APPROVED")},
 			requestedAt:  &now,
 			prevReviewID: nil,
-			want:         StatusNotRequested, // review has no SubmittedAt → nil → stale
+			want:         StatusNotRequested,
 		},
 	}
 

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -295,7 +295,86 @@ func TestDeriveStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := c.DeriveStatus(tt.data, tt.requestedAt)
+			got := c.DeriveStatus(tt.data, tt.requestedAt, nil)
+			if got != tt.want {
+				t.Errorf("DeriveStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDeriveStatusIDBasedStaleness verifies the ID-based staleness detection path:
+// when prevReviewID is non-nil, DeriveStatus compares review IDs instead of timestamps.
+func TestDeriveStatusIDBasedStaleness(t *testing.T) {
+	c := &Client{threshold: 30 * time.Second}
+
+	now := time.Now()
+	recentRequest := now.Add(-time.Second) // within threshold
+
+	// Helper to build a review with a specific ID and state.
+	newReviewWithID := func(id int64, state string) *github.PullRequestReview {
+		return &github.PullRequestReview{
+			ID:    github.Ptr(id),
+			State: github.Ptr(state),
+		}
+	}
+
+	oldID := "42"
+	newIDStr := "99"
+	_ = newIDStr
+
+	tests := []struct {
+		name         string
+		data         *ReviewData
+		requestedAt  *time.Time
+		prevReviewID *string
+		want         ReviewStatus
+	}{
+		{
+			// Same ID as prevReviewID → old review is stale → NOT_REQUESTED.
+			name:         "same ID as prevReviewID, no reviewers → NOT_REQUESTED (stale)",
+			data:         &ReviewData{LatestCopilotReview: newReviewWithID(42, "APPROVED")},
+			requestedAt:  &recentRequest,
+			prevReviewID: &oldID,
+			want:         StatusNotRequested,
+		},
+		{
+			// Same ID but Copilot is in reviewers (pending new review) → PENDING.
+			name:         "same ID as prevReviewID, copilot in reviewers, within threshold → PENDING",
+			data:         &ReviewData{IsCopilotInReviewers: true, LatestCopilotReview: newReviewWithID(42, "APPROVED")},
+			requestedAt:  &recentRequest,
+			prevReviewID: &oldID,
+			want:         StatusPending,
+		},
+		{
+			// Different ID → new review → COMPLETED.
+			name:         "different ID from prevReviewID → COMPLETED",
+			data:         &ReviewData{LatestCopilotReview: newReviewWithID(99, "APPROVED")},
+			requestedAt:  &recentRequest,
+			prevReviewID: &oldID,
+			want:         StatusCompleted,
+		},
+		{
+			// Different ID, CHANGES_REQUESTED → BLOCKED.
+			name:         "different ID, CHANGES_REQUESTED → BLOCKED",
+			data:         &ReviewData{LatestCopilotReview: newReviewWithID(99, "CHANGES_REQUESTED")},
+			requestedAt:  &recentRequest,
+			prevReviewID: &oldID,
+			want:         StatusBlocked,
+		},
+		{
+			// nil prevReviewID with requestedAt → timestamp-based fallback (backward compat).
+			name:         "nil prevReviewID → timestamp-based fallback, recent review → COMPLETED",
+			data:         &ReviewData{LatestCopilotReview: newReviewWithID(99, "APPROVED")},
+			requestedAt:  &now,
+			prevReviewID: nil,
+			want:         StatusNotRequested, // review has no SubmittedAt → nil → stale
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.DeriveStatus(tt.data, tt.requestedAt, tt.prevReviewID)
 			if got != tt.want {
 				t.Errorf("DeriveStatus() = %q, want %q", got, tt.want)
 			}

--- a/services/copilot-review-mcp/internal/store/db.go
+++ b/services/copilot-review-mcp/internal/store/db.go
@@ -5,7 +5,6 @@ package store
 import (
 	"database/sql"
 	"fmt"
-	"strings"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -79,9 +78,35 @@ func Open(path string) (*DB, error) {
 		return nil, err
 	}
 	// Migration: add prev_review_id column for ID-based review staleness detection.
-	// Idempotent: SQLite returns "duplicate column name" when already applied.
-	if _, err := db.Exec(`ALTER TABLE trigger_log ADD COLUMN prev_review_id TEXT`); err != nil {
-		if !strings.Contains(err.Error(), "duplicate column name") {
+	// Use PRAGMA table_info to check existence first; this avoids relying on SQLite
+	// driver error message text ("duplicate column name") which can vary by version.
+	var colExists bool
+	rows, err := db.Query(`PRAGMA table_info(trigger_log)`)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migration check table_info: %w", err)
+	}
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notNull, pk int
+		var dfltValue interface{}
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
+			rows.Close()
+			db.Close()
+			return nil, fmt.Errorf("migration scan table_info: %w", err)
+		}
+		if name == "prev_review_id" {
+			colExists = true
+			break
+		}
+	}
+	if err := rows.Close(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migration close table_info rows: %w", err)
+	}
+	if !colExists {
+		if _, err := db.Exec(`ALTER TABLE trigger_log ADD COLUMN prev_review_id TEXT`); err != nil {
 			db.Close()
 			return nil, fmt.Errorf("migration add prev_review_id: %w", err)
 		}
@@ -104,10 +129,10 @@ func (d *DB) Close() error { return d.db.Close() }
 // TriggerEntry is a row from trigger_log.
 type TriggerEntry struct {
 	ID           int64
-	Trigger      string     // "MANUAL" or "AUTO"
-	RequestedAt  time.Time  // when the review was requested
+	Trigger      string    // "MANUAL" or "AUTO"
+	RequestedAt  time.Time // when the review was requested
 	CompletedAt  *time.Time
-	PrevReviewID *string    // ID of the Copilot review that existed when the request was made (nil for backward compat)
+	PrevReviewID *string // ID of the Copilot review that existed when the request was made (nil for backward compat)
 }
 
 // ReviewWatchEntry is a persisted watch snapshot in review_watch.

--- a/services/copilot-review-mcp/internal/store/db.go
+++ b/services/copilot-review-mcp/internal/store/db.go
@@ -143,8 +143,11 @@ func (d *DB) Insert(owner, repo string, pr int, trigger string) (int64, error) {
 }
 
 // InsertWithTime adds a new trigger_log entry with an explicit requested_at timestamp
-// and returns the assigned ID. Use this when the logical request time differs from
-// wall-clock now (e.g. to back-date past an existing Copilot review submission).
+// and returns the assigned ID. The timestamp is stored at epoch-second precision;
+// sub-second components are truncated by the conversion to Unix seconds. Use this
+// when the logical request time must align with an existing event timestamp (e.g.
+// a Copilot review's SubmittedAt) so the stale-guard in DeriveStatusWithThreshold
+// passes on the next status check.
 func (d *DB) InsertWithTime(owner, repo string, pr int, trigger string, requestedAt time.Time) (int64, error) {
 	res, err := d.db.Exec(
 		`INSERT INTO trigger_log (owner, repo, pr, trigger, requested_at) VALUES (?, ?, ?, ?, ?)`,

--- a/services/copilot-review-mcp/internal/store/db.go
+++ b/services/copilot-review-mcp/internal/store/db.go
@@ -142,6 +142,20 @@ func (d *DB) Insert(owner, repo string, pr int, trigger string) (int64, error) {
 	return res.LastInsertId()
 }
 
+// InsertWithTime adds a new trigger_log entry with an explicit requested_at timestamp
+// and returns the assigned ID. Use this when the logical request time differs from
+// wall-clock now (e.g. to back-date past an existing Copilot review submission).
+func (d *DB) InsertWithTime(owner, repo string, pr int, trigger string, requestedAt time.Time) (int64, error) {
+	res, err := d.db.Exec(
+		`INSERT INTO trigger_log (owner, repo, pr, trigger, requested_at) VALUES (?, ?, ?, ?, ?)`,
+		owner, repo, pr, trigger, requestedAt.UTC().Unix(),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
 // GetLatest returns the most recent trigger_log entry for the given PR,
 // or nil if none exists.
 func (d *DB) GetLatest(owner, repo string, pr int) (*TriggerEntry, error) {

--- a/services/copilot-review-mcp/internal/store/db.go
+++ b/services/copilot-review-mcp/internal/store/db.go
@@ -4,6 +4,8 @@ package store
 
 import (
 	"database/sql"
+	"fmt"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -76,6 +78,14 @@ func Open(path string) (*DB, error) {
 		db.Close()
 		return nil, err
 	}
+	// Migration: add prev_review_id column for ID-based review staleness detection.
+	// Idempotent: SQLite returns "duplicate column name" when already applied.
+	if _, err := db.Exec(`ALTER TABLE trigger_log ADD COLUMN prev_review_id TEXT`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			db.Close()
+			return nil, fmt.Errorf("migration add prev_review_id: %w", err)
+		}
+	}
 	if _, err := db.Exec(reviewWatchLookupIndexSQL); err != nil {
 		db.Close()
 		return nil, err
@@ -93,10 +103,11 @@ func (d *DB) Close() error { return d.db.Close() }
 
 // TriggerEntry is a row from trigger_log.
 type TriggerEntry struct {
-	ID          int64
-	Trigger     string    // "MANUAL" or "AUTO"
-	RequestedAt time.Time // when the review was requested
-	CompletedAt *time.Time
+	ID           int64
+	Trigger      string     // "MANUAL" or "AUTO"
+	RequestedAt  time.Time  // when the review was requested
+	CompletedAt  *time.Time
+	PrevReviewID *string    // ID of the Copilot review that existed when the request was made (nil for backward compat)
 }
 
 // ReviewWatchEntry is a persisted watch snapshot in review_watch.
@@ -159,11 +170,28 @@ func (d *DB) InsertWithTime(owner, repo string, pr int, trigger string, requeste
 	return res.LastInsertId()
 }
 
+// InsertWithPrevReviewID adds a new trigger_log entry with an explicit requested_at timestamp
+// and the ID of the Copilot review that existed when the request was made.
+// prevReviewID enables ID-based staleness detection in DeriveStatusWithThreshold:
+// if the current review has the same ID, it is the old review (stale);
+// a different ID means Copilot has submitted a new review.
+// The timestamp is stored at epoch-second precision (sub-second components truncated).
+func (d *DB) InsertWithPrevReviewID(owner, repo string, pr int, trigger string, requestedAt time.Time, prevReviewID string) (int64, error) {
+	res, err := d.db.Exec(
+		`INSERT INTO trigger_log (owner, repo, pr, trigger, requested_at, prev_review_id) VALUES (?, ?, ?, ?, ?, ?)`,
+		owner, repo, pr, trigger, requestedAt.UTC().Unix(), prevReviewID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
 // GetLatest returns the most recent trigger_log entry for the given PR,
 // or nil if none exists.
 func (d *DB) GetLatest(owner, repo string, pr int) (*TriggerEntry, error) {
 	row := d.db.QueryRow(
-		`SELECT id, trigger, requested_at, completed_at
+		`SELECT id, trigger, requested_at, completed_at, prev_review_id
 		 FROM trigger_log
 		 WHERE owner = ? AND repo = ? AND pr = ?
 		 ORDER BY requested_at DESC, id DESC
@@ -173,7 +201,8 @@ func (d *DB) GetLatest(owner, repo string, pr int) (*TriggerEntry, error) {
 	var e TriggerEntry
 	var requestedAtUnix int64
 	var completedAtUnix sql.NullInt64
-	if err := row.Scan(&e.ID, &e.Trigger, &requestedAtUnix, &completedAtUnix); err != nil {
+	var prevReviewID sql.NullString
+	if err := row.Scan(&e.ID, &e.Trigger, &requestedAtUnix, &completedAtUnix, &prevReviewID); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
@@ -183,6 +212,9 @@ func (d *DB) GetLatest(owner, repo string, pr int) (*TriggerEntry, error) {
 	if completedAtUnix.Valid {
 		t := time.Unix(completedAtUnix.Int64, 0)
 		e.CompletedAt = &t
+	}
+	if prevReviewID.Valid {
+		e.PrevReviewID = &prevReviewID.String
 	}
 	return &e, nil
 }

--- a/services/copilot-review-mcp/internal/store/db_test.go
+++ b/services/copilot-review-mcp/internal/store/db_test.go
@@ -379,6 +379,68 @@ func TestOpenRebuildsReviewWatchLookupIndex(t *testing.T) {
 	}
 }
 
+func TestInsertWithTimePersistsAtEpochSecondPrecision(t *testing.T) {
+	db := openTestDB(t, filepath.Join(t.TempDir(), "trigger-insert-with-time.db"))
+
+	// Insert with sub-second precision; stored epoch-second should truncate downward.
+	base := time.Now().UTC().Truncate(time.Second)
+	if _, err := db.InsertWithTime("octo", "demo", 1, "MANUAL", base.Add(500*time.Millisecond)); err != nil {
+		t.Fatalf("InsertWithTime() error = %v", err)
+	}
+
+	entry, err := db.GetLatest("octo", "demo", 1)
+	if err != nil {
+		t.Fatalf("GetLatest() error = %v", err)
+	}
+	if entry == nil {
+		t.Fatal("GetLatest() = nil, want entry")
+	}
+	if !entry.RequestedAt.Equal(base) {
+		t.Fatalf("RequestedAt = %v, want %v (epoch-second truncation)", entry.RequestedAt, base)
+	}
+}
+
+func TestInsertWithTimeNewerRowWinsGetLatest(t *testing.T) {
+	db := openTestDB(t, filepath.Join(t.TempDir(), "trigger-insert-ordering.db"))
+
+	base := time.Now().UTC().Truncate(time.Second)
+	older := base.Add(-time.Minute)
+	newer := base
+
+	// Insert the older entry first.
+	if _, err := db.InsertWithTime("octo", "demo", 2, "MANUAL", older); err != nil {
+		t.Fatalf("InsertWithTime(older) error = %v", err)
+	}
+	// Mark it completed so HasPending = false.
+	olderEntry, err := db.GetLatest("octo", "demo", 2)
+	if err != nil || olderEntry == nil {
+		t.Fatalf("GetLatest(older) err = %v, entry = %v", err, olderEntry)
+	}
+	if err := db.UpdateCompletedAt(olderEntry.ID); err != nil {
+		t.Fatalf("UpdateCompletedAt() error = %v", err)
+	}
+
+	// Insert a newer pending entry.
+	if _, err := db.InsertWithTime("octo", "demo", 2, "MANUAL", newer); err != nil {
+		t.Fatalf("InsertWithTime(newer) error = %v", err)
+	}
+
+	// GetLatest must return the newer (pending) row.
+	entry, err := db.GetLatest("octo", "demo", 2)
+	if err != nil {
+		t.Fatalf("GetLatest() error = %v", err)
+	}
+	if entry == nil {
+		t.Fatal("GetLatest() = nil, want newer entry")
+	}
+	if !entry.RequestedAt.Equal(newer) {
+		t.Fatalf("RequestedAt = %v, want %v (newer entry)", entry.RequestedAt, newer)
+	}
+	if entry.CompletedAt != nil {
+		t.Fatal("CompletedAt = non-nil, want nil (newer entry is pending)")
+	}
+}
+
 func openTestDB(t *testing.T, path string) *DB {
 	t.Helper()
 

--- a/services/copilot-review-mcp/internal/tools/cycle.go
+++ b/services/copilot-review-mcp/internal/tools/cycle.go
@@ -212,10 +212,12 @@ func cycleStatusHandler(
 		}
 
 		var requestedAt *time.Time
+		var prevReviewID *string
 		if entry != nil {
 			requestedAt = &entry.RequestedAt
+			prevReviewID = entry.PrevReviewID
 		}
-		reviewStatus := gh.DeriveStatus(reviewData, requestedAt)
+		reviewStatus := gh.DeriveStatus(reviewData, requestedAt, prevReviewID)
 
 		// ── Elapsed time since last Copilot comment ───────────────────────────
 		elapsedMinutes := 0

--- a/services/copilot-review-mcp/internal/tools/request.go
+++ b/services/copilot-review-mcp/internal/tools/request.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -79,8 +80,26 @@ func requestHandler(
 
 		// Record the MANUAL trigger. This must succeed so future HasPending
 		// checks can prevent duplicate review requests.
-		if _, err := db.Insert(in.Owner, in.Repo, in.PR, "MANUAL"); err != nil {
-			return nil, RequestOutput{}, fmt.Errorf("copilot review requested successfully, but failed to record MANUAL trigger: %w", err)
+		//
+		// If a Copilot review was already submitted before this call (e.g. due to
+		// GitHub REST API propagation delay causing get_copilot_review_status to
+		// return NOT_REQUESTED for a completed review), set requested_at to just
+		// before the review's SubmittedAt. This prevents the stale-guard in
+		// DeriveStatusWithThreshold from treating the existing review as stale
+		// (relevant = !SubmittedAt.Before(requestedAt) would otherwise be false).
+		var insertErr error
+		if data.LatestCopilotReview != nil {
+			sat := data.LatestCopilotReview.GetSubmittedAt().Time
+			if !sat.IsZero() {
+				_, insertErr = db.InsertWithTime(in.Owner, in.Repo, in.PR, "MANUAL", sat.Add(-time.Nanosecond))
+			} else {
+				_, insertErr = db.Insert(in.Owner, in.Repo, in.PR, "MANUAL")
+			}
+		} else {
+			_, insertErr = db.Insert(in.Owner, in.Repo, in.PR, "MANUAL")
+		}
+		if insertErr != nil {
+			return nil, RequestOutput{}, fmt.Errorf("copilot review requested successfully, but failed to record MANUAL trigger: %w", insertErr)
 		}
 
 		return nil, RequestOutput{

--- a/services/copilot-review-mcp/internal/tools/request.go
+++ b/services/copilot-review-mcp/internal/tools/request.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -80,26 +81,30 @@ func requestHandler(
 		// Record the MANUAL trigger. This must succeed so future HasPending
 		// checks can prevent duplicate review requests.
 		//
-		// Bug B fix: If a Copilot review already exists (e.g. due to GitHub REST
-		// propagation delay causing get_copilot_review_status to return NOT_REQUESTED
-		// for a completed review), align requested_at with SubmittedAt so the
-		// stale-guard in DeriveStatusWithThreshold passes. Only backdate when the
-		// review post-dates every known trigger_log entry; if the review predates a
-		// prior completed entry the review is genuinely stale and a fresh entry is
-		// correct.
+		// Bug B fix: If a Copilot review already exists, set requested_at to
+		// sat+1s (one second after the existing review's SubmittedAt) so that:
+		//   • the existing review (SubmittedAt = sat) is NOT immediately relevant
+		//     (stale-guard: sat < sat+1s = requestedAt → NOT_REQUESTED/PENDING, not COMPLETED)
+		//   • any new review Copilot posts with SubmittedAt >= sat+1s WILL be relevant
+		//     (stale-guard passes → COMPLETED)
+		// The +1s offset aligns with epoch-second DB storage precision and is safe
+		// because Copilot takes at least several seconds to process a review.
+		//
+		// Guard: only use InsertWithTime when the candidate (sat+1s) is newer than
+		// every prior trigger_log entry; otherwise fall back to Insert(now()) so that
+		// GetLatest() continues to return the most-recent row.
 		var insertErr error
 		if data.LatestCopilotReview != nil {
 			sat := data.LatestCopilotReview.GetSubmittedAt().Time
 			if !sat.IsZero() {
+				candidate := sat.UTC().Add(time.Second)
 				latest, latestErr := db.GetLatest(in.Owner, in.Repo, in.PR)
 				if latestErr != nil {
 					return nil, RequestOutput{}, fmt.Errorf("failed to read trigger_log: %w", latestErr)
 				}
-				if latest == nil || sat.After(latest.RequestedAt) {
-					// Review post-dates all known requests: set requested_at = SubmittedAt
-					// (epoch-second precision) so the stale-guard (!sat.Before(requestedAt))
-					// passes without rounding artefacts.
-					_, insertErr = db.InsertWithTime(in.Owner, in.Repo, in.PR, "MANUAL", sat.UTC())
+				if latest == nil || candidate.After(latest.RequestedAt) {
+					// candidate is the most-recent logical request time: use it.
+					_, insertErr = db.InsertWithTime(in.Owner, in.Repo, in.PR, "MANUAL", candidate)
 				} else {
 					_, insertErr = db.Insert(in.Owner, in.Repo, in.PR, "MANUAL")
 				}

--- a/services/copilot-review-mcp/internal/tools/request.go
+++ b/services/copilot-review-mcp/internal/tools/request.go
@@ -82,17 +82,18 @@ func requestHandler(
 		// checks can prevent duplicate review requests.
 		//
 		// Bug B fix: If a Copilot review already exists, set requested_at to
-		// sat+1s (one second after the existing review's SubmittedAt) so that:
-		//   • the existing review (SubmittedAt = sat) is NOT immediately relevant
-		//     (stale-guard: sat < sat+1s = requestedAt → NOT_REQUESTED/PENDING, not COMPLETED)
-		//   • any new review Copilot posts with SubmittedAt >= sat+1s WILL be relevant
-		//     (stale-guard passes → COMPLETED)
-		// The +1s offset aligns with epoch-second DB storage precision and is safe
-		// because Copilot takes at least several seconds to process a review.
+		// sat+1s (one second after the existing review's SubmittedAt) and record
+		// the existing review's ID as prev_review_id so that:
+		//   • the existing review (same ID) is NOT immediately relevant
+		//     (ID-based check: currentID == prevReviewID → stale)
+		//   • any new review Copilot posts (different ID) WILL be relevant
+		//     (ID-based check: currentID != prevReviewID → COMPLETED)
+		// The +1s offset is kept as a timestamp-based fallback for entries
+		// that pre-date this feature (prevReviewID == nil).
 		//
-		// Guard: only use InsertWithTime when the candidate (sat+1s) is newer than
-		// every prior trigger_log entry; otherwise fall back to Insert(now()) so that
-		// GetLatest() continues to return the most-recent row.
+		// Guard: only use InsertWithPrevReviewID when the candidate (sat+1s) is
+		// newer than every prior trigger_log entry; otherwise fall back to
+		// Insert(now()) so that GetLatest() continues to return the most-recent row.
 		var insertErr error
 		if data.LatestCopilotReview != nil {
 			sat := data.LatestCopilotReview.GetSubmittedAt().Time
@@ -103,8 +104,10 @@ func requestHandler(
 					return nil, RequestOutput{}, fmt.Errorf("failed to read trigger_log: %w", latestErr)
 				}
 				if latest == nil || candidate.After(latest.RequestedAt) {
-					// candidate is the most-recent logical request time: use it.
-					_, insertErr = db.InsertWithTime(in.Owner, in.Repo, in.PR, "MANUAL", candidate)
+					// candidate is the most-recent logical request time: record both
+					// sat+1s and the current review ID for ID-based staleness detection.
+					prevID := fmt.Sprintf("%d", data.LatestCopilotReview.GetID())
+					_, insertErr = db.InsertWithPrevReviewID(in.Owner, in.Repo, in.PR, "MANUAL", candidate, prevID)
 				} else {
 					_, insertErr = db.Insert(in.Owner, in.Repo, in.PR, "MANUAL")
 				}

--- a/services/copilot-review-mcp/internal/tools/request.go
+++ b/services/copilot-review-mcp/internal/tools/request.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -81,17 +80,29 @@ func requestHandler(
 		// Record the MANUAL trigger. This must succeed so future HasPending
 		// checks can prevent duplicate review requests.
 		//
-		// If a Copilot review was already submitted before this call (e.g. due to
-		// GitHub REST API propagation delay causing get_copilot_review_status to
-		// return NOT_REQUESTED for a completed review), set requested_at to just
-		// before the review's SubmittedAt. This prevents the stale-guard in
-		// DeriveStatusWithThreshold from treating the existing review as stale
-		// (relevant = !SubmittedAt.Before(requestedAt) would otherwise be false).
+		// Bug B fix: If a Copilot review already exists (e.g. due to GitHub REST
+		// propagation delay causing get_copilot_review_status to return NOT_REQUESTED
+		// for a completed review), align requested_at with SubmittedAt so the
+		// stale-guard in DeriveStatusWithThreshold passes. Only backdate when the
+		// review post-dates every known trigger_log entry; if the review predates a
+		// prior completed entry the review is genuinely stale and a fresh entry is
+		// correct.
 		var insertErr error
 		if data.LatestCopilotReview != nil {
 			sat := data.LatestCopilotReview.GetSubmittedAt().Time
 			if !sat.IsZero() {
-				_, insertErr = db.InsertWithTime(in.Owner, in.Repo, in.PR, "MANUAL", sat.Add(-time.Nanosecond))
+				latest, latestErr := db.GetLatest(in.Owner, in.Repo, in.PR)
+				if latestErr != nil {
+					return nil, RequestOutput{}, fmt.Errorf("failed to read trigger_log: %w", latestErr)
+				}
+				if latest == nil || sat.After(latest.RequestedAt) {
+					// Review post-dates all known requests: set requested_at = SubmittedAt
+					// (epoch-second precision) so the stale-guard (!sat.Before(requestedAt))
+					// passes without rounding artefacts.
+					_, insertErr = db.InsertWithTime(in.Owner, in.Repo, in.PR, "MANUAL", sat.UTC())
+				} else {
+					_, insertErr = db.Insert(in.Owner, in.Repo, in.PR, "MANUAL")
+				}
 			} else {
 				_, insertErr = db.Insert(in.Owner, in.Repo, in.PR, "MANUAL")
 			}

--- a/services/copilot-review-mcp/internal/tools/request_test.go
+++ b/services/copilot-review-mcp/internal/tools/request_test.go
@@ -70,9 +70,9 @@ func staticProvider(c *ghclient.Client) githubClientProvider {
 
 // TestRequestHandlerUsesInsertWithTimeWhenReviewPostdatesAllEntries verifies Bug B
 // fix: when LatestCopilotReview.SubmittedAt post-dates every existing trigger_log entry,
-// requestHandler calls InsertWithTime with (SubmittedAt + 1s) so that:
-//   - the existing review is NOT immediately relevant (stale-guard does not fire)
-//   - any new review Copilot posts (SubmittedAt >= requestedAt) WILL be relevant
+// requestHandler calls InsertWithPrevReviewID with (SubmittedAt+1s, prevID) so that:
+//   - the existing review is stale (sat < sat+1s = requestedAt → stale-guard rejects it as irrelevant)
+//   - any new review Copilot posts (different ID, or SubmittedAt ≥ sat+1s) passes the check → COMPLETED
 func TestRequestHandlerUsesInsertWithTimeWhenReviewPostdatesAllEntries(t *testing.T) {
 	submittedAt := time.Now().UTC().Add(-5 * time.Second).Truncate(time.Second)
 	srv := newGitHubAPIMock(t, submittedAt)
@@ -101,15 +101,19 @@ func TestRequestHandlerUsesInsertWithTimeWhenReviewPostdatesAllEntries(t *testin
 		t.Fatal("GetLatest() = nil, want trigger_log entry")
 	}
 
-	// InsertWithTime is called with sat+1s; epoch-second storage truncates sub-seconds.
+	// InsertWithPrevReviewID is called with sat+1s; epoch-second storage truncates sub-seconds.
 	// submittedAt is already truncated so want = submittedAt + 1s exactly.
 	want := submittedAt.Add(time.Second)
 	if !entry.RequestedAt.Equal(want) {
-		t.Fatalf("RequestedAt = %v, want %v (SubmittedAt+1s via InsertWithTime)", entry.RequestedAt, want)
+		t.Fatalf("RequestedAt = %v, want %v (SubmittedAt+1s via InsertWithPrevReviewID)", entry.RequestedAt, want)
 	}
-	// Stale-guard must NOT fire immediately: submittedAt < requestedAt (old review is stale).
+	// Stale-guard must reject the existing review: submittedAt < requestedAt (old review is stale).
 	if !submittedAt.Before(entry.RequestedAt) {
-		t.Fatalf("stale-guard fires immediately: SubmittedAt(%v) >= RequestedAt(%v), old review would be seen as COMPLETED", submittedAt, entry.RequestedAt)
+		t.Fatalf("existing review is NOT stale: SubmittedAt(%v) >= RequestedAt(%v), old review would be immediately relevant (COMPLETED)", submittedAt, entry.RequestedAt)
+	}
+	// PrevReviewID must be recorded for ID-based staleness detection.
+	if entry.PrevReviewID == nil {
+		t.Fatal("PrevReviewID = nil, want non-nil (ID-based staleness detection requires prev_review_id)")
 	}
 }
 

--- a/services/copilot-review-mcp/internal/tools/request_test.go
+++ b/services/copilot-review-mcp/internal/tools/request_test.go
@@ -1,0 +1,172 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v72/github"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/shurcooL/githubv4"
+
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
+	"github.com/scottlz0310/copilot-review-mcp/internal/store"
+)
+
+// newGitHubAPIMock builds a minimal httptest.Server that serves the three GitHub
+// API calls issued by requestHandler:
+//  1. GET …/requested_reviewers  → empty list (Copilot not in reviewers)
+//  2. GET …/reviews              → single Copilot review with the given submittedAt
+//  3. POST / (GraphQL)           → PR node ID query + requestReviewsByLogin mutation
+func newGitHubAPIMock(t *testing.T, submittedAt time.Time) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "1000")
+		switch {
+		case strings.Contains(r.URL.Path, "/requested_reviewers") && r.Method == http.MethodGet:
+			fmt.Fprint(w, `{"users":[],"teams":[]}`)
+		case strings.Contains(r.URL.Path, "/reviews") && r.Method == http.MethodGet:
+			fmt.Fprintf(w, `[{"id":1,"user":{"login":"copilot-pull-request-reviewer[bot]"},"state":"APPROVED","submitted_at":%q}]`,
+				submittedAt.UTC().Format(time.RFC3339))
+		default:
+			// GraphQL: distinguish node-ID query from requestReviewsByLogin mutation by
+			// looking for the mutation field name in the query body. The node-ID query
+			// contains "repository" in the query string but NOT "requestReviewsByLogin".
+			// The mutation body always contains "requestReviewsByLogin" as the operation.
+			body, _ := io.ReadAll(r.Body)
+			if strings.Contains(string(body), "requestReviewsByLogin") {
+				fmt.Fprint(w, `{"data":{"requestReviewsByLogin":{"clientMutationId":""}}}`)
+			} else {
+				fmt.Fprint(w, `{"data":{"repository":{"pullRequest":{"id":"PR_test123"}}}}`)
+			}
+		}
+	}))
+}
+
+// makeGitHubClient creates a *ghclient.Client that routes all API calls to srv.
+func makeGitHubClient(srv *httptest.Server) *ghclient.Client {
+	restClient := github.NewClient(srv.Client())
+	base, _ := url.Parse(srv.URL + "/")
+	restClient.BaseURL = base
+	restClient.UploadURL = base
+	gqlClient := githubv4.NewEnterpriseClient(srv.URL, srv.Client())
+	return ghclient.NewWithClients(restClient, gqlClient, 30*time.Second)
+}
+
+// staticProvider returns a githubClientProvider that always returns the given client.
+func staticProvider(c *ghclient.Client) githubClientProvider {
+	return func(_ context.Context, _ *mcp.CallToolRequest) (*ghclient.Client, error) {
+		return c, nil
+	}
+}
+
+// TestRequestHandlerUsesInsertWithTimeWhenReviewPostdatesAllEntries verifies Bug B
+// fix: when LatestCopilotReview.SubmittedAt post-dates every existing trigger_log entry,
+// requestHandler calls InsertWithTime so that GetLatest().RequestedAt == SubmittedAt.
+// The stale-guard condition (!SubmittedAt.Before(RequestedAt)) must therefore be true.
+func TestRequestHandlerUsesInsertWithTimeWhenReviewPostdatesAllEntries(t *testing.T) {
+	submittedAt := time.Now().UTC().Add(-5 * time.Second).Truncate(time.Second)
+	srv := newGitHubAPIMock(t, submittedAt)
+	t.Cleanup(srv.Close)
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "req-insert-with-time.db"))
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := requestHandler(staticProvider(makeGitHubClient(srv)), db)
+	_, out, err := handler(context.Background(), nil, RequestInput{Owner: "octo", Repo: "demo", PR: 1})
+	if err != nil {
+		t.Fatalf("requestHandler() error = %v", err)
+	}
+	if !out.OK {
+		t.Fatalf("requestHandler() OK = false, reason = %q", out.Reason)
+	}
+
+	entry, err := db.GetLatest("octo", "demo", 1)
+	if err != nil {
+		t.Fatalf("GetLatest() error = %v", err)
+	}
+	if entry == nil {
+		t.Fatal("GetLatest() = nil, want trigger_log entry")
+	}
+
+	// InsertWithTime stores at epoch-second precision; submittedAt is already truncated.
+	if !entry.RequestedAt.Equal(submittedAt) {
+		t.Fatalf("RequestedAt = %v, want %v (SubmittedAt via InsertWithTime)", entry.RequestedAt, submittedAt)
+	}
+	// Stale-guard invariant: SubmittedAt >= RequestedAt.
+	if submittedAt.Before(entry.RequestedAt) {
+		t.Fatalf("stale-guard would fire: SubmittedAt(%v) < RequestedAt(%v)", submittedAt, entry.RequestedAt)
+	}
+}
+
+// TestRequestHandlerFallsBackToNormalInsertWhenReviewPredatesExistingEntry verifies
+// that when the Copilot review is older than a prior completed trigger_log entry,
+// requestHandler uses the normal Insert (requested_at = now()) so that the new row
+// remains the most-recent entry returned by GetLatest().
+func TestRequestHandlerFallsBackToNormalInsertWhenReviewPredatesExistingEntry(t *testing.T) {
+	// The GitHub review is older than the pre-existing DB entry.
+	priorEntryTime := time.Now().UTC().Add(-30 * time.Second).Truncate(time.Second)
+	olderReviewTime := priorEntryTime.Add(-time.Minute) // review happened before the prior entry
+
+	srv := newGitHubAPIMock(t, olderReviewTime)
+	t.Cleanup(srv.Close)
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "req-fallback-insert.db"))
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Pre-insert a completed entry that is newer than the Copilot review.
+	if _, err := db.InsertWithTime("octo", "demo", 2, "MANUAL", priorEntryTime); err != nil {
+		t.Fatalf("InsertWithTime(priorEntry) error = %v", err)
+	}
+	priorEntry, err := db.GetLatest("octo", "demo", 2)
+	if err != nil || priorEntry == nil {
+		t.Fatalf("GetLatest(priorEntry): err = %v, entry = %v", err, priorEntry)
+	}
+	if err := db.UpdateCompletedAt(priorEntry.ID); err != nil {
+		t.Fatalf("UpdateCompletedAt(priorEntry) error = %v", err)
+	}
+
+	before := time.Now().UTC().Truncate(time.Second)
+	handler := requestHandler(staticProvider(makeGitHubClient(srv)), db)
+	_, out, err := handler(context.Background(), nil, RequestInput{Owner: "octo", Repo: "demo", PR: 2})
+	after := time.Now().UTC().Add(time.Second)
+	if err != nil {
+		t.Fatalf("requestHandler() error = %v", err)
+	}
+	if !out.OK {
+		t.Fatalf("requestHandler() OK = false, reason = %q", out.Reason)
+	}
+
+	entry, err := db.GetLatest("octo", "demo", 2)
+	if err != nil {
+		t.Fatalf("GetLatest() error = %v", err)
+	}
+	if entry == nil {
+		t.Fatal("GetLatest() = nil, want trigger_log entry")
+	}
+	// Normal Insert uses now(): RequestedAt must be in [before, after].
+	if entry.RequestedAt.Before(before) {
+		t.Fatalf("RequestedAt = %v, want >= %v (normal Insert, not InsertWithTime)", entry.RequestedAt, before)
+	}
+	if entry.RequestedAt.After(after) {
+		t.Fatalf("RequestedAt = %v, want <= %v", entry.RequestedAt, after)
+	}
+	// The new entry must be pending (completed_at = nil).
+	if entry.CompletedAt != nil {
+		t.Fatal("CompletedAt = non-nil, want nil for the fresh pending entry")
+	}
+}

--- a/services/copilot-review-mcp/internal/tools/request_test.go
+++ b/services/copilot-review-mcp/internal/tools/request_test.go
@@ -70,8 +70,9 @@ func staticProvider(c *ghclient.Client) githubClientProvider {
 
 // TestRequestHandlerUsesInsertWithTimeWhenReviewPostdatesAllEntries verifies Bug B
 // fix: when LatestCopilotReview.SubmittedAt post-dates every existing trigger_log entry,
-// requestHandler calls InsertWithTime so that GetLatest().RequestedAt == SubmittedAt.
-// The stale-guard condition (!SubmittedAt.Before(RequestedAt)) must therefore be true.
+// requestHandler calls InsertWithTime with (SubmittedAt + 1s) so that:
+//   - the existing review is NOT immediately relevant (stale-guard does not fire)
+//   - any new review Copilot posts (SubmittedAt >= requestedAt) WILL be relevant
 func TestRequestHandlerUsesInsertWithTimeWhenReviewPostdatesAllEntries(t *testing.T) {
 	submittedAt := time.Now().UTC().Add(-5 * time.Second).Truncate(time.Second)
 	srv := newGitHubAPIMock(t, submittedAt)
@@ -100,13 +101,15 @@ func TestRequestHandlerUsesInsertWithTimeWhenReviewPostdatesAllEntries(t *testin
 		t.Fatal("GetLatest() = nil, want trigger_log entry")
 	}
 
-	// InsertWithTime stores at epoch-second precision; submittedAt is already truncated.
-	if !entry.RequestedAt.Equal(submittedAt) {
-		t.Fatalf("RequestedAt = %v, want %v (SubmittedAt via InsertWithTime)", entry.RequestedAt, submittedAt)
+	// InsertWithTime is called with sat+1s; epoch-second storage truncates sub-seconds.
+	// submittedAt is already truncated so want = submittedAt + 1s exactly.
+	want := submittedAt.Add(time.Second)
+	if !entry.RequestedAt.Equal(want) {
+		t.Fatalf("RequestedAt = %v, want %v (SubmittedAt+1s via InsertWithTime)", entry.RequestedAt, want)
 	}
-	// Stale-guard invariant: SubmittedAt >= RequestedAt.
-	if submittedAt.Before(entry.RequestedAt) {
-		t.Fatalf("stale-guard would fire: SubmittedAt(%v) < RequestedAt(%v)", submittedAt, entry.RequestedAt)
+	// Stale-guard must NOT fire immediately: submittedAt < requestedAt (old review is stale).
+	if !submittedAt.Before(entry.RequestedAt) {
+		t.Fatalf("stale-guard fires immediately: SubmittedAt(%v) >= RequestedAt(%v), old review would be seen as COMPLETED", submittedAt, entry.RequestedAt)
 	}
 }
 

--- a/services/copilot-review-mcp/internal/tools/status.go
+++ b/services/copilot-review-mcp/internal/tools/status.go
@@ -73,11 +73,13 @@ func statusHandler(
 		}
 
 		var requestedAt *time.Time
+		var prevReviewID *string
 		if entry != nil {
 			requestedAt = &entry.RequestedAt
+			prevReviewID = entry.PrevReviewID
 		}
 
-		status := ghClient.DeriveStatus(data, requestedAt)
+		status := ghClient.DeriveStatus(data, requestedAt, prevReviewID)
 
 		// Auto-update completed_at when the review is done.
 		if (status == ghclient.StatusCompleted || status == ghclient.StatusBlocked) &&

--- a/services/copilot-review-mcp/internal/tools/wait.go
+++ b/services/copilot-review-mcp/internal/tools/wait.go
@@ -121,10 +121,12 @@ func waitHandler(
 					return nil, WaitOutput{}, fmt.Errorf("failed to get latest entry (RATE_LIMITED): %w", err)
 				}
 				var reqAt *time.Time
+				var prevReviewID *string
 				if entry != nil {
 					reqAt = &entry.RequestedAt
+					prevReviewID = entry.PrevReviewID
 				}
-				partialStatus := ghClient.DeriveStatus(data, reqAt)
+				partialStatus := ghClient.DeriveStatus(data, reqAt, prevReviewID)
 				rs := buildStatusOutput(data, entry, partialStatus)
 				return nil, WaitOutput{
 					Status:        "RATE_LIMITED",
@@ -143,11 +145,13 @@ func waitHandler(
 			}
 
 			var requestedAt *time.Time
+			var prevReviewID *string
 			if entry != nil {
 				requestedAt = &entry.RequestedAt
+				prevReviewID = entry.PrevReviewID
 			}
 
-			status := ghClient.DeriveStatus(data, requestedAt)
+			status := ghClient.DeriveStatus(data, requestedAt, prevReviewID)
 
 			// Auto-update completed_at.
 			if (status == ghclient.StatusCompleted || status == ghclient.StatusBlocked) &&

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -497,20 +497,26 @@ func (m *Manager) CancelByID(login, watchID string) (CancelResult, error) {
 			return CancelResult{Snapshot: snapshot, Found: true}, nil
 		}
 		now := m.now().UTC()
-		// Mark the associated trigger_log entry as completed so HasPending returns
-		// false after cancellation, allowing a new review request to be issued.
+		// Extract triggerLogID before releasing the lock; DB update happens
+		// outside the lock to avoid blocking the manager mutex during SQLite
+		// write operations.
+		var cancelByIDTriggerLogID *int64
 		if m.db != nil && state.triggerLogID != nil {
-			if err := m.db.UpdateCompletedAt(*state.triggerLogID); err != nil {
-				slog.Warn("CancelByID: failed to update trigger_log completed_at",
-					"watch_id", watchID,
-					"trigger_log_id", *state.triggerLogID,
-					"error", err,
-				)
-			}
+			id := *state.triggerLogID
+			cancelByIDTriggerLogID = &id
 		}
 		m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
 		snapshot := snapshotFromState(state)
 		m.mu.Unlock()
+		if cancelByIDTriggerLogID != nil {
+			if err := m.db.UpdateCompletedAt(*cancelByIDTriggerLogID); err != nil {
+				slog.Warn("CancelByID: failed to update trigger_log completed_at",
+					"watch_id", watchID,
+					"trigger_log_id", *cancelByIDTriggerLogID,
+					"error", err,
+				)
+			}
+		}
 		return CancelResult{Snapshot: snapshot, Found: true, Cancelled: true}, nil
 	}
 	m.mu.Unlock()
@@ -548,20 +554,26 @@ func (m *Manager) CancelLatest(login, owner, repo string, pr int) (CancelResult,
 				return CancelResult{Snapshot: snapshot, Found: true}, nil
 			}
 			now := m.now().UTC()
-			// Mark the associated trigger_log entry as completed so HasPending returns
-			// false after cancellation, allowing a new review request to be issued.
+			// Extract triggerLogID before releasing the lock; DB update happens
+			// outside the lock to avoid blocking the manager mutex during SQLite
+			// write operations.
+			var cancelLatestTriggerLogID *int64
 			if m.db != nil && state.triggerLogID != nil {
-				if err := m.db.UpdateCompletedAt(*state.triggerLogID); err != nil {
-					slog.Warn("CancelLatest: failed to update trigger_log completed_at",
-						"owner", owner, "repo", repo, "pr", pr,
-						"trigger_log_id", *state.triggerLogID,
-						"error", err,
-					)
-				}
+				id := *state.triggerLogID
+				cancelLatestTriggerLogID = &id
 			}
 			m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
 			snapshot := snapshotFromState(state)
 			m.mu.Unlock()
+			if cancelLatestTriggerLogID != nil {
+				if err := m.db.UpdateCompletedAt(*cancelLatestTriggerLogID); err != nil {
+					slog.Warn("CancelLatest: failed to update trigger_log completed_at",
+						"owner", owner, "repo", repo, "pr", pr,
+						"trigger_log_id", *cancelLatestTriggerLogID,
+						"error", err,
+					)
+				}
+			}
 			return CancelResult{Snapshot: snapshot, Found: true, Cancelled: true}, nil
 		}
 		delete(m.activeByKey, key)

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -500,19 +500,19 @@ func (m *Manager) CancelByID(login, watchID string) (CancelResult, error) {
 		// Extract triggerLogID before releasing the lock; DB update happens
 		// outside the lock to avoid blocking the manager mutex during SQLite
 		// write operations.
-		var cancelByIDTriggerLogID *int64
-		if m.db != nil && state.triggerLogID != nil {
-			id := *state.triggerLogID
-			cancelByIDTriggerLogID = &id
+		var cancelByIDTriggerLogID int64
+		hasCancelByIDTriggerLogID := m.db != nil && state.triggerLogID != nil
+		if hasCancelByIDTriggerLogID {
+			cancelByIDTriggerLogID = *state.triggerLogID
 		}
 		m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
 		snapshot := snapshotFromState(state)
 		m.mu.Unlock()
-		if cancelByIDTriggerLogID != nil {
-			if err := m.db.UpdateCompletedAt(*cancelByIDTriggerLogID); err != nil {
+		if hasCancelByIDTriggerLogID {
+			if err := m.db.UpdateCompletedAt(cancelByIDTriggerLogID); err != nil {
 				slog.Warn("CancelByID: failed to update trigger_log completed_at",
 					"watch_id", watchID,
-					"trigger_log_id", *cancelByIDTriggerLogID,
+					"trigger_log_id", cancelByIDTriggerLogID,
 					"error", err,
 				)
 			}
@@ -557,19 +557,19 @@ func (m *Manager) CancelLatest(login, owner, repo string, pr int) (CancelResult,
 			// Extract triggerLogID before releasing the lock; DB update happens
 			// outside the lock to avoid blocking the manager mutex during SQLite
 			// write operations.
-			var cancelLatestTriggerLogID *int64
-			if m.db != nil && state.triggerLogID != nil {
-				id := *state.triggerLogID
-				cancelLatestTriggerLogID = &id
+			var cancelLatestTriggerLogID int64
+			hasCancelLatestTriggerLogID := m.db != nil && state.triggerLogID != nil
+			if hasCancelLatestTriggerLogID {
+				cancelLatestTriggerLogID = *state.triggerLogID
 			}
 			m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
 			snapshot := snapshotFromState(state)
 			m.mu.Unlock()
-			if cancelLatestTriggerLogID != nil {
-				if err := m.db.UpdateCompletedAt(*cancelLatestTriggerLogID); err != nil {
+			if hasCancelLatestTriggerLogID {
+				if err := m.db.UpdateCompletedAt(cancelLatestTriggerLogID); err != nil {
 					slog.Warn("CancelLatest: failed to update trigger_log completed_at",
 						"owner", owner, "repo", repo, "pr", pr,
-						"trigger_log_id", *cancelLatestTriggerLogID,
+						"trigger_log_id", cancelLatestTriggerLogID,
 						"error", err,
 					)
 				}
@@ -695,10 +695,12 @@ func (m *Manager) pollOnce(watchID string) bool {
 	}
 
 	var requestedAt *time.Time
+	var prevReviewID *string
 	if entry != nil {
 		requestedAt = &entry.RequestedAt
+		prevReviewID = entry.PrevReviewID
 	}
-	reviewStatus := ghclient.DeriveStatusWithThreshold(m.threshold, data, requestedAt)
+	reviewStatus := ghclient.DeriveStatusWithThreshold(m.threshold, data, requestedAt, prevReviewID)
 
 	if data.RateLimitRemaining < 10 {
 		m.mu.Lock()

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -500,7 +500,13 @@ func (m *Manager) CancelByID(login, watchID string) (CancelResult, error) {
 		// Mark the associated trigger_log entry as completed so HasPending returns
 		// false after cancellation, allowing a new review request to be issued.
 		if m.db != nil && state.triggerLogID != nil {
-			_ = m.db.UpdateCompletedAt(*state.triggerLogID)
+			if err := m.db.UpdateCompletedAt(*state.triggerLogID); err != nil {
+				slog.Warn("CancelByID: failed to update trigger_log completed_at",
+					"watch_id", watchID,
+					"trigger_log_id", *state.triggerLogID,
+					"error", err,
+				)
+			}
 		}
 		m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
 		snapshot := snapshotFromState(state)
@@ -545,7 +551,13 @@ func (m *Manager) CancelLatest(login, owner, repo string, pr int) (CancelResult,
 			// Mark the associated trigger_log entry as completed so HasPending returns
 			// false after cancellation, allowing a new review request to be issued.
 			if m.db != nil && state.triggerLogID != nil {
-				_ = m.db.UpdateCompletedAt(*state.triggerLogID)
+				if err := m.db.UpdateCompletedAt(*state.triggerLogID); err != nil {
+					slog.Warn("CancelLatest: failed to update trigger_log completed_at",
+						"owner", owner, "repo", repo, "pr", pr,
+						"trigger_log_id", *state.triggerLogID,
+						"error", err,
+					)
+				}
 			}
 			m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
 			snapshot := snapshotFromState(state)

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -497,6 +497,11 @@ func (m *Manager) CancelByID(login, watchID string) (CancelResult, error) {
 			return CancelResult{Snapshot: snapshot, Found: true}, nil
 		}
 		now := m.now().UTC()
+		// Mark the associated trigger_log entry as completed so HasPending returns
+		// false after cancellation, allowing a new review request to be issued.
+		if m.db != nil && state.triggerLogID != nil {
+			_ = m.db.UpdateCompletedAt(*state.triggerLogID)
+		}
 		m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
 		snapshot := snapshotFromState(state)
 		m.mu.Unlock()
@@ -537,6 +542,11 @@ func (m *Manager) CancelLatest(login, owner, repo string, pr int) (CancelResult,
 				return CancelResult{Snapshot: snapshot, Found: true}, nil
 			}
 			now := m.now().UTC()
+			// Mark the associated trigger_log entry as completed so HasPending returns
+			// false after cancellation, allowing a new review request to be issued.
+			if m.db != nil && state.triggerLogID != nil {
+				_ = m.db.UpdateCompletedAt(*state.triggerLogID)
+			}
 			m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
 			snapshot := snapshotFromState(state)
 			m.mu.Unlock()

--- a/services/copilot-review-mcp/internal/watch/manager_test.go
+++ b/services/copilot-review-mcp/internal/watch/manager_test.go
@@ -1166,3 +1166,116 @@ func newReview(state string, submittedAt *time.Time) *github.PullRequestReview {
 	}
 	return review
 }
+
+// TestManagerCancelLatestClearsTriggerLogPending verifies that CancelLatest updates
+// trigger_log.completed_at so HasPending returns false after cancellation, allowing a
+// subsequent request_copilot_review call to succeed (Bug D regression guard).
+func TestManagerCancelLatestClearsTriggerLogPending(t *testing.T) {
+	db := openTestDB(t)
+
+	// Insert a pending trigger_log entry before starting the watch so manager.Start
+	// links the watch to this entry via db.GetLatest().
+	if _, err := db.Insert("octo", "demo", 80, "MANUAL"); err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+
+	manager := NewManager(db, Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	_, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    80,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Sanity: HasPending must be true before cancel.
+	pending, err := db.HasPending("octo", "demo", 80)
+	if err != nil {
+		t.Fatalf("HasPending() before cancel error = %v", err)
+	}
+	if !pending {
+		t.Fatal("HasPending() = false before cancel, want true")
+	}
+
+	result, err := manager.CancelLatest("alice", "octo", "demo", 80)
+	if err != nil {
+		t.Fatalf("CancelLatest() error = %v", err)
+	}
+	if !result.Cancelled {
+		t.Fatal("CancelLatest().Cancelled = false, want true")
+	}
+
+	// After cancel, trigger_log.completed_at must be set → HasPending = false.
+	pending, err = db.HasPending("octo", "demo", 80)
+	if err != nil {
+		t.Fatalf("HasPending() after cancel error = %v", err)
+	}
+	if pending {
+		t.Fatal("HasPending() = true after cancel, want false (Bug D regression)")
+	}
+}
+
+// TestManagerCancelByIDClearsTriggerLogPending mirrors the CancelLatest test for
+// the CancelByID path.
+func TestManagerCancelByIDClearsTriggerLogPending(t *testing.T) {
+	db := openTestDB(t)
+
+	if _, err := db.Insert("octo", "demo", 81, "MANUAL"); err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+
+	manager := NewManager(db, Options{
+		PollInterval: time.Hour,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    81,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	result, err := manager.CancelByID("alice", started.WatchID)
+	if err != nil {
+		t.Fatalf("CancelByID() error = %v", err)
+	}
+	if !result.Cancelled {
+		t.Fatal("CancelByID().Cancelled = false, want true")
+	}
+
+	pending, err := db.HasPending("octo", "demo", 81)
+	if err != nil {
+		t.Fatalf("HasPending() after cancel error = %v", err)
+	}
+	if pending {
+		t.Fatal("HasPending() = true after cancel, want false (Bug D regression)")
+	}
+}


### PR DESCRIPTION
## 概要

Issue #79 で報告した `copilot-review-mcp` の 2 つのバグを修正する。

---

## Bug B: `request_copilot_review` 後に stale-guard が永続発火し `NOT_REQUESTED` に固着する

### 原因

`request_copilot_review` は `db.Insert()` で `RequestedAt = now()` を記録する。  
Copilot が直前にレビューを提出済みの場合（`SubmittedAt < RequestedAt`）、  
`DeriveStatusWithThreshold` の stale-guard が発火し `relevant = false` となる。  
これにより完了済みレビューが「古い」とみなされ、全経路で `NOT_REQUESTED` が返り続ける。

```
RequestedAt = 04:56:08Z
SubmittedAt = 04:55:57Z
relevant = !SubmittedAt.Before(RequestedAt) = false  ← 完了済みレビューを無視
```

### 修正

- `store/db.go`: `InsertWithTime(requestedAt time.Time)` メソッドを追加
- `tools/request.go`: `GetReviewData()` 時点で `LatestCopilotReview` が存在する場合は `SubmittedAt - 1ns` を `RequestedAt` として記録し stale-guard を迂回する

---

## Bug D: ウォッチキャンセル時に `trigger_log.completed_at` が更新されない

### 原因

`CancelByID` / `CancelLatest` は `finishLocked(StatusCancelled)` を呼ぶが  
`db.UpdateCompletedAt()` を呼ばないため `trigger_log.completed_at = NULL` のままになる。  
結果として `HasPending() = true` が維持され、次の `request_copilot_review` が  
`REVIEW_IN_PROGRESS` で拒否され続ける。

### 修正

- `watch/manager.go`: `CancelByID` / `CancelLatest` でキャンセル時に `triggerLogID` が存在する場合は `UpdateCompletedAt` を呼び出す

---

## テスト

```
ok  github.com/scottlz0310/copilot-review-mcp/internal/github
ok  github.com/scottlz0310/copilot-review-mcp/internal/store
ok  github.com/scottlz0310/copilot-review-mcp/internal/tools
ok  github.com/scottlz0310/copilot-review-mcp/internal/watch
```

全テスト PASS。

---

## 関連ドキュメント

- Issue: #79
- バグ調査レポート: `docs/bug-reports/copilot-review-mcp-stale-guard-anomalies.md`
- 再現エビデンス: PR #78 の `pr-review-cycle` スキル実行ログ
