### PR TITLE
fix(copilot-review-mcp): event-based PENDING/IN_PROGRESS detection (#83)

### DIFF
--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -187,51 +187,54 @@ func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber
 		reviewOpts.Page = resp2.NextPage
 	}
 
-	// Timeline is only needed when Copilot is in requested_reviewers (PENDING vs
-	// IN_PROGRESS distinction). Skip the extra API call(s) otherwise.
-	if data.IsCopilotInReviewers {
+	// Timeline is needed when Copilot is currently in requested_reviewers (PENDING vs
+	// IN_PROGRESS distinction) OR when a Copilot review already exists and we need the
+	// most recent review_requested event as the authoritative staleness baseline.
+	needsTimeline := data.IsCopilotInReviewers || data.LatestCopilotReview != nil
+	if needsTimeline {
 		// Short-circuit before timeline fetch if rate limit is too low.
 		if data.RateLimitRemaining < 10 {
 			data.SkippedTimeline = true
 			return data, nil
 		}
 
-		// Fetch REST timeline events for event-based PENDING/IN_PROGRESS detection.
-		// copilot_work_started exists only in the REST timeline (no GraphQL equivalent).
+		// Fetch REST timeline events for event-based PENDING/IN_PROGRESS detection
+		// and review_requested timestamps. copilot_work_started exists only in the
+		// REST timeline (no GraphQL equivalent).
 		timelineOpts := &github.ListOptions{PerPage: 100}
 		for {
-		events, resp3, err := c.gh.Issues.ListIssueTimeline(ctx, owner, repo, prNumber, timelineOpts)
-		if err != nil {
-			// Non-fatal: timeline is best-effort; proceed with what we have.
-			break
-		}
-		if resp3 != nil {
-			data.RateLimitRemaining = resp3.Rate.Remaining
-			data.RateLimitReset = resp3.Rate.Reset.Time
-		}
-		for _, ev := range events {
-			switch ev.GetEvent() {
-			case "review_requested":
-				// Reviewer is json:"requested_reviewer" on the Timeline struct.
-				if r := ev.GetReviewer(); r != nil && isCopilot(r.GetLogin()) {
+			events, resp3, err := c.gh.Issues.ListIssueTimeline(ctx, owner, repo, prNumber, timelineOpts)
+			if err != nil {
+				// Non-fatal: timeline is best-effort; proceed with what we have.
+				break
+			}
+			if resp3 != nil {
+				data.RateLimitRemaining = resp3.Rate.Remaining
+				data.RateLimitReset = resp3.Rate.Reset.Time
+			}
+			for _, ev := range events {
+				switch ev.GetEvent() {
+				case "review_requested":
+					// Reviewer is json:"requested_reviewer" on the Timeline struct.
+					if r := ev.GetReviewer(); r != nil && isCopilot(r.GetLogin()) {
+						t := ev.GetCreatedAt().Time
+						if data.ReviewRequestedAt == nil || t.After(*data.ReviewRequestedAt) {
+							data.ReviewRequestedAt = &t
+						}
+					}
+				case "copilot_work_started":
 					t := ev.GetCreatedAt().Time
-					if data.ReviewRequestedAt == nil || t.After(*data.ReviewRequestedAt) {
-						data.ReviewRequestedAt = &t
+					if data.WorkStartedAt == nil || t.After(*data.WorkStartedAt) {
+						data.WorkStartedAt = &t
 					}
 				}
-			case "copilot_work_started":
-				t := ev.GetCreatedAt().Time
-				if data.WorkStartedAt == nil || t.After(*data.WorkStartedAt) {
-					data.WorkStartedAt = &t
-				}
 			}
-		}
 			if resp3 == nil || resp3.NextPage == 0 {
 				break
 			}
 			timelineOpts.Page = resp3.NextPage
 		}
-	} // end if IsCopilotInReviewers
+	} // end if needsTimeline
 
 	return data, nil
 }

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -38,7 +38,12 @@ const copilotBotLogin = "copilot-pull-request-reviewer[bot]"
 
 // copilotLogins lists the known GitHub Copilot reviewer identities used for
 // detection in GetReviewData. Kept separate from copilotBotLogin (request path).
+//
+// "Copilot" (capitalized, no [bot] suffix) is returned by the REST
+// requested_reviewers endpoint and must be included here so PENDING and
+// IN_PROGRESS can be detected via IsCopilotInReviewers.
 var copilotLogins = []string{
+	"Copilot",
 	"github-copilot[bot]",
 	"copilot-pull-request-reviewer[bot]",
 	"github-copilot",
@@ -79,6 +84,15 @@ type ReviewData struct {
 	RateLimitRemaining int
 	// RateLimitReset is when the rate limit window resets.
 	RateLimitReset time.Time
+	// ReviewRequestedAt is the CreatedAt of the most recent "review_requested" timeline
+	// event for Copilot. Used as the primary source for staleness detection and as the
+	// requestedAt baseline when no trigger_log DB entry exists (AUTO trigger).
+	ReviewRequestedAt *time.Time
+	// WorkStartedAt is the CreatedAt of the most recent "copilot_work_started" timeline
+	// event. When WorkStartedAt > ReviewRequestedAt, the review is IN_PROGRESS;
+	// otherwise it is PENDING. This field is REST-timeline-only; GraphQL has no
+	// corresponding __typename for this event.
+	WorkStartedAt *time.Time
 }
 
 // Client wraps the GitHub API for Copilot review operations.
@@ -169,26 +183,81 @@ func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber
 		reviewOpts.Page = resp2.NextPage
 	}
 
+	// Short-circuit before timeline fetch if rate limit is too low.
+	if data.RateLimitRemaining < 10 {
+		return data, nil
+	}
+
+	// Fetch REST timeline events for event-based PENDING/IN_PROGRESS detection.
+	// copilot_work_started exists only in the REST timeline (no GraphQL equivalent).
+	timelineOpts := &github.ListOptions{PerPage: 100}
+	for {
+		events, resp3, err := c.gh.Issues.ListIssueTimeline(ctx, owner, repo, prNumber, timelineOpts)
+		if err != nil {
+			// Non-fatal: timeline is best-effort; proceed with what we have.
+			break
+		}
+		if resp3 != nil {
+			data.RateLimitRemaining = resp3.Rate.Remaining
+			data.RateLimitReset = resp3.Rate.Reset.Time
+		}
+		for _, ev := range events {
+			switch ev.GetEvent() {
+			case "review_requested":
+				// Reviewer is json:"requested_reviewer" on the Timeline struct.
+				if r := ev.GetReviewer(); r != nil && isCopilot(r.GetLogin()) {
+					t := ev.GetCreatedAt().Time
+					if data.ReviewRequestedAt == nil || t.After(*data.ReviewRequestedAt) {
+						data.ReviewRequestedAt = &t
+					}
+				}
+			case "copilot_work_started":
+				t := ev.GetCreatedAt().Time
+				if data.WorkStartedAt == nil || t.After(*data.WorkStartedAt) {
+					data.WorkStartedAt = &t
+				}
+			}
+		}
+		if resp3 == nil || resp3.NextPage == 0 {
+			break
+		}
+		timelineOpts.Page = resp3.NextPage
+	}
+
 	return data, nil
 }
 
 // DeriveStatus resolves the ReviewStatus from raw data and optional trigger_log requestedAt.
-// requestedAt is nil when no trigger_log entry exists (AUTO trigger or not yet recorded).
+// requestedAt is the DB trigger_log entry time (MANUAL trigger); nil for AUTO trigger.
 // prevReviewID, when non-nil, enables ID-based staleness detection: the existing review is
 // treated as stale only if its ID matches prevReviewID (same review seen before the request).
+//
+// PENDING vs IN_PROGRESS is determined by the timeline events in data:
+//   - WorkStartedAt > ReviewRequestedAt → IN_PROGRESS
+//   - otherwise (WorkStartedAt absent, or before the latest request) → PENDING
+//
+// Staleness detection uses data.ReviewRequestedAt (REST timeline) as the primary source,
+// falling back to the requestedAt parameter when timeline data is unavailable.
 func (c *Client) DeriveStatus(data *ReviewData, requestedAt *time.Time, prevReviewID *string) ReviewStatus {
-	return DeriveStatusWithThreshold(c.threshold, data, requestedAt, prevReviewID)
+	return DeriveStatus(data, requestedAt, prevReviewID)
 }
 
-// DeriveStatusWithThreshold resolves the ReviewStatus from raw data and an elapsed threshold.
-// prevReviewID, when non-nil, enables ID-based staleness detection (see DeriveStatus).
-func DeriveStatusWithThreshold(threshold time.Duration, data *ReviewData, requestedAt *time.Time, prevReviewID *string) ReviewStatus {
+// DeriveStatus resolves the ReviewStatus from raw ReviewData.
+// It is the package-level counterpart of (*Client).DeriveStatus for callers that do
+// not hold a Client reference (e.g. the watch manager).
+func DeriveStatus(data *ReviewData, requestedAt *time.Time, prevReviewID *string) ReviewStatus {
+	// Prefer timeline-sourced requestedAt for accurate staleness detection.
+	// Fall back to the DB trigger_log entry only when timeline data is unavailable.
+	effectiveRequestedAt := data.ReviewRequestedAt
+	if effectiveRequestedAt == nil {
+		effectiveRequestedAt = requestedAt
+	}
+
 	if data.LatestCopilotReview != nil {
-		// When requestedAt is known, only treat this review as relevant if it was submitted
-		// at or after the request time, or (when prevReviewID is set) if its ID differs from
-		// the review that existed when the request was made.
+		// Only treat this review as relevant if it was submitted at/after the request time,
+		// or (when prevReviewID is set) if its ID differs from the pre-request review.
 		relevant := true
-		if requestedAt != nil {
+		if effectiveRequestedAt != nil {
 			if prevReviewID != nil {
 				// ID-based: relevant only if this is a different review from when the
 				// request was made. Same ID means the old review is still present (stale).
@@ -197,9 +266,9 @@ func DeriveStatusWithThreshold(threshold time.Duration, data *ReviewData, reques
 			} else {
 				// Timestamp-based fallback for entries without prevReviewID (backward compat).
 				// - Use !Before (≥) instead of After (>) to include same-second events.
-				// - nil submittedAt means the review has no timestamp → treat as stale.
+				// - Zero submittedAt means the review has no timestamp → treat as stale.
 				sat := data.LatestCopilotReview.GetSubmittedAt()
-				relevant = !sat.IsZero() && !sat.Before(*requestedAt)
+				relevant = !sat.IsZero() && !sat.Before(*effectiveRequestedAt)
 			}
 		}
 		if relevant {
@@ -210,17 +279,21 @@ func DeriveStatusWithThreshold(threshold time.Duration, data *ReviewData, reques
 		}
 	}
 	if data.IsCopilotInReviewers {
-		if requestedAt != nil {
-			elapsed := time.Since(*requestedAt)
-			if elapsed >= threshold {
-				return StatusInProgress
-			}
-			return StatusPending
+		// Event-based PENDING vs IN_PROGRESS: copilot_work_started after review_requested
+		// means work has begun on the current cycle.
+		if data.WorkStartedAt != nil &&
+			(data.ReviewRequestedAt == nil || data.WorkStartedAt.After(*data.ReviewRequestedAt)) {
+			return StatusInProgress
 		}
-		// No trigger_log entry (AUTO trigger or unknown): assume IN_PROGRESS
-		return StatusInProgress
+		return StatusPending
 	}
 	return StatusNotRequested
+}
+
+// DeriveStatusWithThreshold is kept for backward compatibility.
+// The threshold parameter is ignored; use DeriveStatus instead.
+func DeriveStatusWithThreshold(_ time.Duration, data *ReviewData, requestedAt *time.Time, prevReviewID *string) ReviewStatus {
+	return DeriveStatus(data, requestedAt, prevReviewID)
 }
 
 // IsAuthError reports whether err is a GitHub authentication failure.

--- a/services/copilot-review-mcp/internal/github/client.go
+++ b/services/copilot-review-mcp/internal/github/client.go
@@ -93,6 +93,10 @@ type ReviewData struct {
 	// otherwise it is PENDING. This field is REST-timeline-only; GraphQL has no
 	// corresponding __typename for this event.
 	WorkStartedAt *time.Time
+	// SkippedTimeline is true when the timeline fetch was skipped due to low rate-limit
+	// budget. When true, ReviewRequestedAt and WorkStartedAt are nil and callers should
+	// fall back to DB-recorded requestedAt for staleness decisions.
+	SkippedTimeline bool
 }
 
 // Client wraps the GitHub API for Copilot review operations.
@@ -183,15 +187,19 @@ func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber
 		reviewOpts.Page = resp2.NextPage
 	}
 
-	// Short-circuit before timeline fetch if rate limit is too low.
-	if data.RateLimitRemaining < 10 {
-		return data, nil
-	}
+	// Timeline is only needed when Copilot is in requested_reviewers (PENDING vs
+	// IN_PROGRESS distinction). Skip the extra API call(s) otherwise.
+	if data.IsCopilotInReviewers {
+		// Short-circuit before timeline fetch if rate limit is too low.
+		if data.RateLimitRemaining < 10 {
+			data.SkippedTimeline = true
+			return data, nil
+		}
 
-	// Fetch REST timeline events for event-based PENDING/IN_PROGRESS detection.
-	// copilot_work_started exists only in the REST timeline (no GraphQL equivalent).
-	timelineOpts := &github.ListOptions{PerPage: 100}
-	for {
+		// Fetch REST timeline events for event-based PENDING/IN_PROGRESS detection.
+		// copilot_work_started exists only in the REST timeline (no GraphQL equivalent).
+		timelineOpts := &github.ListOptions{PerPage: 100}
+		for {
 		events, resp3, err := c.gh.Issues.ListIssueTimeline(ctx, owner, repo, prNumber, timelineOpts)
 		if err != nil {
 			// Non-fatal: timeline is best-effort; proceed with what we have.
@@ -218,11 +226,12 @@ func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber
 				}
 			}
 		}
-		if resp3 == nil || resp3.NextPage == 0 {
-			break
+			if resp3 == nil || resp3.NextPage == 0 {
+				break
+			}
+			timelineOpts.Page = resp3.NextPage
 		}
-		timelineOpts.Page = resp3.NextPage
-	}
+	} // end if IsCopilotInReviewers
 
 	return data, nil
 }

--- a/services/copilot-review-mcp/internal/github/client_test.go
+++ b/services/copilot-review-mcp/internal/github/client_test.go
@@ -173,16 +173,13 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 }
 
 func TestDeriveStatus(t *testing.T) {
-	// threshold=30s.
-	// recentRequest: 1s elapsed → PENDING (29s slack vs threshold, safe on slow CI).
-	// longAgoRequest: 2min elapsed → IN_PROGRESS.
-	c := &Client{threshold: 30 * time.Second}
+	c := &Client{}
 
 	now := time.Now()
-	recentRequest := now.Add(-time.Second)      // 1s ago — safely within 30s threshold
-	longAgoRequest := now.Add(-2 * time.Minute) // 2min ago — safely past threshold
-	threeMinAgo := now.Add(-3 * time.Minute)
+	oneSecAgo := now.Add(-time.Second)
 	oneMinAgo := now.Add(-1 * time.Minute)
+	twoMinAgo := now.Add(-2 * time.Minute)
+	threeMinAgo := now.Add(-3 * time.Minute)
 	oneMinLater := now.Add(1 * time.Minute)
 
 	tests := []struct {
@@ -198,24 +195,51 @@ func TestDeriveStatus(t *testing.T) {
 			want: StatusNotRequested,
 		},
 		{
-			name:        "no review, copilot in reviewers, within threshold → PENDING",
-			data:        &ReviewData{IsCopilotInReviewers: true},
-			requestedAt: &recentRequest,
-			want:        StatusPending,
-		},
-		{
-			name:        "no review, copilot in reviewers, threshold elapsed → IN_PROGRESS",
-			data:        &ReviewData{IsCopilotInReviewers: true},
-			requestedAt: &longAgoRequest,
-			want:        StatusInProgress,
-		},
-		{
-			name: "no review, copilot in reviewers, no requestedAt → IN_PROGRESS (AUTO)",
+			// No work_started event → PENDING regardless of requestedAt.
+			name: "no review, copilot in reviewers, no work_started → PENDING",
 			data: &ReviewData{IsCopilotInReviewers: true},
+			want: StatusPending,
+		},
+		{
+			// ReviewRequestedAt set but no WorkStartedAt → PENDING.
+			name: "no review, copilot in reviewers, review_requested but no work_started → PENDING",
+			data: &ReviewData{
+				IsCopilotInReviewers: true,
+				ReviewRequestedAt:    &oneSecAgo,
+			},
+			want: StatusPending,
+		},
+		{
+			// WorkStartedAt after ReviewRequestedAt → IN_PROGRESS.
+			name: "no review, copilot in reviewers, work_started after review_requested → IN_PROGRESS",
+			data: &ReviewData{
+				IsCopilotInReviewers: true,
+				ReviewRequestedAt:    &twoMinAgo,
+				WorkStartedAt:        &oneMinAgo,
+			},
 			want: StatusInProgress,
 		},
+		{
+			// WorkStartedAt set but no ReviewRequestedAt → IN_PROGRESS.
+			name: "no review, copilot in reviewers, work_started, no review_requested → IN_PROGRESS",
+			data: &ReviewData{
+				IsCopilotInReviewers: true,
+				WorkStartedAt:        &oneMinAgo,
+			},
+			want: StatusInProgress,
+		},
+		{
+			// Rereview PENDING: new review_requested (oneMinAgo) is after old work_started (twoMinAgo).
+			name: "no review, copilot in reviewers, old work_started before new review_requested → PENDING",
+			data: &ReviewData{
+				IsCopilotInReviewers: true,
+				ReviewRequestedAt:    &oneMinAgo,
+				WorkStartedAt:        &twoMinAgo, // old cycle, before new request
+			},
+			want: StatusPending,
+		},
 
-		// ── review exists, requestedAt nil (backward compat) ─────────────────────
+		// ── review exists, no requestedAt (backward compat) ─────────────────────
 		{
 			name: "APPROVED review, no requestedAt → COMPLETED",
 			data: &ReviewData{LatestCopilotReview: newReview("APPROVED", &oneMinAgo)},
@@ -227,18 +251,31 @@ func TestDeriveStatus(t *testing.T) {
 			want: StatusBlocked,
 		},
 
-		// ── review submitted AFTER requestedAt ───────────────────────────────────
+		// ── review submitted AFTER requestedAt (DB fallback) ─────────────────────
 		{
-			name:        "APPROVED review after requestedAt → COMPLETED",
+			name:        "APPROVED review after DB requestedAt → COMPLETED",
 			data:        &ReviewData{LatestCopilotReview: newReview("APPROVED", &oneMinLater)},
 			requestedAt: &now,
 			want:        StatusCompleted,
 		},
 		{
-			name:        "CHANGES_REQUESTED review after requestedAt → BLOCKED",
+			name:        "CHANGES_REQUESTED review after DB requestedAt → BLOCKED",
 			data:        &ReviewData{LatestCopilotReview: newReview("CHANGES_REQUESTED", &oneMinLater)},
 			requestedAt: &now,
 			want:        StatusBlocked,
+		},
+
+		// ── timeline ReviewRequestedAt takes priority over DB requestedAt ─────────
+		{
+			// Review (1min ago) is AFTER timeline ReviewRequestedAt (2min ago) → COMPLETED.
+			// DB requestedAt (now) would make it stale, but timeline takes priority.
+			name: "APPROVED review after timeline review_requested, DB would mark stale → COMPLETED",
+			data: &ReviewData{
+				LatestCopilotReview: newReview("APPROVED", &oneMinAgo),
+				ReviewRequestedAt:   &twoMinAgo, // timeline: 2min ago
+			},
+			requestedAt: &now, // DB: now (would falsely mark as stale)
+			want:        StatusCompleted,
 		},
 
 		// ── review submitted at EXACTLY requestedAt (same-second inclusive) ───────
@@ -249,34 +286,57 @@ func TestDeriveStatus(t *testing.T) {
 			want:        StatusCompleted,
 		},
 
-		// ── stale review (submitted BEFORE requestedAt) ───────────────────────────
+		// ── stale review (submitted BEFORE review_requested) ─────────────────────
 		{
-			// review (1min ago) is older than recentRequest (1s ago) → stale,
-			// then elapsed since request = 1s < 30s threshold → PENDING.
-			name:        "stale APPROVED review, copilot in reviewers, within threshold → PENDING",
-			data:        &ReviewData{IsCopilotInReviewers: true, LatestCopilotReview: newReview("APPROVED", &oneMinAgo)},
-			requestedAt: &recentRequest,
+			// Review (3min ago) is older than ReviewRequestedAt (1min ago) → stale.
+			// No WorkStartedAt → PENDING.
+			name: "stale APPROVED review, copilot in reviewers, no work_started → PENDING",
+			data: &ReviewData{
+				IsCopilotInReviewers: true,
+				LatestCopilotReview:  newReview("APPROVED", &threeMinAgo),
+				ReviewRequestedAt:    &oneMinAgo, // new request after old review
+			},
+			want: StatusPending,
+		},
+		{
+			name: "stale CHANGES_REQUESTED review, copilot in reviewers, no work_started → PENDING (not BLOCKED)",
+			data: &ReviewData{
+				IsCopilotInReviewers: true,
+				LatestCopilotReview:  newReview("CHANGES_REQUESTED", &threeMinAgo),
+				ReviewRequestedAt:    &oneMinAgo,
+			},
+			want: StatusPending,
+		},
+		{
+			// Stale review but no Copilot in reviewers (request cancelled) → NOT_REQUESTED.
+			name: "stale review, copilot NOT in reviewers → NOT_REQUESTED",
+			data: &ReviewData{
+				LatestCopilotReview: newReview("APPROVED", &threeMinAgo),
+				ReviewRequestedAt:   &oneMinAgo,
+			},
+			want: StatusNotRequested,
+		},
+		{
+			// Stale review + work_started after new review_requested → IN_PROGRESS.
+			name: "stale review, copilot in reviewers, work_started after review_requested → IN_PROGRESS",
+			data: &ReviewData{
+				IsCopilotInReviewers: true,
+				LatestCopilotReview:  newReview("APPROVED", &threeMinAgo),
+				ReviewRequestedAt:    &twoMinAgo,
+				WorkStartedAt:        &oneMinAgo, // after review_requested
+			},
+			want: StatusInProgress,
+		},
+		{
+			// DB-only requestedAt fallback: review stale relative to DB entry.
+			name: "stale review, DB requestedAt fallback, no work_started → PENDING",
+			data: &ReviewData{
+				IsCopilotInReviewers: true,
+				LatestCopilotReview:  newReview("APPROVED", &threeMinAgo),
+				// ReviewRequestedAt not set → fallback to DB requestedAt
+			},
+			requestedAt: &oneMinAgo, // DB: 1min ago
 			want:        StatusPending,
-		},
-		{
-			name:        "stale CHANGES_REQUESTED review, copilot in reviewers, within threshold → PENDING (not BLOCKED)",
-			data:        &ReviewData{IsCopilotInReviewers: true, LatestCopilotReview: newReview("CHANGES_REQUESTED", &oneMinAgo)},
-			requestedAt: &recentRequest,
-			want:        StatusPending,
-		},
-		{
-			name:        "stale review, copilot NOT in reviewers → NOT_REQUESTED",
-			data:        &ReviewData{LatestCopilotReview: newReview("APPROVED", &oneMinAgo)},
-			requestedAt: &recentRequest,
-			want:        StatusNotRequested,
-		},
-		{
-			// review (3min ago) is older than longAgoRequest (2min ago) → stale,
-			// then elapsed since request = 2min > 30s threshold → IN_PROGRESS.
-			name:        "stale review, copilot in reviewers, threshold elapsed → IN_PROGRESS",
-			data:        &ReviewData{IsCopilotInReviewers: true, LatestCopilotReview: newReview("APPROVED", &threeMinAgo)},
-			requestedAt: &longAgoRequest,
-			want:        StatusInProgress,
 		},
 
 		// ── nil submittedAt on review ─────────────────────────────────────────────
@@ -306,10 +366,10 @@ func TestDeriveStatus(t *testing.T) {
 // TestDeriveStatusIDBasedStaleness verifies the ID-based staleness detection path:
 // when prevReviewID is non-nil, DeriveStatus compares review IDs instead of timestamps.
 func TestDeriveStatusIDBasedStaleness(t *testing.T) {
-	c := &Client{threshold: 30 * time.Second}
+	c := &Client{}
 
 	now := time.Now()
-	recentRequest := now.Add(-time.Second) // within threshold
+	recentRequest := now.Add(-time.Second)
 
 	// Helper to build a review with a specific ID and state.
 	newReviewWithID := func(id int64, state string) *github.PullRequestReview {
@@ -566,4 +626,158 @@ func join(ss []string, sep string) string {
 		result += sep + s
 	}
 	return result
+}
+
+// TestGetReviewDataTimeline verifies that GetReviewData populates ReviewRequestedAt
+// and WorkStartedAt from the REST timeline (Issues.ListIssueTimeline).
+func TestGetReviewDataTimeline(t *testing.T) {
+	const (
+		owner = "owner"
+		repo  = "repo"
+		pr    = 5
+	)
+
+	reviewRequestedAt := "2024-01-01T00:59:02Z"
+	workStartedAt := "2024-01-01T00:59:29Z"
+
+	// Minimal timeline JSON with review_requested and copilot_work_started events.
+	timelineJSON := fmt.Sprintf(`[
+		{"event":"review_requested","created_at":%q,"requested_reviewer":{"login":"Copilot","type":"Bot"}},
+		{"event":"copilot_work_started","created_at":%q}
+	]`, reviewRequestedAt, workStartedAt)
+
+	writeJSON := func(w http.ResponseWriter, body string) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "100")
+		w.Header().Set("X-RateLimit-Reset", "9999999999")
+		fmt.Fprint(w, body)
+	}
+
+	mux := http.NewServeMux()
+
+	// requested reviewers: Copilot is in the list.
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, pr),
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, `{"users":[{"login":"Copilot","type":"Bot"}],"teams":[]}`)
+		})
+
+	// reviews: one completed review from a previous cycle.
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, pr),
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, `[{"id":1,"user":{"login":"copilot-pull-request-reviewer[bot]"},"state":"COMMENTED","submitted_at":"2024-01-01T00:58:00Z"}]`)
+		})
+
+	// timeline events.
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d/timeline", owner, repo, pr),
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, timelineJSON)
+		})
+
+	c, teardown := newTestGHClient(mux)
+	defer teardown()
+
+	data, err := c.GetReviewData(context.Background(), owner, repo, pr)
+	if err != nil {
+		t.Fatalf("GetReviewData() error = %v", err)
+	}
+
+	if !data.IsCopilotInReviewers {
+		t.Error("IsCopilotInReviewers = false, want true (login \"Copilot\" must be recognized)")
+	}
+
+	if data.ReviewRequestedAt == nil {
+		t.Fatal("ReviewRequestedAt = nil, want non-nil")
+	}
+	wantReviewRequestedAt, _ := time.Parse(time.RFC3339, reviewRequestedAt)
+	if !data.ReviewRequestedAt.Equal(wantReviewRequestedAt) {
+		t.Errorf("ReviewRequestedAt = %v, want %v", data.ReviewRequestedAt, wantReviewRequestedAt)
+	}
+
+	if data.WorkStartedAt == nil {
+		t.Fatal("WorkStartedAt = nil, want non-nil")
+	}
+	wantWorkStartedAt, _ := time.Parse(time.RFC3339, workStartedAt)
+	if !data.WorkStartedAt.Equal(wantWorkStartedAt) {
+		t.Errorf("WorkStartedAt = %v, want %v", data.WorkStartedAt, wantWorkStartedAt)
+	}
+}
+
+// TestGetReviewDataTimelinePicksLatestEvents verifies that when multiple
+// review_requested / copilot_work_started events exist (rereview), only the
+// most recent timestamps are kept.
+func TestGetReviewDataTimelinePicksLatestEvents(t *testing.T) {
+	const (
+		owner = "owner"
+		repo  = "repo"
+		pr    = 6
+	)
+
+	// Two cycles: cycle-1 at 01:00, cycle-2 at 02:00.
+	timelineJSON := `[
+		{"event":"review_requested","created_at":"2024-01-01T01:00:00Z","requested_reviewer":{"login":"Copilot","type":"Bot"}},
+		{"event":"copilot_work_started","created_at":"2024-01-01T01:01:00Z"},
+		{"event":"review_requested","created_at":"2024-01-01T02:00:00Z","requested_reviewer":{"login":"Copilot","type":"Bot"}},
+		{"event":"copilot_work_started","created_at":"2024-01-01T02:01:00Z"}
+	]`
+
+	writeJSON := func(w http.ResponseWriter, body string) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "100")
+		w.Header().Set("X-RateLimit-Reset", "9999999999")
+		fmt.Fprint(w, body)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, pr),
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, `{"users":[{"login":"Copilot","type":"Bot"}],"teams":[]}`)
+		})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, pr),
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, `[]`)
+		})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d/timeline", owner, repo, pr),
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, timelineJSON)
+		})
+
+	c, teardown := newTestGHClient(mux)
+	defer teardown()
+
+	data, err := c.GetReviewData(context.Background(), owner, repo, pr)
+	if err != nil {
+		t.Fatalf("GetReviewData() error = %v", err)
+	}
+
+	wantReviewRequested, _ := time.Parse(time.RFC3339, "2024-01-01T02:00:00Z")
+	wantWorkStarted, _ := time.Parse(time.RFC3339, "2024-01-01T02:01:00Z")
+
+	if data.ReviewRequestedAt == nil || !data.ReviewRequestedAt.Equal(wantReviewRequested) {
+		t.Errorf("ReviewRequestedAt = %v, want %v", data.ReviewRequestedAt, wantReviewRequested)
+	}
+	if data.WorkStartedAt == nil || !data.WorkStartedAt.Equal(wantWorkStarted) {
+		t.Errorf("WorkStartedAt = %v, want %v", data.WorkStartedAt, wantWorkStarted)
+	}
+}
+
+// TestIsCopilotLoginCoversAllKnownIdentities verifies that all known Copilot
+// reviewer identities are recognized, including the REST requested_reviewers form.
+func TestIsCopilotLoginCoversAllKnownIdentities(t *testing.T) {
+	cases := []struct {
+		login string
+		want  bool
+	}{
+		{"Copilot", true}, // REST requested_reviewers (observation #1)
+		{"copilot-pull-request-reviewer[bot]", true}, // REST reviews
+		{"github-copilot[bot]", true},
+		{"github-copilot", true},
+		{"other-user", false},
+		{"copilot", false}, // case-sensitive: lowercase must not match
+	}
+	for _, tc := range cases {
+		got := IsCopilotLogin(tc.login)
+		if got != tc.want {
+			t.Errorf("IsCopilotLogin(%q) = %v, want %v", tc.login, got, tc.want)
+		}
+	}
 }

--- a/services/copilot-review-mcp/internal/watch/manager.go
+++ b/services/copilot-review-mcp/internal/watch/manager.go
@@ -700,7 +700,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 		requestedAt = &entry.RequestedAt
 		prevReviewID = entry.PrevReviewID
 	}
-	reviewStatus := ghclient.DeriveStatusWithThreshold(m.threshold, data, requestedAt, prevReviewID)
+	reviewStatus := ghclient.DeriveStatus(data, requestedAt, prevReviewID)
 
 	if data.RateLimitRemaining < 10 {
 		m.mu.Lock()


### PR DESCRIPTION
## 概要

観測シート ([docs/observations/observation-sheet.md](docs/observations/observation-sheet.md)) の検証結果に基づき、ISSUE #83 で報告された以下の問題を修正する。

## 問題

1. **`copilotLogins` に `"Copilot"` が欠落**  
   REST API の `requested_reviewers` が返す Bot の login は `"Copilot"`（先頭大文字）。未定義だったため `IsCopilotInReviewers` が常に `false` となり、PENDING/IN_PROGRESS が一切検出できなかった。

2. **threshold ベースの PENDING/IN_PROGRESS 判定が不正確**  
   DB の `requested_at` は実際の GitHub `review_requested` イベント時刻より 2 分以上ずれることがあり、threshold 比較が不安定だった。

3. **`requestedAt` の精度不足**  
   DB 記録時刻を `requestedAt` として使用していたため、staleness 判定が不正確だった。

## 変更内容

### `internal/github/client.go`

- `copilotLogins` に `"Copilot"` を追加（REST `requested_reviewers` 対応）
- `ReviewData` に `ReviewRequestedAt *time.Time`、`WorkStartedAt *time.Time` フィールドを追加
- `GetReviewData` に REST timeline 取得を追加（`Issues.ListIssueTimeline`）
  - `review_requested`（Copilot 宛て）イベント → `ReviewRequestedAt`
  - `copilot_work_started` イベント → `WorkStartedAt`（REST timeline 専用、GraphQL 非対応）
  - Rate limit 残量 < 10 の場合はスキップ
- `DeriveStatus` をイベントベースに書き換え
  - `WorkStartedAt > ReviewRequestedAt` → `IN_PROGRESS`
  - それ以外（`WorkStartedAt` なし、または古い） → `PENDING`
  - staleness 判定: `ReviewRequestedAt`（timeline）優先、なければ DB `requestedAt` にフォールバック
- `DeriveStatusWithThreshold` を後方互換シム（threshold 引数は無視）として残存

### `internal/watch/manager.go`

- `DeriveStatusWithThreshold(m.threshold, ...)` → `DeriveStatus(...)` に変更

### `internal/github/client_test.go`

- `TestDeriveStatus`: イベントベースロジックに合わせて全面書き換え
- `TestDeriveStatusIDBasedStaleness`: threshold フィールド削除
- `TestGetReviewDataTimeline` (新規): timeline から `ReviewRequestedAt`/`WorkStartedAt` が取得できることを確認
- `TestGetReviewDataTimelinePicksLatestEvents` (新規): rereview 時に最新イベントのみ保持されることを確認
- `TestIsCopilotLoginCoversAllKnownIdentities` (新規): `"Copilot"` (先頭大文字) が認識されることを確認

## テスト結果

```
ok  github.com/scottlz0310/copilot-review-mcp/internal/github  (42 tests, 0 failures)
ok  github.com/scottlz0310/copilot-review-mcp/internal/tools
ok  github.com/scottlz0310/copilot-review-mcp/internal/watch
ok  github.com/scottlz0310/copilot-review-mcp/internal/store
```

Closes #83