### PR TITLE
fix: deep-research 指摘事項の対応（CI/CD スコープ・バージョン情報・永続化）

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -20,7 +20,7 @@ GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # GitHub MCP Serverの利用イメージ
 # デフォルト: ghcr.io/github/github-mcp-server:main (HTTP transport対応)
 # 安定タグを固定したい場合のみコメントアウトを解除
-# GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:v0.30.3
+# GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:v1.0.0
 
 # ローカルHTTP接続先 (IDE設定生成スクリプトで使用)
 # GITHUB_MCP_SERVER_URL=http://127.0.0.1:8082

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ make clean-all       # Full cleanup including images
 - **Environment-first auth**: `GITHUB_PERSONAL_ACCESS_TOKEN` env var always wins over `.env` file. Set both consistently to avoid confusion.
 - **Port**: Default MCP HTTP port is `8082`. Override with `GITHUB_MCP_HTTP_PORT`.
 - **Image override**: Set `GITHUB_MCP_IMAGE` to swap the default container image.
-- **HTTP transport only in `main` tag**: Stable releases `v0.31.0` and later include native Streamable HTTP support (`http` subcommand). `v1.0.0` is the current latest stable. Use `main` for cutting-edge features.
+- **HTTP transport: supported in stable releases `v0.31.0+`**: Stable releases `v0.31.0` and later include native Streamable HTTP support (`http` subcommand). `v1.0.0` is the current latest stable. Use `main` for cutting-edge features.
 - **Claude Desktop exception**: HTTP transport 非対応のため、`docker run -i --rm <image> stdio` で直接起動する。VS Code/Cursor/Kiro/Amazon Q/Codex/Copilot CLI は HTTP (port 8082) に接続する。
 - **Distroless container**: The container has no shell. Health checks are done host-side via `scripts/health-check.sh`, not inside the container.
 - **Go patches**: Source patches for the custom build live in `patches/github/`. They are copied into the builder stage in `Dockerfile.github-mcp-server`. Add new `.go` files there and reference them in the Dockerfile.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ make clean-all       # Full cleanup including images
 - **Environment-first auth**: `GITHUB_PERSONAL_ACCESS_TOKEN` env var always wins over `.env` file. Set both consistently to avoid confusion.
 - **Port**: Default MCP HTTP port is `8082`. Override with `GITHUB_MCP_HTTP_PORT`.
 - **Image override**: Set `GITHUB_MCP_IMAGE` to swap the default container image.
-- **HTTP transport only in `main` tag**: Using a pinned release (e.g. `v0.30.3`) will silently fall back to stdio-only mode and break.
+- **HTTP transport only in `main` tag**: Stable releases `v0.31.0` and later include native Streamable HTTP support (`http` subcommand). `v1.0.0` is the current latest stable. Use `main` for cutting-edge features.
 - **Claude Desktop exception**: HTTP transport 非対応のため、`docker run -i --rm <image> stdio` で直接起動する。VS Code/Cursor/Kiro/Amazon Q/Codex/Copilot CLI は HTTP (port 8082) に接続する。
 - **Distroless container**: The container has no shell. Health checks are done host-side via `scripts/health-check.sh`, not inside the container.
 - **Go patches**: Source patches for the custom build live in `patches/github/`. They are copied into the builder stage in `Dockerfile.github-mcp-server`. Add new `.go` files there and reference them in the Dockerfile.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,6 +59,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Go 解析の場合、go.mod のバージョンで toolchain をセットアップ
+      - name: Goセットアップ（Go解析時のみ）
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: services/copilot-review-mcp/go.mod
+          cache-dependency-path: services/copilot-review-mcp/go.sum
+
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
       # or others). This is typically only required for manual builds.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,8 @@ jobs:
         include:
           - language: actions
             build-mode: none
+          - language: go
+            build-mode: autobuild
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -9,9 +9,6 @@ on:
 permissions:
   contents: read
 
-env:
-  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
 jobs:
   test-node:
     name: Nodeテスト
@@ -25,9 +22,10 @@ jobs:
           node-version: '20.20.2'
 
       - name: Nodeテスト実行（カバレッジ付き）
-        run: npx c8 --reporter=lcov --reporter=text node --test tests/node/*.test.js
+        run: npx c8@10.1.3 --reporter=lcov --reporter=text node --test tests/node/*.test.js
 
       - name: Codecovにアップロード（Node）
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -78,6 +76,7 @@ jobs:
         run: go test -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Codecovにアップロード（Go）
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
 jobs:
   test-node:
     name: Nodeテスト
@@ -21,8 +24,16 @@ jobs:
         with:
           node-version: '20.20.2'
 
-      - name: Nodeテスト実行
-        run: npm test
+      - name: Nodeテスト実行（カバレッジ付き）
+        run: npx c8 --reporter=lcov --reporter=text node --test tests/node/*.test.js
+
+      - name: Codecovにアップロード（Node）
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          flags: node
+          fail_ci_if_error: true
 
   lint-shell:
     name: シェルスクリプトLint
@@ -49,3 +60,27 @@ jobs:
       
       - name: シェルスクリプトテスト実行
         run: bats tests/shell/*.bats
+
+  test-go:
+    name: Goテスト（copilot-review-mcp）
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Goセットアップ
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: services/copilot-review-mcp/go.mod
+          cache-dependency-path: services/copilot-review-mcp/go.sum
+
+      - name: Goテスト実行（カバレッジ付き）
+        working-directory: services/copilot-review-mcp
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Codecovにアップロード（Go）
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: services/copilot-review-mcp/coverage.out
+          flags: go
+          fail_ci_if_error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  GITHUB_MCP_GO_SDK_VERSION: ${{ vars.GITHUB_MCP_GO_SDK_VERSION || 'v1.3.1' }}
+  GITHUB_MCP_GO_SDK_VERSION: ${{ vars.GITHUB_MCP_GO_SDK_VERSION || 'v1.5.0' }}
   SECURITY_SCAN_IMAGE: github-mcp-server:security-scan
 
 permissions:
@@ -92,3 +92,37 @@ jobs:
         if: always()
         with:
           sarif_file: trivy-container-results.sarif
+
+  copilot-review-mcp-scan:
+    name: copilot-review-mcp Container Scan (Trivy)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build copilot-review-mcp image
+        run: |
+          docker build \
+            -f services/copilot-review-mcp/Dockerfile \
+            -t copilot-review-mcp:security-scan \
+            services/copilot-review-mcp
+
+      - name: Run Trivy scan on copilot-review-mcp image
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: copilot-review-mcp:security-scan
+          format: sarif
+          output: trivy-crm-results.sarif
+          vuln-type: os,library
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+          trivyignores: .trivyignore
+
+      - name: Upload Trivy copilot-review-mcp results
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: trivy-crm-results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  GITHUB_MCP_GO_SDK_VERSION: ${{ vars.GITHUB_MCP_GO_SDK_VERSION || 'v1.5.0' }}
+  GITHUB_MCP_GO_SDK_VERSION: ${{ vars.GITHUB_MCP_GO_SDK_VERSION || 'v1.3.1' }}
   SECURITY_SCAN_IMAGE: github-mcp-server:security-scan
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Claude Desktop だけは HTTP transport 非対応のため、`docker run -i ... 
 
 **イメージ方針（2026-04-24時点）:**
 - 既定イメージ: `ghcr.io/github/github-mcp-server:main`
-- 理由: 公式最新リリース `v0.30.3` には `http` サブコマンドが未搭載で、`http` 対応は現時点で `main` タグに含まれるため
+- 理由: 公式安定リリースの最新は `v1.0.0`（`v0.31.0` 以降 Streamable HTTP / `http` サブコマンドが正式搭載）。安定性より最新機能を優先する場合は `main` タグを使用
 - セキュリティ: `.github/workflows/security.yml` でTrivyスキャンを継続実行
 
 ## 概要
@@ -410,7 +410,7 @@ docker compose logs --tail=100 github-mcp
 - 別のバージョンを使う場合は次のように上書きします:
 
 ```bash
-export GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:v0.30.3
+export GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:v1.0.0
 docker compose pull github-mcp
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,13 @@ services:
     image: copilot-review-mcp:local
     container_name: copilot-review-mcp
     restart: unless-stopped
+    # distroless:nonroot の UID/GID を明示（UID=65532）。
+    # /data ボリュームの初回マウント時、Docker はイメージの /data ディレクトリ
+    # （Dockerfile で COPY --chown=nonroot:nonroot 済み）の内容をボリュームに
+    # コピーするため、正しいオーナーシップが引き継がれます。
+    # 既存の空ボリュームが root 所有になっている場合は
+    # "docker volume rm copilot-review-data" で削除後に再作成してください。
+    user: "65532:65532"
 
     environment:
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,9 @@ services:
     ports:
       - "127.0.0.1:${COPILOT_REVIEW_MCP_PORT:-8083}:${COPILOT_REVIEW_MCP_PORT:-8083}"
 
+    volumes:
+      - copilot-review-data:/data
+
     networks:
       - mcp-network
 
@@ -131,6 +134,8 @@ services:
 
 volumes:
   github-mcp-cache:
+    driver: local
+  copilot-review-data:
     driver: local
 
 networks:

--- a/docs/SECURITY_PATCHES.md
+++ b/docs/SECURITY_PATCHES.md
@@ -2,12 +2,11 @@
 
 ## 現在の運用
 
-2026-03-02時点で、本プロジェクトは実行時には公式イメージを利用しつつ、Security Scan では再ビルドした検証用イメージを利用します。
+2026-04-24時点で、本プロジェクトは実行時には公式イメージを利用しつつ、Security Scan では再ビルドした検証用イメージを利用します。
 
 - 既定: `ghcr.io/github/github-mcp-server:main`
-- 理由: HTTP transport（`github-mcp-server http`）を利用するため
-- 補足: 公式最新リリース `v0.30.3` には `http` サブコマンドが未搭載
-- Security Scan補足: `Dockerfile.github-mcp-server` で `go-sdk v1.3.1` を固定してビルドしたイメージをTrivyでスキャン
+- 補足: 公式安定リリースの最新は `v1.0.0`（`v0.31.0` 以降 Streamable HTTP / `http` サブコマンドが正式搭載）
+- Security Scan補足: `Dockerfile.github-mcp-server` で `go-sdk v1.5.0` を固定してビルドしたイメージをTrivyでスキャン
 
 ## 脆弱性管理
 

--- a/docs/SECURITY_PATCHES.md
+++ b/docs/SECURITY_PATCHES.md
@@ -6,7 +6,7 @@
 
 - 既定: `ghcr.io/github/github-mcp-server:main`
 - 補足: 公式安定リリースの最新は `v1.0.0`（`v0.31.0` 以降 Streamable HTTP / `http` サブコマンドが正式搭載）
-- Security Scan補足: `Dockerfile.github-mcp-server` で `go-sdk v1.5.0` を固定してビルドしたイメージをTrivyでスキャン
+- Security Scan補足: `Dockerfile.github-mcp-server` をベースに、workflow 側で `build-arg` により `go-sdk`（デフォルト: `v1.3.1`、`GITHUB_MCP_GO_SDK_VERSION` で上書き可）を指定してビルドしたイメージを Trivy でスキャン
 
 ## 脆弱性管理
 


### PR DESCRIPTION
## 概要

deep-research-report.md の指摘事項を解消します。

## 変更内容

### CI/CD スコープの修正

- **`.github/workflows/codeql.yml`**: matrix に `go / autobuild` を追加。Go コードが CodeQL 解析の対象外だった問題を修正。
- **`.github/workflows/security.yml`**:
  - `GITHUB_MCP_GO_SDK_VERSION` のデフォルト値は `v1.3.1` を維持（`Dockerfile.github-mcp-server` の ARG デフォルト・互換パッチと整合させるため）
  - `copilot-review-mcp` コンテナの Trivy スキャンジョブ（`copilot-review-mcp-scan`）を追加。これまで `patched github-mcp-server` のみがスキャン対象で `copilot-review-mcp` はスコープ外だった問題を修正。
- **`.github/workflows/lint-test.yml`**:
  - Node.js テストに `c8` によるカバレッジ収集（LCOV）と Codecov アップロードを追加（flags: `node`）
  - Go テストジョブ（`test-go`）を新規追加。`go test -coverprofile` でカバレッジ収集し Codecov にアップロード（flags: `go`）
  - `CODECOV_TOKEN` を `secrets.CODECOV_TOKEN` から参照

### 永続化（P1）

- **`docker-compose.yml`**: `copilot-review-mcp` サービスに `/data` ボリュームマウントを追加（`copilot-review-data` named volume）。コンテナ再作成時に SQLite DB（`/data/copilot-review.db`）が消える問題を修正。

### バージョン情報の更新

公式 `github-mcp-server` は `v0.31.0` 以降（現在の最新: `v1.0.0`）で Streamable HTTP / `http` サブコマンドが正式搭載。`v0.30.3` 前提の古い記述を各所で更新。

- **`README.md`**: 「`v0.30.3` には `http` サブコマンドが未搭載」→「`v0.31.0+` では stable release でも HTTP 対応済み」に書き換え（2箇所）
- **`docs/SECURITY_PATCHES.md`**: 「Dockerfile で固定」→「workflow の `build-arg` で指定（デフォルト: `v1.3.1`、`GITHUB_MCP_GO_SDK_VERSION` で上書き可）」に修正
- **`.env.template`**: イメージ例 `v0.30.3` → `v1.0.0`
- **`.github/copilot-instructions.md`**: 見出し「HTTP transport only in `main` tag」→「HTTP transport: supported in stable releases `v0.31.0+`」に更新（本文との矛盾を解消）

## テスト・影響範囲

- `docker-compose.yml` のボリューム追加は **後方互換**（既存ユーザーは `docker compose up` 実行時に named volume が自動作成される）
- CI 変更（`codeql.yml` / `security.yml`）はワークフロー追加のみ、既存ジョブへの影響なし
- Codecov アップロードは `fail_ci_if_error: true` のため、`CODECOV_TOKEN` 未設定の fork PR では失敗する可能性あり

## 関連 Issue

- Issue #87: `Dockerfile.github-mcp-server` の `go-sdk` を `v1.5.0` 以上に更新（互換パッチの検証を含む、本 PR では `v1.3.1` を維持）