### PR TITLE
chore: go-sdk を v1.3.1 から v1.5.0 に更新し互換パッチを除去する

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  GITHUB_MCP_GO_SDK_VERSION: ${{ vars.GITHUB_MCP_GO_SDK_VERSION || 'v1.3.1' }}
+  GITHUB_MCP_GO_SDK_VERSION: ${{ vars.GITHUB_MCP_GO_SDK_VERSION || 'v1.5.0' }}
   SECURITY_SCAN_IMAGE: github-mcp-server:security-scan
 
 permissions:

--- a/Dockerfile.github-mcp-server
+++ b/Dockerfile.github-mcp-server
@@ -21,7 +21,7 @@ ARG GITHUB_MCP_SERVER_REPO=https://github.com/github/github-mcp-server.git
 # Pin to a known-compatible upstream commit until the patch set is updated
 # for newer github-mcp-server/go-sdk changes.
 ARG GITHUB_MCP_SERVER_REF=a24c0be254cd72f80aa76b2a90395f2ce155dd94
-ARG GO_SDK_VERSION=v1.3.1
+ARG GO_SDK_VERSION=v1.5.0
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 
@@ -39,9 +39,6 @@ RUN git init . && \
     git remote add origin ${GITHUB_MCP_SERVER_REPO} && \
     git fetch --depth 1 origin ${GITHUB_MCP_SERVER_REF} && \
     git checkout FETCH_HEAD
-
-# Keep compatibility with go-sdk v1.3.1 capability naming.
-RUN sed -i 's/Capabilities.Extensions/Capabilities.Experimental/g' /src/pkg/github/ui_capability.go
 
 # Pin go-sdk to the fixed release for CVE-2026-27896.
 RUN go mod edit -require=github.com/modelcontextprotocol/go-sdk@${GO_SDK_VERSION} && \

--- a/Dockerfile.github-mcp-server
+++ b/Dockerfile.github-mcp-server
@@ -40,7 +40,10 @@ RUN git init . && \
     git fetch --depth 1 origin ${GITHUB_MCP_SERVER_REF} && \
     git checkout FETCH_HEAD
 
-# Pin go-sdk to the fixed release for CVE-2026-27896.
+# Security pin: keep github.com/modelcontextprotocol/go-sdk at the patched release
+# for CVE-2026-27896. Reference: https://nvd.nist.gov/vuln/detail/CVE-2026-27896
+# If this pin is updated or removed, also record the upstream advisory / issue / PR
+# in the commit message or docs/SECURITY_PATCHES.md so the rationale remains auditable.
 RUN go mod edit -require=github.com/modelcontextprotocol/go-sdk@${GO_SDK_VERSION} && \
     go mod tidy && \
     test "$(go list -m -f '{{.Version}}' github.com/modelcontextprotocol/go-sdk)" = "${GO_SDK_VERSION}"

--- a/docs/SECURITY_PATCHES.md
+++ b/docs/SECURITY_PATCHES.md
@@ -6,7 +6,7 @@
 
 - 既定: `ghcr.io/github/github-mcp-server:main`
 - 補足: 公式安定リリースの最新は `v1.0.0`（`v0.31.0` 以降 Streamable HTTP / `http` サブコマンドが正式搭載）
-- Security Scan補足: `Dockerfile.github-mcp-server` をベースに、workflow 側で `build-arg` により `go-sdk`（デフォルト: `v1.3.1`、`GITHUB_MCP_GO_SDK_VERSION` で上書き可）を指定してビルドしたイメージを Trivy でスキャン
+- Security Scan補足: `Dockerfile.github-mcp-server` をベースに、workflow 側で `build-arg` により `go-sdk`（デフォルト: `v1.5.0`、`GITHUB_MCP_GO_SDK_VERSION` で上書き可）を指定してビルドしたイメージを Trivy でスキャン（CVE-2026-27896 対応版。詳細: [CVE-2026-27896](https://nvd.nist.gov/vuln/detail/CVE-2026-27896)）
 
 ## 脆弱性管理
 

--- a/docs/design/pr-review-thread-list-design.md
+++ b/docs/design/pr-review-thread-list-design.md
@@ -61,14 +61,14 @@ Dockerfile.github-mcp-server ビルドフロー (変更後)
 │ Stage 2: builder (golang:1.26-bookworm)                          │
 │                                                                  │
 │  1. git fetch github/github-mcp-server@main              (既存)  │
-│  2. sed パッチ (Capabilities.Extensions → Experimental)   (既存)  │
-│  3. go mod edit -require=go-sdk@v1.3.1                   (既存)  │
+│  2. go mod edit -require=go-sdk@v1.5.0                   (既存)  │
+│     ※ CVE-2026-27896 対応済みリリースに固定                       │
 │  ↓                                                               │
-│  4. COPY patches/github/ → /src/pkg/github/              (追加)  │
+│  3. COPY patches/github/ → /src/pkg/github/              (追加)  │
 │     - list_pr_review_threads.go  ← 新ツール実装                  │
-│  5. RUN patch コマンドで server.go にツール登録を追記    (追加)  │
+│  4. RUN sed コマンドで tools.go にツール登録を追記       (追加)  │
 │  ↓                                                               │
-│  6. go build                                             (既存)  │
+│  5. go build                                             (既存)  │
 │                                                                  │
 └──────────────────────────────────────────────────────────────────┘
          │
@@ -300,10 +300,9 @@ RUN sed -i '/registerTool.*resolve_pull_request_review_thread/a\\t\tregisterTool
 ### 8.1 変更差分（概要）
 
 ```dockerfile
-# [既存] ソース取得・パッチ適用
+# [既存] ソース取得・依存バージョン固定 (CVE-2026-27896 対応: go-sdk@v1.5.0)
 RUN git init . && git remote add origin ... && git fetch ...
-RUN sed -i 's/Capabilities.Extensions/Capabilities.Experimental/g' ...
-RUN go mod edit -require=... && go mod tidy
+RUN go mod edit -require=github.com/modelcontextprotocol/go-sdk@v1.5.0 && go mod tidy
 
 # [追加] ここから
 # 新ツールの Go ファイルをソースツリーに注入


### PR DESCRIPTION
## Summary

- `Dockerfile.github-mcp-server` の `ARG GO_SDK_VERSION` を `v1.3.1` → `v1.5.0` に更新
- `security.yml` の `GITHUB_MCP_GO_SDK_VERSION` デフォルトを `v1.3.1` → `v1.5.0` に合わせ統一
- v1.3.1 向けの互換パッチ（`Capabilities.Extensions` → `Capabilities.Experimental` sed 置換）を除去

## 互換性検証

go-sdk v1.5.0 の `protocol.go` を確認した結果、`ClientCapabilities.Extensions` フィールドが正式に定義された:

```go
// Extensions reports extensions that the client supports.
Extensions map[string]any `json:"extensions,omitempty"`
```

upstream `github-mcp-server@a24c0be` の `ui_capability.go` は `Capabilities.Extensions[...]` を使用しており、v1.5.0 の API と整合する。  
v1.3.1 時代の sed パッチは不要になったため除去。

`patches/github/list_pr_review_threads.go` は github-mcp-server 内部 API のみを使用しており、go-sdk バージョンに依存しないため変更不要。

## 関連

Closes #87

## Test plan

- [ ] `make build-custom` でビルドが通ることを確認（CI で検証）
- [ ] Security Scan ワークフローが `v1.5.0` でビルド成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)