### PR TITLE
[codex] fix Codecov workflow guard

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -39,8 +39,6 @@ jobs:
   test-go:
     name: Goテスト（copilot-review-mcp）
     runs-on: ubuntu-latest
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 
@@ -54,11 +52,17 @@ jobs:
         working-directory: services/copilot-review-mcp
         run: go test -coverprofile=coverage.out -covermode=atomic ./...
 
+      - name: CODECOVトークン確認
+        id: token_check
+        env:
+          HAS_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
+        run: echo "available=$HAS_TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Codecovにアップロード（Go）
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: steps.token_check.outputs.available == 'true'
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: services/copilot-review-mcp/coverage.out
           flags: go
           fail_ci_if_error: true

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -39,6 +39,8 @@ jobs:
   test-go:
     name: Goテスト（copilot-review-mcp）
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 
@@ -53,10 +55,10 @@ jobs:
         run: go test -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Codecovにアップロード（Go）
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: services/copilot-review-mcp/coverage.out
           flags: go
           fail_ci_if_error: true

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,26 @@
+name: Workflow Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: GitHub Actions workflow lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Goセットアップ
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: actionlint実行
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -17,10 +17,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Goセットアップ
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-
       - name: actionlint実行
-        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+        uses: reviewdog/action-actionlint@v1


### PR DESCRIPTION
## Summary

- Fix the Codecov upload step so it does not reference `secrets` directly from a step `if:` condition.
- Add a lightweight `Workflow Lint` workflow using `actionlint` to catch GitHub Actions workflow syntax and context errors in PRs.

## Background

The recent Actions failure was a workflow file evaluation error, so it produced a failed Actions run without a normal PR job entry. This made the PR checks view look green while the Actions list showed a failure.

Refs #94

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --check`
