### PR TITLE
feat: github-oauth-proxy を mcp-gateway に移行

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,6 +22,11 @@ GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # 安定タグを固定したい場合のみコメントアウトを解除
 # GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:v1.0.0
 
+# mcp-gateway の利用イメージ
+# デフォルト: ghcr.io/scottlz0310/mcp-gateway:latest
+# 別タグを使う場合のみコメントアウトを解除
+# GITHUB_MCP_GATEWAY_IMAGE=ghcr.io/scottlz0310/mcp-gateway:latest
+
 # ローカルHTTP接続先 (IDE設定生成スクリプトで使用)
 # GITHUB_MCP_SERVER_URL=http://127.0.0.1:8082
 

--- a/.env.template
+++ b/.env.template
@@ -36,14 +36,14 @@ GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 LOG_LEVEL=info
 
 # =============================================================================
-# github-oauth-proxy (ISSUE #41) — mcp-remote経由でClaude Desktopから接続する場合
+# mcp-gateway — OAuth 2.0 認証ゲートウェイ（github-oauth-proxy の後継）
 # =============================================================================
 #
 # GitHub OAuth App の作成手順:
 #   1. https://github.com/settings/applications/new にアクセス
-#   2. Application name: 任意 (例: "GitHub MCP Proxy")
-#   3. Homepage URL: http://localhost:8084
-#   4. Authorization callback URL: http://localhost:8084/callback
+#   2. Application name: 任意 (例: "GitHub MCP Gateway")
+#   3. Homepage URL: http://localhost:8080
+#   4. Authorization callback URL: http://localhost:8080/callback
 #   5. 作成後に Client ID と Client Secret を取得
 #
 # 補足: copilot-review-mcp 用の GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET と
@@ -52,17 +52,13 @@ LOG_LEVEL=info
 # GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
 # GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# github-oauth-proxy の外部 URL（OAuth callback URL に使用）
-# デフォルト: http://localhost:8084
-# GITHUB_OAUTH_PROXY_BASE_URL=http://localhost:8084
+# mcp-gateway の外部 URL（OAuth callback URL に使用）
+# デフォルト: http://localhost:8080
+# MCP_GATEWAY_BASE_URL=http://localhost:8080
 
-# github-oauth-proxy のリッスンポート
-# デフォルト: 8084
-# GITHUB_OAUTH_PROXY_PORT=8084
-
-# 転送先 github-mcp-server の URL（Docker ネットワーク内部）
-# デフォルト: http://github-mcp:8082
-# GITHUB_MCP_UPSTREAM_URL=http://github-mcp:8082
+# mcp-gateway のリッスンポート
+# デフォルト: 8080
+# MCP_GATEWAY_PORT=8080
 
 # GitHub OAuth スコープ
 # デフォルト: repo,user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ 破壊的変更
+
+- `github-oauth-proxy` を `mcp-gateway` に置き換え（#N）
+  - **ポート変更**: `8084` → `8080`（`MCP_GATEWAY_PORT`）
+  - **環境変数変更**:
+    - `GITHUB_OAUTH_PROXY_BASE_URL` → `MCP_GATEWAY_BASE_URL`
+    - `GITHUB_OAUTH_PROXY_PORT` → `MCP_GATEWAY_PORT`
+    - `GITHUB_MCP_UPSTREAM_URL` を削除（`ROUTE_*` 環境変数に置き換え）
+  - `copilot-review-mcp` のホスト公開ポート（8083）を廃止し、mcp-gateway 経由のみに変更
+  - Makefile: `start-oauth` → `start-gateway`、`logs-oauth` → `logs-gateway`、`status-oauth` → `status-gateway`
+  - IDE設定スクリプト: `--service github-oauth-proxy` → `--service mcp-gateway`
+
+### ✨ 新機能
+
+- `mcp-gateway`（`ghcr.io/scottlz0310/mcp-gateway:latest`）をルーティングゲートウェイとして追加
+  - `ROUTE_GITHUB=/mcp/github|http://github-mcp:8082`
+  - `ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083`
+  - `github-mcp` と `copilot-review-mcp` の両サービスを単一ポートから提供
+  - OAuth 2.0 認証フローを gateway に一元化
+
 ## [2.5.0] - 2026-04-24
 
 ### 🗑️ 削除

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⚠️ 破壊的変更
 
-- `github-oauth-proxy` を `mcp-gateway` に置き換え（#N）
+- `github-oauth-proxy` を `mcp-gateway` に置き換え (#107)
   - **ポート変更**: `8084` → `8080`（`MCP_GATEWAY_PORT`）
   - **環境変数変更**:
     - `GITHUB_OAUTH_PROXY_BASE_URL` → `MCP_GATEWAY_BASE_URL`

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ start: ## GitHub MCPサーバー起動
 .PHONY: start-gateway
 start-gateway: ## mcp-gateway経由で起動（localhost:8080）
 	$(if $(and $(GITHUB_MCP_CLIENT_ID),$(GITHUB_MCP_CLIENT_SECRET)),,$(error ERROR: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET must be set in .env or environment))
+	$(if $(and $(GITHUB_CLIENT_ID),$(GITHUB_CLIENT_SECRET)),,$(error ERROR: GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET must be set in .env or environment (required by copilot-review-mcp)))
 	docker compose up -d github-mcp copilot-review-mcp mcp-gateway
 	@echo "Started mcp-gateway endpoint: http://127.0.0.1:$(or $(MCP_GATEWAY_PORT),8080)"
 

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ ifneq (,$(wildcard .env))
   GITHUB_PERSONAL_ACCESS_TOKEN ?= $(call ENV_GET,GITHUB_PERSONAL_ACCESS_TOKEN)
   BASE_URL                     ?= $(call ENV_GET,BASE_URL)
   GITHUB_OAUTH_SCOPES          ?= $(call ENV_GET,GITHUB_OAUTH_SCOPES)
-	GITHUB_OAUTH_PROXY_PORT      ?= $(call ENV_GET,GITHUB_OAUTH_PROXY_PORT)
+	MCP_GATEWAY_PORT             ?= $(call ENV_GET,MCP_GATEWAY_PORT)
 endif
 
-# oauth-proxy向け変数が空または未設定なら既存OAuth変数をフォールバック利用
+# mcp-gateway向け変数が空または未設定なら既存OAuth変数をフォールバック利用
 ifeq ($(strip $(GITHUB_MCP_CLIENT_ID)),)
 	GITHUB_MCP_CLIENT_ID := $(GITHUB_CLIENT_ID)
 endif
@@ -27,7 +27,7 @@ ifeq ($(strip $(GITHUB_MCP_CLIENT_SECRET)),)
 	GITHUB_MCP_CLIENT_SECRET := $(GITHUB_CLIENT_SECRET)
 endif
 # 子プロセス（docker compose / docker run）に確実に渡す
-export GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET GITHUB_MCP_CLIENT_ID GITHUB_MCP_CLIENT_SECRET GITHUB_PERSONAL_ACCESS_TOKEN BASE_URL GITHUB_OAUTH_SCOPES GITHUB_OAUTH_PROXY_PORT
+export GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET GITHUB_MCP_CLIENT_ID GITHUB_MCP_CLIENT_SECRET GITHUB_PERSONAL_ACCESS_TOKEN BASE_URL GITHUB_OAUTH_SCOPES MCP_GATEWAY_PORT
 
 .DEFAULT_GOAL := help
 
@@ -44,11 +44,11 @@ help: ## 利用可能なターゲット一覧を表示
 start: ## GitHub MCPサーバー起動
 	docker compose up -d github-mcp
 
-.PHONY: start-oauth
-start-oauth: ## OAuthプロキシ経由で起動（localhost:8084）
+.PHONY: start-gateway
+start-gateway: ## mcp-gateway経由で起動（localhost:8080）
 	$(if $(and $(GITHUB_MCP_CLIENT_ID),$(GITHUB_MCP_CLIENT_SECRET)),,$(error ERROR: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET must be set in .env or environment))
-	docker compose up -d github-mcp github-oauth-proxy
-	@echo "Started OAuth proxy endpoint: http://127.0.0.1:$(or $(GITHUB_OAUTH_PROXY_PORT),8084)"
+	docker compose up -d github-mcp copilot-review-mcp mcp-gateway
+	@echo "Started mcp-gateway endpoint: http://127.0.0.1:$(or $(MCP_GATEWAY_PORT),8080)"
 
 .PHONY: prepare
 prepare: ## 環境整備のみ実行（.env作成・事前確認）
@@ -65,17 +65,17 @@ restart: stop start ## 再起動
 logs: ## ログ表示
 	docker compose logs -f github-mcp
 
-.PHONY: logs-oauth
-logs-oauth: ## OAuthプロキシのログ表示
-	docker compose logs -f github-oauth-proxy
+.PHONY: logs-gateway
+logs-gateway: ## mcp-gatewayのログ表示
+	docker compose logs -f mcp-gateway
 
 .PHONY: status
 status: ## 状態確認
 	docker compose ps
 
-.PHONY: status-oauth
-status-oauth: ## github-mcp / OAuthプロキシの状態確認
-	docker compose ps github-mcp github-oauth-proxy
+.PHONY: status-gateway
+status-gateway: ## github-mcp / mcp-gateway / copilot-review-mcpの状態確認
+	docker compose ps github-mcp mcp-gateway copilot-review-mcp
 
 .PHONY: pull
 pull: ## Dockerイメージを取得

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ GitHub公式のMCPサーバーをDockerコンテナとして常駐させ、各ID
 
 - Docker 20.10+
 - GitHub Personal Access Token (PAT) または OAuth対応クライアント
-- Node.js 18+（`verify-mcp-endpoint.js` を使用する場合のみ）
+- Node.js 18+（`verify-mcp-endpoint.js` を使用する場合、または `generate-ide-config.sh --ide claude-desktop --service mcp-gateway` が生成する `npx mcp-remote` 設定で Claude Desktop を利用する場合に必要。Claude Desktop は `mcp-gateway` 経由ではなく `docker run -i --rm <image> stdio` による直接利用を推奨）
 
 ### インストール
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ OAuth プロキシ経由で接続する場合、MCP ホスト（各 IDE）の設
 
 ```
 IDE（VS Code / Cursor / Kiro 等）
-  │  URL のみ（OAuth プロキシ経由）または env var 参照（直接 HTTP 接続）
+  │  URL のみ（mcp-gateway 経由）または env var 参照（直接 HTTP 接続）
   ▼
-github-oauth-proxy  ←── Docker ランタイム内で PAT / OAuth トークンを保持
+mcp-gateway  ←── Docker ランタイム内で OAuth 認証・ルーティングを担当
   │
-  ▼
-github-mcp-server（Docker ネットワーク内に閉じ込め）
+  ├──▶ github-mcp-server（Docker ネットワーク内に閉じ込め）
+  └──▶ copilot-review-mcp（Docker ネットワーク内に閉じ込め）
 ```
 
 これにより：
@@ -57,7 +57,7 @@ GitHub公式のMCPサーバーをDockerコンテナとして常駐させ、各ID
 
 - Docker 20.10+
 - GitHub Personal Access Token (PAT) または OAuth対応クライアント
-- Node.js 18+（`--service github-oauth-proxy --ide claude-desktop` または `verify-mcp-endpoint.js` を使用する場合のみ）
+- Node.js 18+（`verify-mcp-endpoint.js` を使用する場合のみ）
 
 ### インストール
 
@@ -133,13 +133,13 @@ GITHUB_PERSONAL_ACCESS_TOKEN=ghp_your_token_here
 
 ### OAuthの準備（GitHub OAuth App登録）
 
-OAuthプロキシ経由で接続する場合は、GitHub OAuth App の Client ID / Client Secret が必要です。
+mcp-gateway 経由で接続する場合は、GitHub OAuth App の Client ID / Client Secret が必要です。
 
 1. GitHub OAuth App を作成
   - https://github.com/settings/applications/new にアクセス
-  - Application name: 任意（例: GitHub MCP Proxy）
-  - Homepage URL: http://localhost:8084
-  - Authorization callback URL: http://localhost:8084/callback
+  - Application name: 任意（例: GitHub MCP Gateway）
+  - Homepage URL: http://localhost:8080
+  - Authorization callback URL: http://localhost:8080/callback
 
 2. 作成後に Client ID と Client Secret を取得
 
@@ -149,26 +149,26 @@ OAuthプロキシ経由で接続する場合は、GitHub OAuth App の Client ID
 GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
 GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# 必要に応じて変更（未設定時は 8084）
-# GITHUB_OAUTH_PROXY_PORT=8084
-# GITHUB_OAUTH_PROXY_BASE_URL=http://localhost:8084
+# 必要に応じて変更（未設定時は 8080）
+# MCP_GATEWAY_PORT=8080
+# MCP_GATEWAY_BASE_URL=http://localhost:8080
 ```
 
-4. OAuthプロキシを起動
+4. mcp-gateway を起動
 
 ```bash
-make start-oauth
+make start-gateway
 ```
 
 5. 起動確認
 
 ```bash
-make status-oauth
-curl -i "http://127.0.0.1:${GITHUB_OAUTH_PROXY_PORT:-8084}/.well-known/oauth-authorization-server"
+make status-gateway
+curl -i "http://127.0.0.1:${MCP_GATEWAY_PORT:-8080}/health"
 ```
 
 補足:
-- callback URL は `GITHUB_OAUTH_PROXY_BASE_URL` と一致させてください（末尾 `/callback` を付与）。
+- callback URL は `MCP_GATEWAY_BASE_URL` と一致させてください（末尾 `/callback` を付与）。
 - `copilot-review-mcp` で使っている OAuth App を共有しても問題ありません。
 
 ## copilot-review-mcp
@@ -236,24 +236,26 @@ PR 作成直後または `request_copilot_review` ツール呼び出し直後に
 
 ## HTTPエンドポイント
 
-- 既定でホストに公開されるURL（OAuthプロキシ経由）: `http://127.0.0.1:8084`
-- `github-mcp` 本体の `8082` は Docker ネットワーク内向け（`expose`）で、ホスト直公開はしません。
-- OAuth で接続する場合は `make start-oauth` を実行してください。
+- mcp-gateway 経由 URL: `http://127.0.0.1:8080`
+  - GitHub MCP Server: `http://127.0.0.1:8080/mcp/github`
+  - Copilot Review MCP: `http://127.0.0.1:8080/mcp/copilot-review`
+- `github-mcp` と `copilot-review-mcp` は Docker ネットワーク内向け（`expose`）でホスト直公開しません。
+- mcp-gateway で接続するには `make start-gateway` を実行してください。
 - ポートを変更する場合:
-  - `GITHUB_OAUTH_PROXY_PORT`（未設定時は `8084`）
+  - `MCP_GATEWAY_PORT`（未設定時は `8080`）
   - `GITHUB_MCP_HTTP_PORT`（コンテナ内向け、未設定時は `8082`）
 - 直接 HTTP 接続するクライアントでは、必要に応じて `Authorization: Bearer <PAT/OAuth Token>` ヘッダーを送ってください。
 - Claude Desktop は `docker run -i ... stdio` で接続します。`-e GITHUB_PERSONAL_ACCESS_TOKEN`（値なし）を指定すると、ホスト環境変数を安全に受け渡せます。
-- 疎通確認（`200 OK` で discovery ドキュメントが返ることを確認）:
+- 疎通確認（`200 OK` でヘルス情報が返ることを確認）:
 
 ```bash
-curl -i "http://127.0.0.1:${GITHUB_OAUTH_PROXY_PORT:-8084}/.well-known/oauth-authorization-server"
+curl -i "http://127.0.0.1:${MCP_GATEWAY_PORT:-8080}/health"
 ```
 
 ```bash
-# 例: 18084でOAuthプロキシ起動
-export GITHUB_OAUTH_PROXY_PORT=18084
-make start-oauth
+# 例: 18080でmcp-gateway起動
+export MCP_GATEWAY_PORT=18080
+make start-gateway
 ```
 
 ```bash
@@ -363,8 +365,8 @@ make start
 # 起動（github-mcp本体のみ）
 make start
 
-# OAuthプロキシ経由で起動（localhost:8084）
-make start-oauth
+# OAuthプロキシ(mcp-gateway)経由で起動（localhost:8080）
+make start-gateway
 
 # 停止
 docker compose down
@@ -534,7 +536,7 @@ Mcp-Docker/
 ├── renovate.json              # Renovate 依存更新設定
 ├── services/
 │   ├── copilot-review-mcp/   # Copilot review 非同期 Watch MCP サーバー（Go）
-│   └── github-oauth-proxy/   # GitHub OAuth プロキシサーバー（Go）
+│   └── (github-oauth-proxy は削除 → mcp-gateway に移行)
 ├── config/
 │   └── github-mcp/           # github-mcp-server 設定
 ├── scripts/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - github-mcp-cache:/app/cache
 
     # Exposed only within the Docker network. Direct host access is intentionally
-    # removed; use github-oauth-proxy (:8084) for authenticated external access.
+    # removed; use mcp-gateway (:8080) for authenticated external access.
     expose:
       - "${GITHUB_MCP_HTTP_PORT:-8082}"
 
@@ -43,35 +43,33 @@ services:
           cpus: "0.5"
           memory: 256M
 
-  github-oauth-proxy:
-    build:
-      context: ./services/github-oauth-proxy
-      dockerfile: Dockerfile
-    image: github-oauth-proxy:local
-    container_name: github-oauth-proxy
+  mcp-gateway:
+    image: ${GITHUB_MCP_GATEWAY_IMAGE:-ghcr.io/scottlz0310/mcp-gateway:latest}
+    container_name: mcp-gateway
     restart: unless-stopped
     depends_on:
       - github-mcp
+      - copilot-review-mcp
 
     environment:
       - GITHUB_MCP_CLIENT_ID=${GITHUB_MCP_CLIENT_ID}
       - GITHUB_MCP_CLIENT_SECRET=${GITHUB_MCP_CLIENT_SECRET}
-      - GITHUB_OAUTH_PROXY_BASE_URL=${GITHUB_OAUTH_PROXY_BASE_URL:-http://localhost:8084}
-      - GITHUB_OAUTH_PROXY_PORT=${GITHUB_OAUTH_PROXY_PORT:-8084}
-      - GITHUB_MCP_UPSTREAM_URL=${GITHUB_MCP_UPSTREAM_URL:-http://github-mcp:8082}
+      - MCP_GATEWAY_BASE_URL=${MCP_GATEWAY_BASE_URL:-http://localhost:8080}
+      - MCP_GATEWAY_PORT=${MCP_GATEWAY_PORT:-8080}
+      - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}
+      - ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:${COPILOT_REVIEW_MCP_PORT:-8083}
       - GITHUB_MCP_OAUTH_SCOPES=${GITHUB_MCP_OAUTH_SCOPES:-repo,user}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - SESSION_TTL_MIN=${SESSION_TTL_MIN:-10}
-      - TOKEN_CACHE_TTL_MIN=${TOKEN_CACHE_TTL_MIN:-5}
+      - TOKEN_CACHE_TTL_MIN=${TOKEN_CACHE_TTL_MIN:-30}
       - TOKEN_EXPIRES_IN_SEC=${TOKEN_EXPIRES_IN_SEC:-7776000}
 
     ports:
-      - "127.0.0.1:${GITHUB_OAUTH_PROXY_PORT:-8084}:${GITHUB_OAUTH_PROXY_PORT:-8084}"
+      - "127.0.0.1:${MCP_GATEWAY_PORT:-8080}:${MCP_GATEWAY_PORT:-8080}"
 
     networks:
       - mcp-network
 
-    # Note: distroless image has no shell/wget. Health is validated host-side.
     healthcheck:
       disable: true
 
@@ -85,7 +83,7 @@ services:
       resources:
         limits:
           cpus: "0.5"
-          memory: 256M
+          memory: 128M
 
   copilot-review-mcp:
     build:
@@ -110,9 +108,14 @@ services:
       - MCP_PORT=${COPILOT_REVIEW_MCP_PORT:-8083}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - SESSION_TTL_MIN=${SESSION_TTL_MIN:-10}
-      - TOKEN_CACHE_TTL_MIN=${TOKEN_CACHE_TTL_MIN:-5}
-    ports:
-      - "127.0.0.1:${COPILOT_REVIEW_MCP_PORT:-8083}:${COPILOT_REVIEW_MCP_PORT:-8083}"
+      - TOKEN_CACHE_TTL_MIN=${TOKEN_CACHE_TTL_MIN:-30}
+
+    # mcp-gateway 経由でのみアクセス（http://localhost:8080/mcp/copilot-review）。
+    # ホストから直接アクセスする場合は下記のコメントを解除してください。
+    # ports:
+    #   - "127.0.0.1:${COPILOT_REVIEW_MCP_PORT:-8083}:${COPILOT_REVIEW_MCP_PORT:-8083}"
+    expose:
+      - "${COPILOT_REVIEW_MCP_PORT:-8083}"
 
     volumes:
       - copilot-review-data:/data

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -43,13 +43,15 @@ IDE名:
   GITHUB_MCP_IMAGE              コンテナイメージのオーバーライド（デフォルト: ghcr.io/github/github-mcp-server:main）
 
 環境変数 (copilot-review-mcp):
-  MCP_GATEWAY_URL               mcp-gateway の接続先 URL（未設定時は MCP_GATEWAY_PORT から生成）
-  MCP_GATEWAY_PORT              mcp-gateway のポート番号（デフォルト: 8080）
+  MCP_GATEWAY_URL               mcp-gateway の接続先 URL（優先）
+  MCP_GATEWAY_BASE_URL          mcp-gateway の接続先 URL（MCP_GATEWAY_URL 未設定時のフォールバック）
+  MCP_GATEWAY_PORT              mcp-gateway のポート番号（デフォルト: 8080、URL 未指定時に使用）
   GITHUB_PERSONAL_ACCESS_TOKEN  Bearer トークン（GitHub PAT, fine-grained 推奨）
 
 環境変数 (mcp-gateway):
-  MCP_GATEWAY_URL               HTTP 接続先 URL（未設定時は MCP_GATEWAY_PORT から生成）
-  MCP_GATEWAY_PORT              HTTP ポート番号（デフォルト: 8080）
+  MCP_GATEWAY_URL               HTTP 接続先 URL（優先）
+  MCP_GATEWAY_BASE_URL          HTTP 接続先 URL（MCP_GATEWAY_URL 未設定時のフォールバック）
+  MCP_GATEWAY_PORT              HTTP ポート番号（デフォルト: 8080、URL 未指定時に使用）
   GITHUB_PERSONAL_ACCESS_TOKEN  Bearer トークン（GitHub PAT または OAuth トークン）
 EOF
     exit 1

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -22,16 +22,16 @@ IDE名:
 
 サービス名 (--service):
   github-mcp          GitHub MCP Server（Docker ネットワーク内部のみ port 8082、ホストからは直接アクセス不可）
-                      ※ ホストから接続するには github-oauth-proxy 経由を推奨
-  copilot-review-mcp  Copilot Review MCP Server（OAuth 付き HTTP、port 8083）
-  github-oauth-proxy  GitHub OAuth Proxy（mcp-remote 経由 Claude Desktop 対応、port 8084）
+                      ※ ホストから接続するには mcp-gateway 経由を推奨
+  copilot-review-mcp  Copilot Review MCP Server（mcp-gateway 経由、port 8080）
+  mcp-gateway         MCP Gateway（OAuth 2.0 認証ゲートウェイ、port 8080）
                       ※ Claude Desktop から github-mcp-server に接続する場合はこちらを使用
 
 例:
   $0 --ide vscode
   $0 --ide vscode --service copilot-review-mcp
   $0 --ide claude-desktop
-  $0 --ide claude-desktop --service github-oauth-proxy
+  $0 --ide claude-desktop --service mcp-gateway
   $0 --ide amazonq --service copilot-review-mcp
   $0 --ide codex
   $0 --ide copilot-cli
@@ -43,13 +43,13 @@ IDE名:
   GITHUB_MCP_IMAGE              コンテナイメージのオーバーライド（デフォルト: ghcr.io/github/github-mcp-server:main）
 
 環境変数 (copilot-review-mcp):
-  COPILOT_REVIEW_MCP_URL        HTTP 接続先 URL（未設定時は COPILOT_REVIEW_MCP_PORT から生成）
-  COPILOT_REVIEW_MCP_PORT       HTTP ポート番号（デフォルト: 8083）
+  MCP_GATEWAY_URL               mcp-gateway の接続先 URL（未設定時は MCP_GATEWAY_PORT から生成）
+  MCP_GATEWAY_PORT              mcp-gateway のポート番号（デフォルト: 8080）
   GITHUB_PERSONAL_ACCESS_TOKEN  Bearer トークン（GitHub PAT, fine-grained 推奨）
 
-環境変数 (github-oauth-proxy):
-  GITHUB_OAUTH_PROXY_URL        HTTP 接続先 URL（未設定時は GITHUB_OAUTH_PROXY_PORT から生成）
-  GITHUB_OAUTH_PROXY_PORT       HTTP ポート番号（デフォルト: 8084）
+環境変数 (mcp-gateway):
+  MCP_GATEWAY_URL               HTTP 接続先 URL（未設定時は MCP_GATEWAY_PORT から生成）
+  MCP_GATEWAY_PORT              HTTP ポート番号（デフォルト: 8080）
   GITHUB_PERSONAL_ACCESS_TOKEN  Bearer トークン（GitHub PAT または OAuth トークン）
 EOF
     exit 1
@@ -78,7 +78,7 @@ if [[ -z "$IDE" ]]; then
 fi
 
 case "$SERVICE" in
-    github-mcp|copilot-review-mcp|github-oauth-proxy) ;;
+    github-mcp|copilot-review-mcp|mcp-gateway) ;;
     *) echo "❌ 未対応のサービス: $SERVICE"; usage ;;
 esac
 
@@ -118,34 +118,24 @@ resolve_server_url() {
 # ── URL 解決 ──────────────────────────────────────────────────────────────────
 
 resolve_copilot_review_url() {
-    local url="${COPILOT_REVIEW_MCP_URL:-}"
-    if [[ -z "${url}" ]]; then
-        url="$(extract_env_value "COPILOT_REVIEW_MCP_URL")"
-    fi
-    if [[ -z "${url}" ]]; then
-        local port="${COPILOT_REVIEW_MCP_PORT:-}"
-        if [[ -z "${port}" ]]; then
-            port="$(extract_env_value "COPILOT_REVIEW_MCP_PORT")"
-        fi
-        port="${port:-8083}"
-        url="http://127.0.0.1:${port}"
-    fi
-    url="${url%/}"
-    url="${url%/mcp}"  # ベースURLのみ受け付ける。末尾に /mcp が含まれていれば除去
-    echo "${url}"
+    # copilot-review-mcp は mcp-gateway 経由でアクセスする
+    # URL: <gateway_url>/mcp/copilot-review
+    local gateway_url
+    gateway_url="$(resolve_gateway_url)"
+    echo "${gateway_url}/mcp/copilot-review"
 }
 
-resolve_oauth_proxy_url() {
-    local url="${GITHUB_OAUTH_PROXY_URL:-}"
+resolve_gateway_url() {
+    local url="${MCP_GATEWAY_URL:-}"
     if [[ -z "${url}" ]]; then
-        url="$(extract_env_value "GITHUB_OAUTH_PROXY_URL")"
+        url="$(extract_env_value "MCP_GATEWAY_URL")"
     fi
     if [[ -z "${url}" ]]; then
-        local port="${GITHUB_OAUTH_PROXY_PORT:-}"
+        local port="${MCP_GATEWAY_PORT:-}"
         if [[ -z "${port}" ]]; then
-            port="$(extract_env_value "GITHUB_OAUTH_PROXY_PORT")"
+            port="$(extract_env_value "MCP_GATEWAY_PORT")"
         fi
-        port="${port:-8084}"
+        port="${port:-8080}"
         url="http://127.0.0.1:${port}"
     fi
     url="${url%/}"
@@ -155,12 +145,13 @@ resolve_oauth_proxy_url() {
 
 SERVER_URL="$(resolve_server_url)"
 COPILOT_REVIEW_URL="$(resolve_copilot_review_url)"
-OAUTH_PROXY_URL="$(resolve_oauth_proxy_url)"
+GATEWAY_URL="$(resolve_gateway_url)"
 
 # ── 出力先・サービス別ディスパッチ ───────────────────────────────────────────
 
 if [[ "$SERVICE" == "copilot-review-mcp" ]]; then
     CRM_SERVER_KEY="copilot-review-mcp"
+    # copilot-review-mcp は mcp-gateway 経由でアクセス
     CRM_MCP_URL="${COPILOT_REVIEW_URL}/mcp"
 
     # IDE の妥当性を先に検証（mkdir より前）
@@ -320,11 +311,11 @@ EOF
     exit 0
 fi
 
-# ── github-oauth-proxy サービス ──────────────────────────────────────────────
+# ── mcp-gateway サービス ─────────────────────────────────────────────────────
 
-if [[ "$SERVICE" == "github-oauth-proxy" ]]; then
-    GOP_SERVER_KEY="github-mcp-server-docker"
-    GOP_MCP_URL="${OAUTH_PROXY_URL}/mcp"
+if [[ "$SERVICE" == "mcp-gateway" ]]; then
+    GW_SERVER_KEY="github-mcp-server-docker"
+    GW_MCP_URL="${GATEWAY_URL}/mcp/github"
 
     case "$IDE" in
         vscode|claude-desktop|kiro|amazonq|codex|copilot-cli)
@@ -336,30 +327,30 @@ if [[ "$SERVICE" == "github-oauth-proxy" ]]; then
             ;;
     esac
 
-    GOP_OUTPUT_DIR="${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/${IDE}"
-    mkdir -p "${GOP_OUTPUT_DIR}"
+    GW_OUTPUT_DIR="${PROJECT_ROOT}/config/ide-configs/mcp-gateway/${IDE}"
+    mkdir -p "${GW_OUTPUT_DIR}"
 
     case "$IDE" in
         claude-desktop)
-            cat > "${GOP_OUTPUT_DIR}/claude_desktop_config.json" <<EOF
+            cat > "${GW_OUTPUT_DIR}/claude_desktop_config.json" <<EOF
 {
   "mcpServers": {
-    "${GOP_SERVER_KEY}": {
+    "${GW_SERVER_KEY}": {
       "command": "npx",
       "args": [
         "-y",
         "mcp-remote",
-        "${GOP_MCP_URL}"
+        "${GW_MCP_URL}"
       ]
     }
   }
 }
 EOF
-            echo "✅ Claude Desktop設定を生成しました: ${GOP_OUTPUT_DIR}/claude_desktop_config.json"
+            echo "✅ Claude Desktop設定を生成しました: ${GW_OUTPUT_DIR}/claude_desktop_config.json"
             echo ""
             echo "📋 設定方法:"
-            echo "   1. github-oauth-proxy / github-mcp サービスを起動:"
-            echo "      docker compose up -d github-mcp github-oauth-proxy"
+            echo "   1. mcp-gateway / github-mcp サービスを起動:"
+            echo "      make start-gateway"
             echo "   2. 生成された設定を Claude Desktop設定ファイルにマージ:"
             echo "      Windows: %APPDATA%\\Claude\\claude_desktop_config.json"
             echo "      macOS:   ~/Library/Application Support/Claude/claude_desktop_config.json"
@@ -367,16 +358,16 @@ EOF
             echo "   4. ブラウザで GitHub OAuth 認証フロー（初回のみ）"
             echo ""
             echo "ℹ️  mcp-remote が OAuth フローを自動的に処理します（ブラウザが開きます）"
-            echo "   接続先: ${GOP_MCP_URL}"
+            echo "   接続先: ${GW_MCP_URL}"
             ;;
 
         vscode)
-            cat > "${GOP_OUTPUT_DIR}/settings.json" <<EOF
+            cat > "${GW_OUTPUT_DIR}/settings.json" <<EOF
 {
   "mcpServers": {
-    "${GOP_SERVER_KEY}": {
+    "${GW_SERVER_KEY}": {
       "type": "http",
-      "url": "${GOP_MCP_URL}",
+      "url": "${GW_MCP_URL}",
       "headers": {
         "Authorization": "Bearer \${env:GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
@@ -384,25 +375,26 @@ EOF
   }
 }
 EOF
-            echo "✅ VS Code設定を生成しました: ${GOP_OUTPUT_DIR}/settings.json"
+            echo "✅ VS Code設定を生成しました: ${GW_OUTPUT_DIR}/settings.json"
             echo ""
             echo "📋 設定方法:"
-            echo "   1. github-oauth-proxy / github-mcp サービスを起動"
+            echo "   1. mcp-gateway / github-mcp サービスを起動:"
+            echo "      make start-gateway"
             echo "   2. VS Code設定 (.vscode/settings.json) に追加"
-            echo "   3. 接続先URL: ${GOP_MCP_URL}"
+            echo "   3. 接続先URL: ${GW_MCP_URL}"
             echo ""
             echo "💡 Bearer トークンの設定:"
             echo "   export GITHUB_PERSONAL_ACCESS_TOKEN=your_pat_here"
             ;;
 
         kiro)
-            cat > "${GOP_OUTPUT_DIR}/mcp.json" <<EOF
+            cat > "${GW_OUTPUT_DIR}/mcp.json" <<EOF
 {
   "mcp": {
     "servers": {
-      "${GOP_SERVER_KEY}": {
+      "${GW_SERVER_KEY}": {
         "type": "http",
-        "url": "${GOP_MCP_URL}",
+        "url": "${GW_MCP_URL}",
         "headers": {
           "Authorization": "Bearer \${GITHUB_PERSONAL_ACCESS_TOKEN}"
         }
@@ -411,17 +403,17 @@ EOF
   }
 }
 EOF
-            echo "✅ Kiro設定を生成しました: ${GOP_OUTPUT_DIR}/mcp.json"
-            echo "   接続先URL: ${GOP_MCP_URL}"
+            echo "✅ Kiro設定を生成しました: ${GW_OUTPUT_DIR}/mcp.json"
+            echo "   接続先URL: ${GW_MCP_URL}"
             ;;
 
         amazonq)
-            cat > "${GOP_OUTPUT_DIR}/mcp.json" <<EOF
+            cat > "${GW_OUTPUT_DIR}/mcp.json" <<EOF
 {
   "mcpServers": {
-    "${GOP_SERVER_KEY}": {
+    "${GW_SERVER_KEY}": {
       "type": "http",
-      "url": "${GOP_MCP_URL}",
+      "url": "${GW_MCP_URL}",
       "headers": {
         "Authorization": "Bearer \${env:GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
@@ -429,27 +421,27 @@ EOF
   }
 }
 EOF
-            echo "✅ Amazon Q設定を生成しました: ${GOP_OUTPUT_DIR}/mcp.json"
-            echo "   接続先URL: ${GOP_MCP_URL}"
+            echo "✅ Amazon Q設定を生成しました: ${GW_OUTPUT_DIR}/mcp.json"
+            echo "   接続先URL: ${GW_MCP_URL}"
             ;;
 
         codex)
-            cat > "${GOP_OUTPUT_DIR}/config.toml" <<EOF
-[mcp_servers.${GOP_SERVER_KEY}]
-url = "${GOP_MCP_URL}"
+            cat > "${GW_OUTPUT_DIR}/config.toml" <<EOF
+[mcp_servers.${GW_SERVER_KEY}]
+url = "${GW_MCP_URL}"
 bearer_token_env_var = "GITHUB_PERSONAL_ACCESS_TOKEN"
 EOF
-            echo "✅ Codex設定を生成しました: ${GOP_OUTPUT_DIR}/config.toml"
-            echo "   接続先URL: ${GOP_MCP_URL}"
+            echo "✅ Codex設定を生成しました: ${GW_OUTPUT_DIR}/config.toml"
+            echo "   接続先URL: ${GW_MCP_URL}"
             ;;
 
         copilot-cli)
-            cat > "${GOP_OUTPUT_DIR}/mcp-config.json" <<EOF
+            cat > "${GW_OUTPUT_DIR}/mcp-config.json" <<EOF
 {
   "mcpServers": {
-    "${GOP_SERVER_KEY}": {
+    "${GW_SERVER_KEY}": {
       "type": "http",
-      "url": "${GOP_MCP_URL}",
+      "url": "${GW_MCP_URL}",
       "headers": {
         "Authorization": "Bearer \${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
@@ -457,8 +449,8 @@ EOF
   }
 }
 EOF
-            echo "✅ Copilot CLI設定を生成しました: ${GOP_OUTPUT_DIR}/mcp-config.json"
-            echo "   接続先URL: ${GOP_MCP_URL}"
+            echo "✅ Copilot CLI設定を生成しました: ${GW_OUTPUT_DIR}/mcp-config.json"
+            echo "   接続先URL: ${GW_MCP_URL}"
             ;;
     esac
     exit 0
@@ -476,8 +468,8 @@ fi
 if [[ -z "${GITHUB_MCP_SERVER_URL:-}" ]] && [[ -z "$(extract_env_value "GITHUB_MCP_SERVER_URL")" ]]; then
     echo "⚠️  警告: github-mcp はホスト非公開（Docker ネットワーク内部のみ）です。"
     echo "   生成された設定の接続先 (${SERVER_URL}) には接続できない可能性があります。"
-    echo "   代わりに github-oauth-proxy 経由を使用することを推奨します:"
-    echo "   $0 --ide ${IDE} --service github-oauth-proxy"
+    echo "   代わりに mcp-gateway 経由を使用することを推奨します:"
+    echo "   $0 --ide ${IDE} --service mcp-gateway"
     echo ""
 fi
 

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -131,6 +131,12 @@ resolve_gateway_url() {
         url="$(extract_env_value "MCP_GATEWAY_URL")"
     fi
     if [[ -z "${url}" ]]; then
+        url="${MCP_GATEWAY_BASE_URL:-}"
+    fi
+    if [[ -z "${url}" ]]; then
+        url="$(extract_env_value "MCP_GATEWAY_BASE_URL")"
+    fi
+    if [[ -z "${url}" ]]; then
         local port="${MCP_GATEWAY_PORT:-}"
         if [[ -z "${port}" ]]; then
             port="$(extract_env_value "MCP_GATEWAY_PORT")"
@@ -152,7 +158,9 @@ GATEWAY_URL="$(resolve_gateway_url)"
 if [[ "$SERVICE" == "copilot-review-mcp" ]]; then
     CRM_SERVER_KEY="copilot-review-mcp"
     # copilot-review-mcp は mcp-gateway 経由でアクセス
-    CRM_MCP_URL="${COPILOT_REVIEW_URL}/mcp"
+    # resolve_copilot_review_url は最終 MCP エンドポイント(/mcp/copilot-review)を返すため
+    # 追加の /mcp は付与しない
+    CRM_MCP_URL="${COPILOT_REVIEW_URL}"
 
     # IDE の妥当性を先に検証（mkdir より前）
     case "$IDE" in
@@ -462,8 +470,8 @@ fi
 # になっています。GITHUB_MCP_SERVER_URL を明示的に設定していない場合、生成される設定の接続先
 # (http://127.0.0.1:8082) には接続できません。
 #
-# ホストから github-mcp-server に接続するには github-oauth-proxy 経由を推奨:
-#   $0 --ide ${IDE} --service github-oauth-proxy
+# ホストから github-mcp-server に接続するには mcp-gateway 経由を推奨:
+#   $0 --ide ${IDE} --service mcp-gateway
 #
 if [[ -z "${GITHUB_MCP_SERVER_URL:-}" ]] && [[ -z "$(extract_env_value "GITHUB_MCP_SERVER_URL")" ]]; then
     echo "⚠️  警告: github-mcp はホスト非公開（Docker ネットワーク内部のみ）です。"

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -14,7 +14,7 @@ usage() {
 オプション:
   --service <サービス名>  ヘルスチェック対象サービス (デフォルト: mcp-gateway)
                           mcp-gateway        : mcp-gateway 経由のエンドポイントを確認 (port 8080)
-                          copilot-review-mcp : copilot-review-mcp コンテナ状態 + mcp-gateway 経由で確認
+                          copilot-review-mcp : copilot-review-mcp / github-mcp / mcp-gateway の各コンテナ状態 + mcp-gateway 経由で確認
                           github-mcp         : github-mcp コンテナ状態のみ確認 (ホスト非公開のため HTTP 疎通不可)
   --with-api              GitHub API接続確認を必ず実行
   --no-api                GitHub API接続確認をスキップ

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -5,15 +5,16 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 ENV_FILE="${PROJECT_ROOT}/.env"
 WITH_API_CHECK="auto"
-SERVICE="github-oauth-proxy"
+SERVICE="mcp-gateway"
 
 usage() {
     cat <<EOF
 使用方法: $0 [オプション]
 
 オプション:
-  --service <サービス名>  ヘルスチェック対象サービス (デフォルト: github-oauth-proxy)
-                          github-oauth-proxy : OAuth プロキシ経由のエンドポイントを確認 (port 8084)
+  --service <サービス名>  ヘルスチェック対象サービス (デフォルト: mcp-gateway)
+                          mcp-gateway        : mcp-gateway 経由のエンドポイントを確認 (port 8080)
+                          copilot-review-mcp : copilot-review-mcp コンテナ状態 + mcp-gateway 経由で確認
                           github-mcp         : github-mcp コンテナ状態のみ確認 (ホスト非公開のため HTTP 疎通不可)
   --with-api              GitHub API接続確認を必ず実行
   --no-api                GitHub API接続確認をスキップ
@@ -49,10 +50,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$SERVICE" in
-    github-mcp|github-oauth-proxy) ;;
+    github-mcp|mcp-gateway|copilot-review-mcp) ;;
     *)
         echo "❌ 未対応のサービス: $SERVICE"
-        echo "対応サービス: github-mcp, github-oauth-proxy"
+        echo "対応サービス: github-mcp, mcp-gateway, copilot-review-mcp"
         exit 1
         ;;
 esac
@@ -105,17 +106,17 @@ extract_api_url_from_env_file() {
     extract_env_value "GITHUB_API_URL"
 }
 
-resolve_oauth_proxy_url() {
-    local url="${GITHUB_OAUTH_PROXY_URL:-}"
+resolve_gateway_url() {
+    local url="${MCP_GATEWAY_URL:-}"
     if [[ -z "${url}" ]]; then
-        url="$(extract_env_value "GITHUB_OAUTH_PROXY_URL")"
+        url="$(extract_env_value "MCP_GATEWAY_URL")"
     fi
     if [[ -z "${url}" ]]; then
-        local port="${GITHUB_OAUTH_PROXY_PORT:-}"
+        local port="${MCP_GATEWAY_PORT:-}"
         if [[ -z "${port}" ]]; then
-            port="$(extract_env_value "GITHUB_OAUTH_PROXY_PORT")"
+            port="$(extract_env_value "MCP_GATEWAY_PORT")"
         fi
-        port="${port:-8084}"
+        port="${port:-8080}"
         url="http://127.0.0.1:${port}"
     fi
     echo "${url%/}"
@@ -184,9 +185,9 @@ ensure_docker_ready
 
 if [[ "${SERVICE}" == "github-mcp" ]]; then
     # github-mcp はホスト非公開（Docker ネットワーク内部のみ）のため、
-    # コンテナ状態確認のみ実施。HTTP 疎通は github-oauth-proxy 経由で確認してください。
+    # コンテナ状態確認のみ実施。HTTP 疎通は mcp-gateway 経由で確認してください。
     echo "ℹ️  github-mcp はホスト非公開です。HTTP 疎通確認はスキップします。"
-    echo "   HTTP エンドポイントを確認する場合: $0 --service github-oauth-proxy"
+    echo "   HTTP エンドポイントを確認する場合: $0 --service mcp-gateway"
     echo ""
     check_container_state "github-mcp"
     echo ""
@@ -194,24 +195,48 @@ if [[ "${SERVICE}" == "github-mcp" ]]; then
     exit 0
 fi
 
-# github-oauth-proxy のヘルスチェック
+if [[ "${SERVICE}" == "copilot-review-mcp" ]]; then
+    check_container_state "github-mcp"
+    check_container_state "copilot-review-mcp"
+    check_container_state "mcp-gateway"
+    gateway_url="$(resolve_gateway_url)"
+    if command -v curl > /dev/null 2>&1; then
+        http_status="$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "${gateway_url}/health" || true)"
+        if [[ ! "${http_status}" =~ ^[0-9]{3}$ ]]; then
+            http_status="000"
+        fi
+        if [[ "${http_status}" == "200" ]]; then
+            echo "✅ mcp-gateway ヘルスエンドポイント疎通成功 (${gateway_url}/health, status=${http_status})"
+        else
+            echo "❌ mcp-gateway ヘルスエンドポイント疎通失敗 (${gateway_url}/health, status=${http_status})"
+            exit 1
+        fi
+    else
+        echo "⚠️  curl が未インストールのため、HTTP エンドポイント確認をスキップします"
+    fi
+    echo ""
+    echo "🎉 すべてのチェックに合格しました"
+    exit 0
+fi
+
+# mcp-gateway のヘルスチェック
 # github-mcp コンテナ状態も確認
 check_container_state "github-mcp"
-check_container_state "github-oauth-proxy"
+check_container_state "mcp-gateway"
 
-# HTTP エンドポイント確認 (github-oauth-proxy 経由)
-proxy_url="$(resolve_oauth_proxy_url)"
+# HTTP エンドポイント確認 (mcp-gateway 経由)
+gateway_url="$(resolve_gateway_url)"
 if command -v curl > /dev/null 2>&1; then
     # curl failures should not abort the script, so we use || true and check the result
-    http_status="$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "${proxy_url}/health" || true)"
+    http_status="$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "${gateway_url}/health" || true)"
     # 正常な3桁のHTTPステータスコードでない場合は "000" をデフォルトとする
     if [[ ! "${http_status}" =~ ^[0-9]{3}$ ]]; then
         http_status="000"
     fi
     if [[ "${http_status}" == "200" ]]; then
-        echo "✅ github-oauth-proxy ヘルスエンドポイント疎通成功 (${proxy_url}/health, status=${http_status})"
+        echo "✅ mcp-gateway ヘルスエンドポイント疎通成功 (${gateway_url}/health, status=${http_status})"
     else
-        echo "❌ github-oauth-proxy ヘルスエンドポイント疎通失敗 (${proxy_url}/health, status=${http_status})"
+        echo "❌ mcp-gateway ヘルスエンドポイント疎通失敗 (${gateway_url}/health, status=${http_status})"
         exit 1
     fi
 else

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -112,6 +112,12 @@ resolve_gateway_url() {
         url="$(extract_env_value "MCP_GATEWAY_URL")"
     fi
     if [[ -z "${url}" ]]; then
+        url="${MCP_GATEWAY_BASE_URL:-}"
+    fi
+    if [[ -z "${url}" ]]; then
+        url="$(extract_env_value "MCP_GATEWAY_BASE_URL")"
+    fi
+    if [[ -z "${url}" ]]; then
         local port="${MCP_GATEWAY_PORT:-}"
         if [[ -z "${port}" ]]; then
             port="$(extract_env_value "MCP_GATEWAY_PORT")"

--- a/tests/shell/test_scripts.bats
+++ b/tests/shell/test_scripts.bats
@@ -132,33 +132,33 @@ setup() {
     [[ "$output" =~ "HTTP only" ]] || [[ "$output" =~ "stdio" ]]
 }
 
-@test "generate-ide-config.sh: --service github-oauth-proxy claude-desktop 設定生成が動作する" {
-    run "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop --service github-oauth-proxy
+@test "generate-ide-config.sh: --service mcp-gateway claude-desktop 設定生成が動作する" {
+    run "${SCRIPTS_DIR}/generate-ide-config.sh" --ide claude-desktop --service mcp-gateway
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Claude Desktop設定を生成しました" ]]
-    [ -f "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/claude-desktop/claude_desktop_config.json" ]
-    grep -q '"mcp-remote"' "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/claude-desktop/claude_desktop_config.json"
-    grep -q '8084' "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/claude-desktop/claude_desktop_config.json"
+    [ -f "${PROJECT_ROOT}/config/ide-configs/mcp-gateway/claude-desktop/claude_desktop_config.json" ]
+    grep -q '"mcp-remote"' "${PROJECT_ROOT}/config/ide-configs/mcp-gateway/claude-desktop/claude_desktop_config.json"
+    grep -q '8080' "${PROJECT_ROOT}/config/ide-configs/mcp-gateway/claude-desktop/claude_desktop_config.json"
 }
 
-@test "generate-ide-config.sh: --service github-oauth-proxy vscode 設定生成が動作する" {
-    run "${SCRIPTS_DIR}/generate-ide-config.sh" --ide vscode --service github-oauth-proxy
+@test "generate-ide-config.sh: --service mcp-gateway vscode 設定生成が動作する" {
+    run "${SCRIPTS_DIR}/generate-ide-config.sh" --ide vscode --service mcp-gateway
     [ "$status" -eq 0 ]
     [[ "$output" =~ "VS Code設定を生成しました" ]]
-    [ -f "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/vscode/settings.json" ]
-    grep -q '8084' "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/vscode/settings.json"
+    [ -f "${PROJECT_ROOT}/config/ide-configs/mcp-gateway/vscode/settings.json" ]
+    grep -q '8080' "${PROJECT_ROOT}/config/ide-configs/mcp-gateway/vscode/settings.json"
 }
 
-@test "generate-ide-config.sh: --service github-oauth-proxy codex 設定生成が動作する" {
-    run "${SCRIPTS_DIR}/generate-ide-config.sh" --ide codex --service github-oauth-proxy
+@test "generate-ide-config.sh: --service mcp-gateway codex 設定生成が動作する" {
+    run "${SCRIPTS_DIR}/generate-ide-config.sh" --ide codex --service mcp-gateway
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Codex設定を生成しました" ]]
-    [ -f "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/codex/config.toml" ]
-    grep -q '8084' "${PROJECT_ROOT}/config/ide-configs/github-oauth-proxy/codex/config.toml"
+    [ -f "${PROJECT_ROOT}/config/ide-configs/mcp-gateway/codex/config.toml" ]
+    grep -q '8080' "${PROJECT_ROOT}/config/ide-configs/mcp-gateway/codex/config.toml"
 }
 
 @test "health-check.sh: --helpオプションにサービス説明が含まれる" {
     run "${SCRIPTS_DIR}/health-check.sh" --help
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "github-oauth-proxy" ]]
+    [[ "$output" =~ "mcp-gateway" ]]
 }


### PR DESCRIPTION
## 概要

spike-18 調査の結果、`copilot-review-mcp` はコード変更なしで `mcp-gateway` 経由の OAuth 認証に対応可能であることが確認されました。本 PR はその知見をもとに、`github-oauth-proxy`（ポート 8084）を `mcp-gateway`（ポート 8080）へ完全移行します。

## BREAKING CHANGES

- **MCP URL の変更が必要**: 既存の IDE 設定で `localhost:8084` を使用している場合、`localhost:8080/mcp/github` または `localhost:8080/mcp/copilot-review` に更新してください。
- `make start-oauth` → `make start-gateway`
- `GITHUB_OAUTH_PROXY_PORT` → `MCP_GATEWAY_PORT`

## 変更内容

### docker-compose.yml
- `github-oauth-proxy` サービスを `mcp-gateway`（`ghcr.io/scottlz0310/mcp-gateway:latest`）に置き換え
- ルーティング設定:
  - `ROUTE_GITHUB=/mcp/github|http://github-mcp:8082`
  - `ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083`
- `copilot-review-mcp` の `ports` をホスト非公開の `expose` に変更（gateway 経由のみアクセス）

### .env.template
- mcp-gateway 向け環境変数に更新（ポート 8084 → 8080）
- `GITHUB_MCP_UPSTREAM_URL` 削除、`MCP_GATEWAY_BASE_URL` / `MCP_GATEWAY_PORT` 追加

### Makefile
- `start/logs/status-oauth` → `start/logs/status-gateway`
- `GITHUB_OAUTH_PROXY_PORT` → `MCP_GATEWAY_PORT`

### scripts/generate-ide-config.sh
- `resolve_gateway_url()` 追加
- `copilot-review-mcp` の URL を `/mcp/copilot-review` 経由に変更

### scripts/health-check.sh
- デフォルトサービスを `mcp-gateway` に変更
- `copilot-review-mcp` サービスケース追加

### tests/shell/test_scripts.bats
- `github-oauth-proxy` テストを `mcp-gateway` 相当に更新（3テスト）

### README.md / CHANGELOG.md
- アーキテクチャ図、OAuth 設定、HTTP エンドポイントセクションを全更新

## 動作確認

spike-18 にて `gho_` トークンが `https://api.githubcopilot.com/mcp/` で有効であることを確認済み。mcp-gateway の内部ルーティングにより `copilot-review-mcp` も同一ゲートウェイ経由で接続可能。

## 参考

- [spike-18-copilot-api-auth.md](https://github.com/scottlz0310/mcp-gateway/blob/main/docs/spike-18-copilot-api-auth.md)
- [mcp-gateway リポジトリ](https://github.com/scottlz0310/mcp-gateway)
