### PR TITLE
fix: update copilot-instructions.md for mcp-gateway migration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,8 +4,10 @@
 
 ```
 IDEs (VS Code / Cursor / Kiro / Amazon Q / Copilot CLI)
-  ↓ HTTP (port 8082)
-Docker: ghcr.io/github/github-mcp-server  ← official image (default)
+  ↓ HTTP (port 8080)
+Docker: ghcr.io/scottlz0310/mcp-gateway  ← OAuth 2.0 ゲートウェイ
+  ↓ /mcp/github         ↓ /mcp/copilot-review
+ghcr.io/github/github-mcp-server   copilot-review-mcp
   ↓
 GitHub API (REST v3 + GraphQL v4)
 
@@ -44,10 +46,10 @@ make clean-all       # Full cleanup including images
 ## Conventions
 
 - **Environment-first auth**: `GITHUB_PERSONAL_ACCESS_TOKEN` env var always wins over `.env` file. Set both consistently to avoid confusion.
-- **Port**: Default MCP HTTP port is `8082`. Override with `GITHUB_MCP_HTTP_PORT`.
+- **Port**: IDEs connect to `mcp-gateway` on port `8080` (`MCP_GATEWAY_PORT`). `github-mcp-server` runs on internal port `8082` (`GITHUB_MCP_HTTP_PORT`, not exposed to host).
 - **Image override**: Set `GITHUB_MCP_IMAGE` to swap the default container image.
 - **HTTP transport: supported in stable releases `v0.31.0+`**: Stable releases `v0.31.0` and later include native Streamable HTTP support (`http` subcommand). `v1.0.0` is the current latest stable. Use `main` for cutting-edge features.
-- **Claude Desktop exception**: HTTP transport 非対応のため、`docker run -i --rm <image> stdio` で直接起動する。VS Code/Cursor/Kiro/Amazon Q/Codex/Copilot CLI は HTTP (port 8082) に接続する。
+- **Claude Desktop exception**: HTTP transport 非対応のため、`docker run -i --rm <image> stdio` で直接起動する。VS Code/Cursor/Kiro/Amazon Q/Codex/Copilot CLI は HTTP (port 8080, mcp-gateway 経由) に接続する。
 - **Distroless container**: The container has no shell. Health checks are done host-side via `scripts/health-check.sh`, not inside the container.
 - **Documentation language**: User-facing docs, Makefile help output, and messages are written in Japanese.
 - **MCP server key**: Always use `github-mcp-server-docker` as the server identifier in IDE configs.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,9 +5,9 @@
 ```
 IDEs (VS Code / Cursor / Kiro / Amazon Q / Copilot CLI)
   ↓ HTTP (port 8080)
-Docker: ghcr.io/scottlz0310/mcp-gateway  ← OAuth 2.0 ゲートウェイ
+Docker: ghcr.io/scottlz0310/mcp-gateway:latest  ← OAuth 2.0 ゲートウェイ（compose デフォルト）
   ↓ /mcp/github         ↓ /mcp/copilot-review
-ghcr.io/github/github-mcp-server   copilot-review-mcp
+ghcr.io/github/github-mcp-server:main   copilot-review-mcp
   ↓
 GitHub API (REST v3 + GraphQL v4)
 
@@ -46,8 +46,8 @@ make clean-all       # Full cleanup including images
 ## Conventions
 
 - **Environment-first auth**: `GITHUB_PERSONAL_ACCESS_TOKEN` env var always wins over `.env` file. Set both consistently to avoid confusion.
-- **Port**: IDEs connect to `mcp-gateway` on port `8080` (`MCP_GATEWAY_PORT`). `github-mcp-server` runs on internal port `8082` (`GITHUB_MCP_HTTP_PORT`, not exposed to host).
-- **Image override**: Set `GITHUB_MCP_IMAGE` to swap the default container image.
+- **Port**: IDEs connect to `mcp-gateway` on port `8080` (`MCP_GATEWAY_PORT`). `github-mcp-server` runs on internal port `8082` (`GITHUB_MCP_HTTP_PORT`, not exposed to host), and `copilot-review-mcp` runs on internal port `8083` (`COPILOT_REVIEW_MCP_PORT`, also not exposed to host; reachable only via the gateway).
+- **Image override**: Set `GITHUB_MCP_GATEWAY_IMAGE` to swap the default `mcp-gateway` image, and set `GITHUB_MCP_IMAGE` to swap the default `github-mcp-server` image.
 - **HTTP transport: supported in stable releases `v0.31.0+`**: Stable releases `v0.31.0` and later include native Streamable HTTP support (`http` subcommand). `v1.0.0` is the current latest stable. Use `main` for cutting-edge features.
 - **Claude Desktop exception**: HTTP transport 非対応のため、`docker run -i --rm <image> stdio` で直接起動する。VS Code/Cursor/Kiro/Amazon Q/Codex/Copilot CLI は HTTP (port 8080, mcp-gateway 経由) に接続する。
 - **Distroless container**: The container has no shell. Health checks are done host-side via `scripts/health-check.sh`, not inside the container.


### PR DESCRIPTION
## 概要

`.github/copilot-instructions.md` のアーキテクチャ図とポート記述を mcp-gateway 移行後の状態に更新します。

## 変更内容

- **アーキテクチャ図**: IDE → `mcp-gateway` (port 8080) → `github-mcp-server` / `copilot-review-mcp` のフローに更新。`ghcr.io/scottlz0310/mcp-gateway:latest` / `ghcr.io/github/github-mcp-server:main` のイメージタグも明記
- **Port 規約**: IDE は port 8080 (mcp-gateway) に接続。`github-mcp-server` の内部ポート 8082、`copilot-review-mcp` の内部ポート 8083 はホスト非公開であることを明記
- **Image override 規約**: `GITHUB_MCP_GATEWAY_IMAGE`（mcp-gateway）と `GITHUB_MCP_IMAGE`（github-mcp-server）を並記
- **Claude Desktop 例外**: Claude Desktop は HTTP transport 非対応のため、`docker run -i --rm <image> stdio` で直接起動することを明記（mcp-gateway 経由なし）。他 IDE（VS Code/Cursor/Kiro/Amazon Q/Codex/Copilot CLI）は port 8080 経由

## 関連

- #107 (mcp-gateway 移行) のフォローアップ