### PR TITLE
feat: auth=none ルートで認証不要 MCP サーバを設定のみで追加できるパターンを示す

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -74,7 +74,7 @@ LOG_LEVEL=info
 # =============================================================================
 #
 # mcp-gateway が auth=none をサポートしている場合、認証不要な MCP サーバを
-# docker-compose.yml にサービスを追加するだけで接続できます。
+# docker-compose.yml にサービス定義・ROUTE_* 環境変数・depends_on を追加するだけで接続できます。
 #
 # 設定手順:
 #   1. docker-compose.yml の playwright-mcp サービスブロックのコメントを解除

--- a/.env.template
+++ b/.env.template
@@ -68,3 +68,23 @@ LOG_LEVEL=info
 # GitHub OAuth スコープ
 # デフォルト: repo,user
 # GITHUB_MCP_OAUTH_SCOPES=repo,user
+
+# =============================================================================
+# auth=none ルート例: playwright-mcp（認証不要 MCP サーバの追加パターン）
+# =============================================================================
+#
+# mcp-gateway が auth=none をサポートしている場合、認証不要な MCP サーバを
+# docker-compose.yml にサービスを追加するだけで接続できます。
+#
+# 設定手順:
+#   1. docker-compose.yml の playwright-mcp サービスブロックのコメントを解除
+#   2. docker-compose.yml の ROUTE_PLAYWRIGHT 行のコメントを解除
+#   3. docker-compose.yml の depends_on の playwright-mcp 行のコメントを解除
+#   4. IDE 設定に "playwright": {"url": "http://127.0.0.1:8080/mcp/playwright"} を追加
+#   5. make restart で全サービスを再起動
+#
+# playwright-mcp のイメージ（デフォルト: ghcr.io/microsoft/playwright-mcp:latest）
+# PLAYWRIGHT_MCP_IMAGE=ghcr.io/microsoft/playwright-mcp:latest
+#
+# playwright-mcp のリッスンポート（デフォルト: 8931）
+# PLAYWRIGHT_MCP_PORT=8931

--- a/.env.template
+++ b/.env.template
@@ -76,12 +76,11 @@ LOG_LEVEL=info
 # mcp-gateway が auth=none をサポートしている場合、認証不要な MCP サーバを
 # docker-compose.yml にサービス定義・ROUTE_* 環境変数・depends_on を追加するだけで接続できます。
 #
-# 設定手順:
-#   1. docker-compose.yml の playwright-mcp サービスブロックのコメントを解除
-#   2. docker-compose.yml の ROUTE_PLAYWRIGHT 行のコメントを解除
-#   3. docker-compose.yml の depends_on の playwright-mcp 行のコメントを解除
-#   4. IDE 設定に "playwright": {"url": "http://127.0.0.1:8080/mcp/playwright"} を追加
-#   5. make restart で全サービスを再起動
+# playwright-mcp は docker-compose.yml にデフォルトで有効化されています。
+# 使用しない場合は docker-compose.yml から以下を削除してください:
+#   - playwright-mcp サービス定義
+#   - mcp-gateway の depends_on: playwright-mcp
+#   - mcp-gateway の ROUTE_PLAYWRIGHT 環境変数
 #
 # playwright-mcp のイメージ（デフォルト: mcr.microsoft.com/playwright/mcp:latest）
 # PLAYWRIGHT_MCP_IMAGE=mcr.microsoft.com/playwright/mcp:latest

--- a/.env.template
+++ b/.env.template
@@ -83,8 +83,8 @@ LOG_LEVEL=info
 #   4. IDE 設定に "playwright": {"url": "http://127.0.0.1:8080/mcp/playwright"} を追加
 #   5. make restart で全サービスを再起動
 #
-# playwright-mcp のイメージ（デフォルト: ghcr.io/microsoft/playwright-mcp:latest）
-# PLAYWRIGHT_MCP_IMAGE=ghcr.io/microsoft/playwright-mcp:latest
+# playwright-mcp のイメージ（デフォルト: mcr.microsoft.com/playwright/mcp:latest）
+# PLAYWRIGHT_MCP_IMAGE=mcr.microsoft.com/playwright/mcp:latest
 #
 # playwright-mcp のリッスンポート（デフォルト: 8931）
 # PLAYWRIGHT_MCP_PORT=8931

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -2,10 +2,15 @@
   "mcpServers": {
     "github": {
       "type": "http",
-      "url": "http://127.0.0.1:8082",
-      "headers": {
-        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
-      }
+      "url": "http://127.0.0.1:8080/mcp/github"
+    },
+    "copilot-review": {
+      "type": "http",
+      "url": "http://127.0.0.1:8080/mcp/copilot-review"
+    },
+    "playwright": {
+      "type": "http",
+      "url": "http://127.0.0.1:8080/mcp/playwright"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✨ 新機能
 
 - `auth=none` ルートで認証不要 MCP サーバを設定のみで追加できるパターンを追加（#109）
-  - `docker-compose.yml` に `playwright-mcp` サービスのコメントアウト例を追加
-  - `mcp-gateway` の `environment` に `ROUTE_PLAYWRIGHT=.../auth=none` のコメント例を追加
+  - `docker-compose.yml` に `playwright-mcp` サービスをデフォルト有効化済みの設定例として追加
+  - `mcp-gateway` の `environment` に `ROUTE_PLAYWRIGHT=.../auth=none` をデフォルト有効化
+  - `playwright-mcp` を使用しない場合は `depends_on`・`ROUTE_PLAYWRIGHT`・サービス定義を削除してください
   - `.env.template` に `PLAYWRIGHT_MCP_IMAGE` / `PLAYWRIGHT_MCP_PORT` の説明と手順を追加
   - README に「MCPサーバの追加パターン（auth=none）」セクションを追加
   - 前提: `mcp-gateway` の `auth=none` サポート（scottlz0310/mcp-gateway#23 でマージ済み）
+- `copilot-review-mcp` のイメージをローカルビルドから公開パッケージ（`ghcr.io/scottlz0310/copilot-review-mcp:latest`）に変更
+  - `COPILOT_REVIEW_MCP_IMAGE` 環境変数でオーバーライド可能
 
 ### ⚠️ 破壊的変更
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `mcp-gateway` の `environment` に `ROUTE_PLAYWRIGHT=.../auth=none` のコメント例を追加
   - `.env.template` に `PLAYWRIGHT_MCP_IMAGE` / `PLAYWRIGHT_MCP_PORT` の説明と手順を追加
   - README に「MCPサーバの追加パターン（auth=none）」セクションを追加
+  - 前提: `mcp-gateway` の `auth=none` サポート（scottlz0310/mcp-gateway#23 でマージ済み）
 
 ### ⚠️ 破壊的変更
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ 新機能
+
+- `auth=none` ルートで認証不要 MCP サーバを設定のみで追加できるパターンを追加（#109）
+  - `docker-compose.yml` に `playwright-mcp` サービスのコメントアウト例を追加
+  - `mcp-gateway` の `environment` に `ROUTE_PLAYWRIGHT=.../auth=none` のコメント例を追加
+  - `.env.template` に `PLAYWRIGHT_MCP_IMAGE` / `PLAYWRIGHT_MCP_PORT` の説明と手順を追加
+  - README に「MCPサーバの追加パターン（auth=none）」セクションを追加
+
 ### ⚠️ 破壊的変更
 
 - `github-oauth-proxy` を `mcp-gateway` に置き換え (#107)

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ mcp-gateway(:8080)
 
 ### 追加手順
 
-新しい MCP サーバ（例: playwright-mcp）を追加するには以下の3ファイルを変更します。
+新しい MCP サーバ（例: playwright-mcp）を追加するには以下の2箇所を変更します。
 
 #### 1. `docker-compose.yml` — サービスのコメント解除
 
@@ -272,7 +272,7 @@ mcp-gateway(:8080)
     depends_on:
       - playwright-mcp          # ← コメント解除
     environment:
-      - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:8931|auth=none  # ← コメント解除
+      - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none  # ← コメント解除
 ```
 
 #### 2. IDE設定 — パスを追加

--- a/README.md
+++ b/README.md
@@ -247,33 +247,38 @@ mcp-gateway(:8080)
   └── /mcp/playwright      → playwright-mcp      [auth=none]   認証不要
 ```
 
-### 追加手順
+### 設定例（playwright-mcp はデフォルトで有効化済み）
 
-新しい MCP サーバ（例: playwright-mcp）を追加するには以下の2箇所を変更します。
+`playwright-mcp` は `docker-compose.yml` にデフォルトで有効化された設定例として含まれています。
+新しい認証不要 MCP サーバを追加する場合は、同様の3箇所を変更してください。
 
-#### 1. `docker-compose.yml` — サービスのコメント解除
+#### 1. `docker-compose.yml` — サービス定義と mcp-gateway 設定
+
+サービス定義を追加します（`docker-compose.yml` の playwright-mcp セクションを参照）:
 
 ```yaml
   playwright-mcp:
     image: ${PLAYWRIGHT_MCP_IMAGE:-mcr.microsoft.com/playwright/mcp:latest}
     container_name: playwright-mcp
     restart: unless-stopped
-    command: ["--port", "${PLAYWRIGHT_MCP_PORT:-8931}", "--host", "0.0.0.0"]
+    command: ["--port", "${PLAYWRIGHT_MCP_PORT:-8931}", "--host", "0.0.0.0", "--allowed-hosts", "*"]
     expose:
       - "${PLAYWRIGHT_MCP_PORT:-8931}"
     networks:
       - mcp-network
 ```
 
-`mcp-gateway` の `environment` と `depends_on` のコメントも同時に解除します:
+`mcp-gateway` の `environment` と `depends_on` にも追加します:
 
 ```yaml
   mcp-gateway:
     depends_on:
-      - playwright-mcp          # ← コメント解除
+      - playwright-mcp
     environment:
-      - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none  # ← コメント解除
+      - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
 ```
+
+> **Note**: `playwright-mcp` を使用しない場合は、上記の `depends_on` エントリと `ROUTE_PLAYWRIGHT` 行を削除し、`playwright-mcp` サービス定義も削除してください。
 
 #### 2. IDE設定 — パスを追加
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,75 @@ cp docs/skills/pr-review-cycle.md ~/.claude/skills/
 
 PR 作成直後または `request_copilot_review` ツール呼び出し直後に `/pr-review-cycle` スキルを起動するだけです。
 
+## MCPサーバの追加パターン（auth=none）
+
+mcp-gateway の `auth=none` オプションを使うと、認証不要な MCP サーバをコード変更なしで設定のみで追加できます。
+
+### ルーティング設計
+
+```
+mcp-gateway(:8080)
+  ├── /mcp/github          → github-mcp          [auth=oauth]  OAuth必須
+  ├── /mcp/copilot-review  → copilot-review-mcp  [auth=oauth]  OAuth必須
+  └── /mcp/playwright      → playwright-mcp      [auth=none]   認証不要
+```
+
+### 追加手順
+
+新しい MCP サーバ（例: playwright-mcp）を追加するには以下の3ファイルを変更します。
+
+#### 1. `docker-compose.yml` — サービスのコメント解除
+
+```yaml
+  playwright-mcp:
+    image: ${PLAYWRIGHT_MCP_IMAGE:-ghcr.io/microsoft/playwright-mcp:latest}
+    container_name: playwright-mcp
+    restart: unless-stopped
+    expose:
+      - "${PLAYWRIGHT_MCP_PORT:-8931}"
+    networks:
+      - mcp-network
+```
+
+`mcp-gateway` の `environment` と `depends_on` のコメントも同時に解除します:
+
+```yaml
+  mcp-gateway:
+    depends_on:
+      - playwright-mcp          # ← コメント解除
+    environment:
+      - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:8931|auth=none  # ← コメント解除
+```
+
+#### 2. IDE設定 — パスを追加
+
+ホスト・ポートは `127.0.0.1:8080` のまま、パスだけ追加します。
+
+```json
+{
+  "mcpServers": {
+    "github":     { "url": "http://127.0.0.1:8080/mcp/github" },
+    "playwright": { "url": "http://127.0.0.1:8080/mcp/playwright" }
+  }
+}
+```
+
+#### 3. 再起動
+
+```bash
+make restart
+```
+
+### 汎用手順（任意の MCP サーバ）
+
+任意の認証不要 Streamable HTTP MCP サーバを追加する場合:
+
+1. `docker-compose.yml` にサービス定義を追加
+2. `mcp-gateway` の `environment` に `ROUTE_<NAME>=/<path>|http://<service>:<port>|auth=none` を追加
+3. `mcp-gateway` の `depends_on` に新サービスを追加
+4. IDE 設定に `"url": "http://127.0.0.1:8080/<path>"` を追加
+5. `make restart` で再起動
+
 ## HTTPエンドポイント
 
 - mcp-gateway 経由 URL: `http://127.0.0.1:8080`

--- a/README.md
+++ b/README.md
@@ -255,9 +255,10 @@ mcp-gateway(:8080)
 
 ```yaml
   playwright-mcp:
-    image: ${PLAYWRIGHT_MCP_IMAGE:-ghcr.io/microsoft/playwright-mcp:latest}
+    image: ${PLAYWRIGHT_MCP_IMAGE:-mcr.microsoft.com/playwright/mcp:latest}
     container_name: playwright-mcp
     restart: unless-stopped
+    command: ["--port", "${PLAYWRIGHT_MCP_PORT:-8931}", "--host", "0.0.0.0"]
     expose:
       - "${PLAYWRIGHT_MCP_PORT:-8931}"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,8 @@ services:
     depends_on:
       - github-mcp
       - copilot-review-mcp
+      # playwright-mcp を有効にした場合はコメントを解除する
+      # - playwright-mcp
 
     environment:
       - GITHUB_MCP_CLIENT_ID=${GITHUB_MCP_CLIENT_ID}
@@ -58,6 +60,8 @@ services:
       - MCP_GATEWAY_PORT=${MCP_GATEWAY_PORT:-8080}
       - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}
       - ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:${COPILOT_REVIEW_MCP_PORT:-8083}
+      # auth=none ルート例: 認証不要な MCP サーバを追加する場合は下記のようにコメントを解除する
+      # - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
       - GITHUB_MCP_OAUTH_SCOPES=${GITHUB_MCP_OAUTH_SCOPES:-repo,user}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - SESSION_TTL_MIN=${SESSION_TTL_MIN:-10}
@@ -138,6 +142,32 @@ services:
         limits:
           cpus: "0.5"
           memory: 256M
+
+  # =============================================================================
+  # auth=none ルートの例: 認証不要な MCP サーバを追加するパターン
+  # =============================================================================
+  # 手順:
+  #   1. 下記ブロックのコメントを解除してサービスを有効化する
+  #   2. mcp-gateway の ROUTE_PLAYWRIGHT 行のコメントを解除する
+  #   3. mcp-gateway の depends_on に playwright-mcp を追加する（上記コメント参照）
+  #   4. IDE 設定に "playwright": {"url": "http://127.0.0.1:8080/mcp/playwright"} を追加する
+  #   5. make restart で全サービスを再起動する
+  #
+  # playwright-mcp:
+  #   image: ${PLAYWRIGHT_MCP_IMAGE:-ghcr.io/microsoft/playwright-mcp:latest}
+  #   container_name: playwright-mcp
+  #   restart: unless-stopped
+  #   expose:
+  #     - "${PLAYWRIGHT_MCP_PORT:-8931}"
+  #   networks:
+  #     - mcp-network
+  #   healthcheck:
+  #     disable: true
+  #   logging:
+  #     driver: "json-file"
+  #     options:
+  #       max-size: "10m"
+  #       max-file: "3"
 
 volumes:
   github-mcp-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,10 +88,7 @@ services:
           memory: 128M
 
   copilot-review-mcp:
-    build:
-      context: ./services/copilot-review-mcp
-      dockerfile: Dockerfile
-    image: copilot-review-mcp:local
+    image: ${COPILOT_REVIEW_MCP_IMAGE:-ghcr.io/scottlz0310/copilot-review-mcp:latest}
     container_name: copilot-review-mcp
     restart: unless-stopped
     # distroless:nonroot の UID/GID を明示（UID=65532）。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,8 @@ services:
     depends_on:
       - github-mcp
       - copilot-review-mcp
+      # playwright-mcp はデフォルトで有効化済み。不要な場合はこの行と
+      # ROUTE_PLAYWRIGHT 環境変数・playwright-mcp サービス定義を削除してください。
       - playwright-mcp
 
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,7 @@ services:
     depends_on:
       - github-mcp
       - copilot-review-mcp
-      # playwright-mcp を有効にした場合はコメントを解除する
-      # - playwright-mcp
+      - playwright-mcp
 
     environment:
       - GITHUB_MCP_CLIENT_ID=${GITHUB_MCP_CLIENT_ID}
@@ -60,8 +59,7 @@ services:
       - MCP_GATEWAY_PORT=${MCP_GATEWAY_PORT:-8080}
       - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}
       - ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:${COPILOT_REVIEW_MCP_PORT:-8083}
-      # auth=none ルート例: 認証不要な MCP サーバを追加する場合は下記のようにコメントを解除する
-      # - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
+      - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
       - GITHUB_MCP_OAUTH_SCOPES=${GITHUB_MCP_OAUTH_SCOPES:-repo,user}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - SESSION_TTL_MIN=${SESSION_TTL_MIN:-10}
@@ -144,30 +142,32 @@ services:
           memory: 256M
 
   # =============================================================================
-  # auth=none ルートの例: 認証不要な MCP サーバを追加するパターン
+  # auth=none ルートの例: 認証不要な MCP サーバを追加するパターン（上記が有効化済み）
   # =============================================================================
-  # 手順:
-  #   1. 下記ブロックのコメントを解除してサービスを有効化する
-  #   2. mcp-gateway の ROUTE_PLAYWRIGHT 行のコメントを解除する
-  #   3. mcp-gateway の depends_on に playwright-mcp を追加する（上記コメント参照）
-  #   4. IDE 設定に "playwright": {"url": "http://127.0.0.1:8080/mcp/playwright"} を追加する
-  #   5. make restart で全サービスを再起動する
+  # 上記 playwright-mcp サービスが auth=none ルートパターンの実装例です。
+  # 新たな認証不要 MCP サーバを追加する場合は同様の手順で追加してください:
+  #   1. サービス定義を追加（image, command に --port/--host, expose, networks を指定）
+  #   2. mcp-gateway の ROUTE_<NAME>=/<path>|http://<service>:<port>|auth=none を追加
+  #   3. mcp-gateway の depends_on に新サービスを追加
+  #   4. IDE 設定に "url": "http://127.0.0.1:8080/<path>" を追加
+  #   5. make restart
   #
-  # playwright-mcp:
-  #   image: ${PLAYWRIGHT_MCP_IMAGE:-ghcr.io/microsoft/playwright-mcp:latest}
-  #   container_name: playwright-mcp
-  #   restart: unless-stopped
-  #   expose:
-  #     - "${PLAYWRIGHT_MCP_PORT:-8931}"
-  #   networks:
-  #     - mcp-network
-  #   healthcheck:
-  #     disable: true
-  #   logging:
-  #     driver: "json-file"
-  #     options:
-  #       max-size: "10m"
-  #       max-file: "3"
+  playwright-mcp:
+    image: ${PLAYWRIGHT_MCP_IMAGE:-mcr.microsoft.com/playwright/mcp:latest}
+    container_name: playwright-mcp
+    restart: unless-stopped
+    command: ["--port", "${PLAYWRIGHT_MCP_PORT:-8931}", "--host", "0.0.0.0"]
+    expose:
+      - "${PLAYWRIGHT_MCP_PORT:-8931}"
+    networks:
+      - mcp-network
+    healthcheck:
+      disable: true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   github-mcp-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,7 +156,7 @@ services:
     image: ${PLAYWRIGHT_MCP_IMAGE:-mcr.microsoft.com/playwright/mcp:latest}
     container_name: playwright-mcp
     restart: unless-stopped
-    command: ["--port", "${PLAYWRIGHT_MCP_PORT:-8931}", "--host", "0.0.0.0"]
+    command: ["--port", "${PLAYWRIGHT_MCP_PORT:-8931}", "--host", "0.0.0.0", "--allowed-hosts", "*"]
     expose:
       - "${PLAYWRIGHT_MCP_PORT:-8931}"
     networks:


### PR DESCRIPTION
## 概要

closes #109

mcp-gateway の \uth=none\ オプションを使って、認証不要な MCP サーバを設定のみで追加できるパターンを示す。playwright-mcp を例示サービスとして追加。

## 変更内容

### \docker-compose.yml\
- \mcp-gateway\ の \nvironment\ に \ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:\|auth=none\ をコメント例として追加
- \mcp-gateway\ の \depends_on\ に \playwright-mcp\ のコメント例を追加
- \playwright-mcp\ サービスのコメントアウトブロックと手順コメントを追加

### \.env.template\
- \PLAYWRIGHT_MCP_IMAGE\ / \PLAYWRIGHT_MCP_PORT\ 変数の説明と有効化手順を追加

### \README.md\
- 「MCPサーバの追加パターン（auth=none）」セクションを新設（設計図・具体手順・汎用手順）

### \CHANGELOG.md\
- \[Unreleased]\ に新機能エントリを追加（mcp-gateway#23 マージ済み記載を含む）

## 受け入れ基準の確認

- [x] \docker-compose.yml\ に playwright-mcp サービスが追加されること（コメントアウト例）
- [x] \mcp-gateway\ の \nvironment\ に \ROUTE_PLAYWRIGHT=.../auth=none\ が追加されること（コメントアウト例）
- [x] \.env.template\ に関連する変数の説明が追加されること
- [x] README に MCP サーバ追加手順が記載されること
- [x] scottlz0310/mcp-gateway#23 としてマージ済み（\mcp-gateway:latest\ に含まれる）