### PR TITLE
docs: README全面書き換え・tasks.md追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,369 +1,144 @@
-# GitHub MCP Server - Docker統合環境
+# Mcp-Docker — MCP Server Docker 統合環境
 
-VS Code、Cursor、Kiro、Claude Desktop等の統合IDEにGitHub MCP Server機能を提供するDocker常駐サービス。
+GitHub MCP Server をはじめとする複数の MCP サーバーを Docker で常駐させ、OAuth 2.0 認証を一元化して各 IDE から統一的に利用する環境。
 
-## HTTP transport対応
-
-このプロジェクトは `github-mcp-server` のHTTP接続を優先採用しています。
-複数IDEウィンドウから同時接続しやすく、`stdio` 方式より並列利用に向いた構成です。
-Claude Desktop だけは HTTP transport 非対応のため、`docker run -i ... stdio` でサーバーを直接起動します。
-
-**イメージ方針（2026-04-24時点）:**
-- 既定イメージ: `ghcr.io/github/github-mcp-server:main`
-- 理由: 公式安定リリースの最新は `v1.0.0`（`v0.31.0` 以降 Streamable HTTP / `http` サブコマンドが正式搭載）。安定性より最新機能を優先する場合は `main` タグを使用
-- セキュリティ: `.github/workflows/security.yml` でTrivyスキャンを継続実行
-
-## 設計思想：GitHub認証の一元化
-
-従来のローカル Docker 環境では、依然として各 MCP ホストへの PAT（Personal Access Token）の注入が必要です。
-GUI ショートカットやスタートメニュー、あるいは環境変数が一貫して継承されない異なるシェルから IDE を起動する場合、
-この仕組みは不安定になりがちです。
-
-本プロジェクトでは、**GitHub 認証を Docker ランタイム内に一元化**することで、この問題を回避しています。
-OAuth プロキシ経由で接続する場合、MCP ホスト（各 IDE）の設定にはシークレット値ではなくローカルエンドポイントの URL のみが含まれます。直接 HTTP 接続する場合も、トークン値をファイルに書かず環境変数参照（`${env:GITHUB_PERSONAL_ACCESS_TOKEN}`）で渡せます。
+## アーキテクチャ
 
 ```
-IDE（VS Code / Cursor / Kiro 等）
-  │  URL のみ（mcp-gateway 経由）または env var 参照（直接 HTTP 接続）
-  ▼
-mcp-gateway  ←── Docker ランタイム内で OAuth 認証・ルーティングを担当
-  │
-  ├──▶ github-mcp-server（Docker ネットワーク内に閉じ込め）
-  └──▶ copilot-review-mcp（Docker ネットワーク内に閉じ込め）
+IDE（VS Code / Cursor / Kiro / Amazon Q / Copilot CLI）
+  ↓ HTTP  localhost:8080
+mcp-gateway  ← OAuth 2.0 認証・ルーティング
+  ├── /mcp/github          → github-mcp-server   [OAuth 必須]
+  ├── /mcp/copilot-review  → copilot-review-mcp  [OAuth 必須]
+  └── /mcp/playwright      → playwright-mcp      [auth=none]
+
+Claude Desktop（stdio のみ）
+  ↓ stdio
+docker run -i --rm ghcr.io/github/github-mcp-server:main stdio
 ```
 
-これにより：
+### 設計思想：認証の一元化
 
-- IDE 側の設定ファイルにトークン値を書かなくて済む（`.vscode/settings.json` 等にシークレット値不要）
-- 起動方法（GUI ショートカット・ターミナル・スタートメニュー）に関わらず認証が安定して機能する
-- トークンの差し替えは Docker 側の `.env` または `GITHUB_PERSONAL_ACCESS_TOKEN` 環境変数で完結し、環境変数が `.env` より優先される
+各 IDE の設定ファイルにはトークン値ではなく `http://127.0.0.1:8080/<path>` という URL のみを書く。
+OAuth フローは mcp-gateway コンテナ内で完結するため、IDE の起動方法（GUI / ターミナル / スタートメニュー）に関わらず認証が安定する。
 
-## 概要
+## サービス構成
 
-GitHub公式のMCPサーバーをDockerコンテナとして常駐させ、各IDEから統一的にGitHub機能を利用できます。
+| サービス | イメージ | ポート | 説明 |
+|---|---|---|---|
+| `mcp-gateway` | `ghcr.io/scottlz0310/mcp-gateway:latest` | 8080（ホスト公開） | OAuth ゲートウェイ |
+| `github-mcp` | `ghcr.io/github/github-mcp-server:main` | 8082（内部のみ） | GitHub MCP サーバー |
+| `copilot-review-mcp` | `ghcr.io/scottlz0310/copilot-review-mcp:latest` | 8083（内部のみ） | Copilot レビュー自動化 |
+| `playwright-mcp` | `mcr.microsoft.com/playwright/mcp:latest` | 8931（内部のみ） | ブラウザ操作（auth=none） |
 
-### 提供機能
+`github-mcp`・`copilot-review-mcp`・`playwright-mcp` はホストに直接公開されません。
+すべて mcp-gateway（ポート 8080）経由でアクセスします。
 
-- **リポジトリ管理**: 作成、削除、設定
-- **Issue/PR操作**: 作成、更新、コメント、レビュー
-- **GitHub Actions連携**: ワークフロー実行、ログ取得
-- **Code Search**: コード検索、ファイル検索
-- **Discussions**: ディスカッション管理
-- **Projects**: プロジェクト管理
 
 ## クイックスタート
 
 ### 前提条件
 
 - Docker 20.10+
-- GitHub Personal Access Token (PAT) または OAuth対応クライアント
-- Node.js 18+（`verify-mcp-endpoint.js` を使用する場合、または `generate-ide-config.sh --ide claude-desktop --service mcp-gateway` が生成する `npx mcp-remote` 設定で Claude Desktop を利用する場合に必要。Claude Desktop は `mcp-gateway` 経由ではなく `docker run -i --rm <image> stdio` による直接利用を推奨）
+- GitHub Personal Access Token（PAT）
+- GitHub OAuth App の Client ID / Secret（mcp-gateway 経由接続に必要）
 
-### インストール
+### セットアップ
 
 ```bash
 # 1. リポジトリクローン
-git clone https://github.com/scottlz0310/mcp-docker.git
-cd mcp-docker
+git clone https://github.com/scottlz0310/Mcp-Docker.git
+cd Mcp-Docker
 
-# 2. 環境整備のみ実行（初回推奨）
-./scripts/setup.sh --prepare-only
+# 2. 環境ファイル作成
+cp .env.template .env
+# .env を編集して GITHUB_PERSONAL_ACCESS_TOKEN と
+# GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET を設定
 
-# 3. セットアップ本実行
-./scripts/setup.sh
-```
-
-セットアップスクリプトが以下を実行します：
-1. `.env`ファイルの作成（初回のみ）
-2. GITHUB_PERSONAL_ACCESS_TOKENの設定確認（未設定でも起動可能）
-3. 設定ディレクトリの作成
-4. Docker依存関係の確認
-5. Dockerイメージの取得（pull）
-6. サービスの起動
-7. コンテナ状態の確認
-
-`--prepare-only` を使うと、Docker未導入の段階でも `.env` と設定ディレクトリの準備だけ先に完了できます。
-
-```bash
-# Makefile経由でも実行可能
-make prepare
-```
-
-### GitHub Token設定
-
-**方法1: 環境変数で設定 (推奨)**
-
-```bash
-export GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_your_token_here
-./scripts/setup.sh
-```
-
-環境変数が設定されている場合、`.env`ファイルの設定は不要です。
-
-**方法2: .envファイルで設定**
-
-**Fine-grained personal access token (推奨)**
-
-1. [GitHub Settings > Fine-grained tokens](https://github.com/settings/tokens?type=beta) でトークンを作成
-2. 設定:
-   - **Repository access**: 対象リポジトリを選択 (または All repositories)
-   - **Permissions**:
-     - Contents: Read and write
-     - Issues: Read and write
-     - Pull requests: Read and write
-     - Workflows: Read and write
-     - Metadata: Read-only (自動選択)
-3. `.env`ファイルに設定:
-
-```bash
-GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_your_token_here
-```
-
-**Classic token (非推奨)**
-
-1. [GitHub Settings > Tokens (classic)](https://github.com/settings/tokens) でトークンを作成
-2. スコープ: `repo`, `workflow`, `read:org`, `read:user`
-3. `.env`ファイルに設定:
-
-```bash
-GITHUB_PERSONAL_ACCESS_TOKEN=ghp_your_token_here
-```
-
-**注意**: 環境変数 `GITHUB_PERSONAL_ACCESS_TOKEN` が設定されている場合、`.env`ファイルの設定より優先されます。
-
-### OAuthの準備（GitHub OAuth App登録）
-
-mcp-gateway 経由で接続する場合は、GitHub OAuth App の Client ID / Client Secret が必要です。
-
-1. GitHub OAuth App を作成
-  - https://github.com/settings/applications/new にアクセス
-  - Application name: 任意（例: GitHub MCP Gateway）
-  - Homepage URL: http://localhost:8080
-  - Authorization callback URL: http://localhost:8080/callback
-
-2. 作成後に Client ID と Client Secret を取得
-
-3. `.env` に設定
-
-```bash
-GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
-GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# 必要に応じて変更（未設定時は 8080）
-# MCP_GATEWAY_PORT=8080
-# MCP_GATEWAY_BASE_URL=http://localhost:8080
-```
-
-4. mcp-gateway を起動
-
-```bash
+# 3. 全サービス起動
 make start-gateway
 ```
 
-5. 起動確認
+初回は setup スクリプトも利用できます：
 
 ```bash
-make status-gateway
-curl -i "http://127.0.0.1:${MCP_GATEWAY_PORT:-8080}/health"
+./scripts/setup.sh
 ```
 
-補足:
-- callback URL は `MCP_GATEWAY_BASE_URL` と一致させてください（末尾 `/callback` を付与）。
-- `copilot-review-mcp` で使っている OAuth App を共有しても問題ありません。
+### GitHub Personal Access Token
 
-## copilot-review-mcp
+**Fine-grained token（推奨）**
 
-`services/copilot-review-mcp` は Copilot code review の依頼・待機・スレッド対応を自動化する MCP サーバー（Go 実装）です。
-
-### ツール一覧
-
-| ツール | 説明 |
-|---|---|
-| `request_copilot_review` | Copilot にレビューを依頼（GraphQL mutation） |
-| `get_copilot_review_status` | GitHub 上のレビュー状態を即時取得 |
-| `start_copilot_review_watch` | 非同期 watch を開始（SQLite 永続化） |
-| `get_copilot_review_watch_status` | watch の現在状態を cheap read |
-| `list_copilot_review_watches` | アクティブな watch 一覧（watch_id 回復用） |
-| `cancel_copilot_review_watch` | watch をキャンセル |
-| `get_pr_review_cycle_status` | PR レビューサイクル全体の状態を取得 |
-| `get_review_threads` | レビュースレッド一覧を取得 |
-| `reply_to_review_thread` | レビュースレッドに返信 |
-| `reply_and_resolve_review_thread` | 返信して同時に解決済みへ変更 |
-| `resolve_review_thread` | レビュースレッドを解決済みへ変更 |
-| `wait_for_copilot_review` | blocking で完了を待機（legacy fallback） |
-
-### 推奨フロー（非同期 Watch）
-
-1. `get_copilot_review_status` で GitHub 上の即時 snapshot を確認する
-2. 未完了なら `start_copilot_review_watch` を呼ぶ
-3. 他の作業を進めながら `get_copilot_review_watch_status` で cheap read する
-4. `watch_id` を見失ったら `list_copilot_review_watches` で回復する
-5. 不要になった watch は `cancel_copilot_review_watch` で止める
-
-`wait_for_copilot_review` は host 都合で blocking wait が必要な場合だけ使う legacy fallback です。
-
-詳細は [docs/copilot-review-watch-tools.md](docs/copilot-review-watch-tools.md) を参照してください。
-
-### スキルテンプレートとの一体運用（推奨）
-
-`copilot-review-mcp` は単体でも使えますが、`docs/skills/pr-review-cycle.md` のスキルテンプレートと組み合わせることで、Copilot レビュー依頼から完了待機・スレッド対応・サマリ投稿までを AI エージェントに一括して自律実行させられます。
-
-**自動化できるサイクル:**
-
-```
-Copilot レビュー依頼
-  → async watch で完了待機（notifications/resources/updated 通知対応）
-  → スレッド取得・分類・採否判断
-  → 修正・コミット
-  → 全スレッドへ返信 & resolve
-  → サイクル評価（再レビュー要否判定）
-  → PR サマリコメント投稿
-  → マージ判断はユーザーに委ねる
-```
-
-**セットアップ:**
+1. [GitHub Settings > Fine-grained tokens](https://github.com/settings/tokens?type=beta) でトークンを作成
+2. Permissions:
+   - Contents: Read and write
+   - Issues: Read and write
+   - Pull requests: Read and write
+   - Workflows: Read and write
+   - Metadata: Read-only（自動選択）
+3. `.env` に設定：
 
 ```bash
-# スキルテンプレートを AI エージェントのスキルディレクトリへコピー
-cp docs/skills/pr-review-cycle.md ~/.claude/skills/
+GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_xxxx
 ```
 
-コピー後、IDE のツール名プレフィックス（`{CRM}` / `{GH}`）をお使いの環境に合わせて書き換えてください（詳細はテンプレート内の「プレースホルダーの読み替え」を参照）。
+環境変数が設定済みの場合、`.env` の設定より優先されます：
 
-**使い方:**
-
-PR 作成直後または `request_copilot_review` ツール呼び出し直後に `/pr-review-cycle` スキルを起動するだけです。
-
-## MCPサーバの追加パターン（auth=none）
-
-mcp-gateway の `auth=none` オプションを使うと、認証不要な MCP サーバをコード変更なしで設定のみで追加できます。
-
-### ルーティング設計
-
-```
-mcp-gateway(:8080)
-  ├── /mcp/github          → github-mcp          [auth=oauth]  OAuth必須
-  ├── /mcp/copilot-review  → copilot-review-mcp  [auth=oauth]  OAuth必須
-  └── /mcp/playwright      → playwright-mcp      [auth=none]   認証不要
+```bash
+export GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_xxxx
+make start-gateway
 ```
 
-### 設定例（playwright-mcp はデフォルトで有効化済み）
+**Classic token（非推奨）**: スコープ `repo, workflow, read:org, read:user`
 
-`playwright-mcp` は `docker-compose.yml` にデフォルトで有効化された設定例として含まれています。
-新しい認証不要 MCP サーバを追加する場合は、同様の3箇所を変更してください。
+### GitHub OAuth App 登録
 
-#### 1. `docker-compose.yml` — サービス定義と mcp-gateway 設定
+mcp-gateway 経由で接続するには GitHub OAuth App が必要です。
 
-サービス定義を追加します（`docker-compose.yml` の playwright-mcp セクションを参照）:
+1. [https://github.com/settings/applications/new](https://github.com/settings/applications/new) にアクセス
+2. 設定：
+   - Homepage URL: `http://localhost:8080`
+   - Authorization callback URL: `http://localhost:8080/callback`
+3. Client ID / Secret を取得し `.env` に設定：
 
-```yaml
-  playwright-mcp:
-    image: ${PLAYWRIGHT_MCP_IMAGE:-mcr.microsoft.com/playwright/mcp:latest}
-    container_name: playwright-mcp
-    restart: unless-stopped
-    command: ["--port", "${PLAYWRIGHT_MCP_PORT:-8931}", "--host", "0.0.0.0", "--allowed-hosts", "*"]
-    expose:
-      - "${PLAYWRIGHT_MCP_PORT:-8931}"
-    networks:
-      - mcp-network
+```bash
+GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxxGITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-`mcp-gateway` の `environment` と `depends_on` にも追加します:
+> `copilot-review-mcp` で使っている OAuth App を共有しても問題ありません。
+> callback URL は `MCP_GATEWAY_BASE_URL` と一致させてください（末尾に `/callback`）。
 
-```yaml
-  mcp-gateway:
-    depends_on:
-      - playwright-mcp
-    environment:
-      - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
+
+## IDE 統合
+
+設定生成スクリプトで IDE 別の JSON/TOML 設定が得られます：
+
+```bash
+make gen-config IDE=vscode       # VS Code / Cursor
+make gen-config IDE=kiro         # Kiro: ~/.kiro/settings/mcp.json
+make gen-config IDE=amazonq      # Amazon Q
+make gen-config IDE=codex        # Codex CLI: ~/.codex/config.toml
+make gen-config IDE=copilot-cli  # Copilot CLI: ~/.copilot/mcp-config.json
+make gen-config IDE=claude-desktop  # Claude Desktop（stdio 方式）
 ```
 
-> **Note**: `playwright-mcp` を使用しない場合は、上記の `depends_on` エントリと `ROUTE_PLAYWRIGHT` 行を削除し、`playwright-mcp` サービス定義も削除してください。
-
-#### 2. IDE設定 — パスを追加
-
-ホスト・ポートは `127.0.0.1:8080` のまま、パスだけ追加します。
+`.mcp.json.example` に設定例があります：
 
 ```json
 {
   "mcpServers": {
-    "github":     { "url": "http://127.0.0.1:8080/mcp/github" },
-    "playwright": { "url": "http://127.0.0.1:8080/mcp/playwright" }
+    "github-mcp-server":  { "url": "http://127.0.0.1:8080/mcp/github" },
+    "copilot-review-mcp": { "url": "http://127.0.0.1:8080/mcp/copilot-review" },
+    "playwright-mcp":     { "url": "http://127.0.0.1:8080/mcp/playwright" }
   }
 }
 ```
 
-#### 3. 再起動
+IDE は mcp-gateway の OAuth フローでブラウザ認証を自動処理します。設定ファイルにトークンを書く必要はありません。
 
-```bash
-make restart
-```
+### Claude Desktop（例外）
 
-### 汎用手順（任意の MCP サーバ）
-
-任意の認証不要 Streamable HTTP MCP サーバを追加する場合:
-
-1. `docker-compose.yml` にサービス定義を追加
-2. `mcp-gateway` の `environment` に `ROUTE_<NAME>=/<path>|http://<service>:<port>|auth=none` を追加
-3. `mcp-gateway` の `depends_on` に新サービスを追加
-4. IDE 設定に `"url": "http://127.0.0.1:8080/<path>"` を追加
-5. `make restart` で再起動
-
-## HTTPエンドポイント
-
-- mcp-gateway 経由 URL: `http://127.0.0.1:8080`
-  - GitHub MCP Server: `http://127.0.0.1:8080/mcp/github`
-  - Copilot Review MCP: `http://127.0.0.1:8080/mcp/copilot-review`
-- `github-mcp` と `copilot-review-mcp` は Docker ネットワーク内向け（`expose`）でホスト直公開しません。
-- mcp-gateway で接続するには `make start-gateway` を実行してください。
-- ポートを変更する場合:
-  - `MCP_GATEWAY_PORT`（未設定時は `8080`）
-  - `GITHUB_MCP_HTTP_PORT`（コンテナ内向け、未設定時は `8082`）
-- 直接 HTTP 接続するクライアントでは、必要に応じて `Authorization: Bearer <PAT/OAuth Token>` ヘッダーを送ってください。
-- Claude Desktop は `docker run -i ... stdio` で接続します。`-e GITHUB_PERSONAL_ACCESS_TOKEN`（値なし）を指定すると、ホスト環境変数を安全に受け渡せます。
-- 疎通確認（`200 OK` でヘルス情報が返ることを確認）:
-
-```bash
-curl -i "http://127.0.0.1:${MCP_GATEWAY_PORT:-8080}/health"
-```
-
-```bash
-# 例: 18080でmcp-gateway起動
-export MCP_GATEWAY_PORT=18080
-make start-gateway
-```
-
-```bash
-# github-mcp本体のみ起動（ホスト直アクセスなし）
-make start
-```
-
-## IDE統合
-
-### VS Code / Cursor
-
-```bash
-# 設定生成
-./scripts/generate-ide-config.sh --ide vscode
-
-# 設定ファイルに追加
-# VS Code: settings.json
-# Cursor: settings.json
-```
-
-### Claude Desktop
-
-```bash
-# 設定生成
-./scripts/generate-ide-config.sh --ide claude-desktop
-
-# 設定ファイルに追加
-# macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
-# Linux: ~/.config/Claude/claude_desktop_config.json
-# Windows: %APPDATA%\Claude\claude_desktop_config.json
-```
-
-生成される設定は `docker run -i --rm ... stdio` で GitHub MCP Server を直接起動する形式です。
+Claude Desktop は HTTP transport 非対応のため、`docker run -i --rm ... stdio` で直接起動します：
 
 ```json
 {
@@ -371,15 +146,10 @@ make start
     "github-mcp-server-docker": {
       "command": "docker",
       "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "-v",
-        "C:\\Users\\dev\\src\\Mcp-Docker\\config\\github-mcp:/app/config:rw",
-        "-v",
-        "github-mcp-cache:/app/cache:rw",
+        "run", "-i", "--rm",
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "-v", "/path/to/Mcp-Docker/config/github-mcp:/app/config:rw",
+        "-v", "github-mcp-cache:/app/cache:rw",
         "ghcr.io/github/github-mcp-server:main",
         "stdio"
       ]
@@ -388,338 +158,171 @@ make start
 }
 ```
 
-`-i` は必須です。省略すると stdio 通信が切断されます。
+- `-i` は必須（省略すると stdio 通信が切断されます）
+- `-e GITHUB_PERSONAL_ACCESS_TOKEN` は値を書かずそのまま記述（ホスト環境変数を転送）
+- パス `/path/to/Mcp-Docker/config/github-mcp` はクローン先の絶対パスに置き換えてください
 
-`-e GITHUB_PERSONAL_ACCESS_TOKEN` は値を埋め込まずに書いてください。
 
-### Kiro
+## サービス操作
 
-```bash
-# 設定生成
-./scripts/generate-ide-config.sh --ide kiro
+### Makefile コマンド
 
-# 設定ファイルに配置
-# ~/.kiro/settings/mcp.json
-```
+| コマンド | 説明 |
+|---|---|
+| `make start-gateway` | 全サービス起動（推奨） |
+| `make stop` | 全サービス停止 |
+| `make restart` | 再起動（stop → start） |
+| `make status` | 全コンテナ状態一覧 |
+| `make status-gateway` | github-mcp / mcp-gateway / copilot-review-mcp の状態確認 |
+| `make logs` | github-mcp ログ表示 |
+| `make logs-gateway` | mcp-gateway ログ表示 |
+| `make pull` | github-mcp イメージ更新 |
+| `make gen-config` | IDE 設定生成（`IDE=vscode` 等を指定） |
+| `make gen-config-crm` | copilot-review-mcp の IDE 設定生成 |
+| `make lint` | シェルスクリプト Lint |
+| `make test-shell` | シェルスクリプトテスト（BATS） |
+| `make clean` | キャッシュ削除 |
+| `make clean-docker` | Docker リソースクリーンアップ |
+| `make clean-all` | 全クリーンアップ |
 
-### Amazon Q
+### copilot-review-mcp 操作
 
-```bash
-# 設定生成
-./scripts/generate-ide-config.sh --ide amazonq
+| コマンド | 説明 |
+|---|---|
+| `make crm-start` | copilot-review-mcp コンテナ起動 |
+| `make crm-stop` | 停止・削除 |
+| `make crm-restart` | 再起動 |
+| `make crm-logs` | ログ表示 |
+| `make crm-status` | 状態確認 |
+| `make crm-health` | ヘルスチェック |
 
-# 設定方法
-# VS Code: 設定 > Amazon Q > MCP Servers
-```
+### HTTP エンドポイント
 
-### Codex CLI
+| URL | サービス | 認証 |
+|---|---|---|
+| `http://127.0.0.1:8080/mcp/github` | github-mcp-server | OAuth 必須 |
+| `http://127.0.0.1:8080/mcp/copilot-review` | copilot-review-mcp | OAuth 必須 |
+| `http://127.0.0.1:8080/mcp/playwright` | playwright-mcp | なし |
+| `http://127.0.0.1:8080/health` | mcp-gateway | なし |
 
-```bash
-# 設定生成 (TOML)
-./scripts/generate-ide-config.sh --ide codex
-
-# 設定ファイルに追記
-# ~/.codex/config.toml
-```
-
-### Copilot CLI
-
-```bash
-# 設定生成 (JSON)
-./scripts/generate-ide-config.sh --ide copilot-cli
-
-# Copilot CLI MCP設定ファイルに配置
-# ~/.copilot/mcp-config.json
-```
-
-## 基本操作
-
-### サービス管理
-
-```bash
-# 起動（github-mcp本体のみ）
-make start
-
-# OAuthプロキシ(mcp-gateway)経由で起動（localhost:8080）
-make start-gateway
-
-# 停止
-docker compose down
-
-# 再起動
-docker compose restart github-mcp
-
-# ステータス確認
-docker compose ps
-
-# ログ確認
-docker compose logs -f github-mcp
-
-# ログ（最新100行）
-docker compose logs --tail=100 github-mcp
-```
-
-### ヘルスチェック
+疎通確認：
 
 ```bash
-# 標準チェック（コンテナ状態 + トークンがあればAPI確認）
 ./scripts/health-check.sh
-
-# API確認をスキップ
-./scripts/health-check.sh --no-api
-
-# API確認を強制実行
-./scripts/health-check.sh --with-api
+# または
+curl -i http://127.0.0.1:8080/health
 ```
 
-## セキュリティ
-
-### イメージのバージョン固定
-
-- `docker-compose.yml` と各サンプルは `GITHUB_MCP_IMAGE` 変数を参照し、デフォルトで `ghcr.io/github/github-mcp-server:main` を使用します。
-- 別のバージョンを使う場合は次のように上書きします:
+ポートを変更する場合：
 
 ```bash
-export GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:v1.0.0
-docker compose pull github-mcp
+# .env または環境変数で設定
+MCP_GATEWAY_PORT=18080
+make start-gateway
 ```
 
-### GitHub Actionsでのセキュリティスキャン
 
-- `Security Scan` ワークフロー（`.github/workflows/security.yml`）で、Trivy の結果を GitHub Security タブへ送信します。
-- ワークフローは `push`/`pull_request` に加えて毎週月曜 15:00 JST (`0 6 * * 1` UTC) に実行され、リポジトリ/コンテナ双方の脆弱性を継続的に監視します。
+## playwright-mcp（auth=none）
 
-## 開発
+playwright-mcp は認証なしで利用できるブラウザ操作サービスです。
+`docker-compose.yml` でデフォルト有効。`/mcp/playwright` から直接接続できます：
 
-### リント・テスト
-
-```bash
-# すべてのリント実行
-make lint
-
-# シェルスクリプトのみ
-make lint-shell
-
-# シェルスクリプトテスト
-make test-shell
+```json
+{
+  "mcpServers": {
+    "playwright-mcp": { "url": "http://127.0.0.1:8080/mcp/playwright" }
+  }
+}
 ```
 
-## メンテナンス
+## イメージのカスタマイズ
 
-### コンテナ管理
+| 環境変数 | 既定値 | 説明 |
+|---|---|---|
+| `GITHUB_MCP_GATEWAY_IMAGE` | `ghcr.io/scottlz0310/mcp-gateway:latest` | ゲートウェイイメージ |
+| `GITHUB_MCP_IMAGE` | `ghcr.io/github/github-mcp-server:main` | github-mcp-server イメージ |
+| `COPILOT_REVIEW_MCP_IMAGE` | `ghcr.io/scottlz0310/copilot-review-mcp:latest` | copilot-review-mcp イメージ |
 
 ```bash
-# distrolessイメージのためシェルはありません（exec sh不可）
-# 起動コマンドを確認
-docker inspect mcp-github --format='Entrypoint={{.Config.Entrypoint}} Cmd={{.Config.Cmd}}'
-
-# コンテナの詳細情報
-docker compose ps --format json
-docker inspect mcp-github
-
-# リソース使用状況
-docker stats mcp-github
-
-# コンテナ再作成（設定変更後）
-docker compose up -d --force-recreate github-mcp
+GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:v1.0.0 make start-gateway
 ```
 
-### イメージ管理
+## トラブルシューティング
+
+### コンテナが起動しない
 
 ```bash
-# イメージ更新
-docker compose pull github-mcp
-docker compose up -d github-mcp
-
-# イメージ一覧
-docker images | grep github-mcp-server
-
-# 古いイメージ削除
-docker image prune -f
+make status        # コンテナ状態確認
+make logs          # github-mcp ログ
+make logs-gateway  # mcp-gateway ログ
 ```
 
-### ログ管理
+`GITHUB_PERSONAL_ACCESS_TOKEN` が未設定または無効な場合は設定を確認してください。
+
+### IDE から接続できない
+
+1. mcp-gateway が起動しているか確認（`make status-gateway`）
+2. ポート確認（デフォルト 8080）
+3. IDE の MCP サーバー設定 URL が `http://127.0.0.1:8080/mcp/github` 等になっているか確認
+4. OAuth フローが完了しているか確認（ブラウザで `http://127.0.0.1:8080/health` にアクセス可能か）
+
+### タイムアウト
+
+デフォルトの HTTP タイムアウトは 30 秒。複雑な操作では `--timeout` の調整が必要な場合があります。
+
+### コンテナ内部に入れない（Distroless）
+
+`github-mcp-server` コンテナはシェルなし（Distroless）のため、`docker exec -it ... bash` は動作しません。
+ヘルスチェックはホスト側スクリプト（`scripts/health-check.sh`）で行ってください。
+
+### コンフィグボリュームが古い
+
+`make clean` 後も `./config/github-mcp` ボリュームは残ります。
+最初から設定し直す場合は手動で削除してください：
 
 ```bash
-# ログ確認（リアルタイム）
-docker compose logs -f github-mcp
-
-# ログ確認（最新N行）
-docker compose logs --tail=100 github-mcp
-
-# ログ確認（タイムスタンプ付き）
-docker compose logs -t github-mcp
-
-# ログ確認（特定期間）
-docker compose logs --since="2024-01-01" github-mcp
-
-# ログファイル確認
-docker inspect mcp-github --format='{{.LogPath}}'
-```
-
-### データ管理
-
-```bash
-# ボリューム一覧
-docker volume ls | grep mcp
-
-# ボリューム詳細
-docker volume inspect mcp-docker_github-mcp-cache
-
-# キャッシュクリア
-docker compose down
 docker volume rm mcp-docker_github-mcp-cache
-docker compose up -d
-
-# 設定ファイルバックアップ
-tar -czf config-backup-$(date +%Y%m%d).tar.gz config/
-```
-
-### トラブルシューティング
-
-```bash
-# コンテナ完全リセット
-docker compose down -v
-docker compose up -d
-
-# ネットワーク確認
-docker network ls | grep mcp
-docker network inspect mcp-docker_mcp-network
-
-# リソースクリーンアップ
-docker system prune -f
-docker volume prune -f
-
-# 全コンテナ・イメージ削除（注意）
-docker compose down -v --rmi all
-
-# 全コンテナを強制停止・削除
-docker ps -aq | xargs -r docker stop
-docker ps -aq | xargs -r docker rm
 ```
 
 ## ディレクトリ構成
 
 ```
 Mcp-Docker/
-├── docker-compose.yml          # サービス定義（github-mcp）
-├── Makefile                    # タスク管理
-├── SECURITY.md                 # セキュリティポリシー
-├── ci-helper.toml.example     # ci-helper 設定例
-├── .env.template              # 環境変数テンプレート
-├── .env                       # 環境変数（gitignore）
-├── renovate.json              # Renovate 依存更新設定
-├── services/
-│   ├── copilot-review-mcp/   # Copilot review 非同期 Watch MCP サーバー（Go）
-│   └── (github-oauth-proxy は削除 → mcp-gateway に移行)
+├── docker-compose.yml          # メインの Compose 定義（4サービス）
+├── Makefile                    # 操作コマンド集
+├── tasks.md                    # 開発タスク管理
 ├── config/
-│   └── github-mcp/           # github-mcp-server 設定
+│   └── github-mcp/             # github-mcp-server の設定（ボリュームマウント）
 ├── scripts/
-│   ├── setup.sh              # セットアップ
-│   ├── generate-ide-config.sh # IDE設定生成
-│   ├── health-check.sh       # ヘルスチェック
-│   ├── lint-shell.sh         # シェルスクリプトLint
-│   └── verify-mcp-endpoint.js # MCP エンドポイント疎通確認
-├── tests/
-│   └── shell/                # シェルスクリプトテスト（Bats）
-│       └── test_scripts.bats
+│   ├── setup.sh                # 初回セットアップ
+│   ├── health-check.sh         # ヘルスチェック
+│   └── generate-ide-config.sh  # IDE 設定生成
 ├── docs/
-│   ├── SECURITY_PATCHES.md   # セキュリティ方針
-│   ├── copilot-review-watch-tools.md # Watch ツール仕様
-│   ├── design/               # 設計ドキュメント
-│   ├── skills/               # Claude スキルテンプレート
-│   └── bug-reports/          # バグレポート
-└── examples/
-    └── github-mcp/           # サンプル Compose 設定
+│   ├── SECURITY_PATCHES.md     # セキュリティ対応履歴
+│   └── copilot-review-mcp-tasks.md  # copilot-review-mcp 固有タスク
+├── tests/
+│   └── shell/                  # BATS シェルテスト
+└── services/
+    └── copilot-review-mcp/     # ※ 将来削除予定（外部リポジトリへ移行済み）
 ```
 
-## トラブルシューティング
+`services/copilot-review-mcp/` は外部リポジトリ（`scottlz0310/copilot-review-mcp`）への移行に伴い、将来のリリースで削除される予定です。
 
-### サービスが起動しない
+## セキュリティ
 
-```bash
-# ログ確認
-docker compose logs github-mcp
+- トークンはコンテナ外（`.env` またはホスト環境変数）で管理してください
+- `.env` ファイルは `.gitignore` で除外済みです
+- `.env` をコミットしないでください
+- トークンスコープ要件・Fine-grained PAT の詳細は [SECURITY.md](SECURITY.md) を参照
+- セキュリティパッチ・CVE 対応履歴は [docs/SECURITY_PATCHES.md](docs/SECURITY_PATCHES.md) を参照
 
-# 詳細ログ確認
-docker compose logs --tail=200 github-mcp
+## 関連リソース
 
-# コンテナ再作成
-docker compose down
-docker compose up -d
-
-# 強制再作成
-docker compose up -d --force-recreate github-mcp
-```
-
-### GitHub API接続エラー
-
-```bash
-# トークン確認
-cat .env | grep GITHUB_PERSONAL_ACCESS_TOKEN
-
-# トークンの有効性確認
-curl -H "Authorization: Bearer YOUR_TOKEN" https://api.github.com/user
-
-# コンテナ設定から確認（distrolessのため exec env は非対応）
-docker inspect mcp-github --format='{{range .Config.Env}}{{println .}}{{end}}' | grep GITHUB
-```
-
-### ヘルスチェック失敗
-
-```bash
-# コンテナ状態確認
-docker compose ps github-mcp
-
-# 再起動回数の確認
-docker inspect mcp-github --format='running={{.State.Running}} restart={{.RestartCount}}'
-
-# ログ確認
-docker compose logs --tail=200 github-mcp
-
-# API含むヘルスチェック
-./scripts/health-check.sh --with-api
-```
-
-### メモリ不足
-
-```bash
-# リソース使用状況確認
-docker stats mcp-github
-
-# メモリ制限変更（docker-compose.yml編集後）
-docker compose up -d --force-recreate github-mcp
-```
-
-### ポート競合
-
-```bash
-# ポート使用状況確認（使用中のポート番号を指定）
-lsof -i :${GITHUB_MCP_HTTP_PORT:-8082}
-netstat -an | grep ${GITHUB_MCP_HTTP_PORT:-8082}
-
-# ポート変更（環境変数）
-export GITHUB_MCP_HTTP_PORT=8083
-docker compose up -d --force-recreate github-mcp
-```
-
-## 運用ガードレール
-
-- トークンは`.env`ファイルやコンテナ環境変数で管理し、Claude Desktop 側には極力持ち込まない
-- コンテナは専用ネットワークで分離
-- ログは機密情報をマスキング
-- リソース制限: 512MB/1CPU
+- [github-mcp-server](https://github.com/github/github-mcp-server) — 本家 GitHub MCP サーバー
+- [mcp-gateway](https://github.com/scottlz0310/mcp-gateway) — OAuth ゲートウェイ
+- [copilot-review-mcp](https://github.com/scottlz0310/copilot-review-mcp) — Copilot レビュー自動化 MCP
+- [CHANGELOG.md](CHANGELOG.md) — リリース履歴・破壊的変更
 
 ## ライセンス
 
-MIT License - 詳細は[LICENSE](LICENSE)を参照
-
-## 関連プロジェクト
-
-- **[ci-helper](https://github.com/scottlz0310/ci-helper)** - GitHub Actions ローカル実行ツール（旧Actions Simulator）
-- **WSL-kernel-watcher** - WSLカーネル更新監視ツール（開発予定）
-
-## 関連リンク
-
-- [GitHub MCP Server公式](https://github.com/github/github-mcp-server)
-- [Model Context Protocol](https://modelcontextprotocol.io/)
+MIT License — see [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ mcp-gateway 経由で接続するには GitHub OAuth App が必要です。
 3. Client ID / Secret を取得し `.env` に設定：
 
 ```bash
-GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxxGITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
+GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 > `copilot-review-mcp` で使っている OAuth App を共有しても問題ありません。

--- a/README.md
+++ b/README.md
@@ -52,8 +52,13 @@ cd Mcp-Docker
 
 # 2. 環境ファイル作成
 cp .env.template .env
-# .env を編集して GITHUB_PERSONAL_ACCESS_TOKEN と
-# GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET を設定
+# .env を編集して以下を設定:
+#   GITHUB_PERSONAL_ACCESS_TOKEN     (github-mcp-server 用 PAT)
+#   GITHUB_MCP_CLIENT_ID             (mcp-gateway OAuth App Client ID)
+#   GITHUB_MCP_CLIENT_SECRET         (mcp-gateway OAuth App Client Secret)
+#   GITHUB_CLIENT_ID                 (copilot-review-mcp OAuth App Client ID)
+#   GITHUB_CLIENT_SECRET             (copilot-review-mcp OAuth App Client Secret)
+# ※ 同一 OAuth App を共有する場合は GITHUB_MCP_CLIENT_* と GITHUB_CLIENT_* に同じ値を設定
 
 # 3. 全サービス起動
 make start-gateway
@@ -128,12 +133,15 @@ make gen-config IDE=claude-desktop  # Claude Desktop（stdio 方式）
 ```json
 {
   "mcpServers": {
-    "github-mcp-server":  { "url": "http://127.0.0.1:8080/mcp/github" },
-    "copilot-review-mcp": { "url": "http://127.0.0.1:8080/mcp/copilot-review" },
-    "playwright-mcp":     { "url": "http://127.0.0.1:8080/mcp/playwright" }
+    "github":         { "type": "http", "url": "http://127.0.0.1:8080/mcp/github" },
+    "copilot-review": { "type": "http", "url": "http://127.0.0.1:8080/mcp/copilot-review" },
+    "playwright":     { "type": "http", "url": "http://127.0.0.1:8080/mcp/playwright" }
   }
 }
 ```
+
+> キー名はユーザーが自由に命名できます。上記は `.mcp.json.example` の例です。
+> IDE によっては `type` フィールドが不要な場合があります（省略可能）。
 
 IDE は mcp-gateway の OAuth フローでブラウザ認証を自動処理します。設定ファイルにトークンを書く必要はありません。
 
@@ -297,6 +305,7 @@ Mcp-Docker/
 ├── scripts/
 │   ├── setup.sh                # 初回セットアップ
 │   ├── health-check.sh         # ヘルスチェック
+│   ├── lint-shell.sh           # シェルスクリプト Lint（make lint-shell）
 │   └── generate-ide-config.sh  # IDE 設定生成
 ├── docs/
 │   ├── SECURITY_PATCHES.md     # セキュリティ対応履歴

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,76 @@
+# タスク管理
+
+現在の実装状況を踏まえた、今後の開発タスク一覧。
+
+---
+
+## 優先度高
+
+### [#105] Makefile の整理（外部イメージ対応）
+
+**状態**: 部分実装済み  
+**関連 ISSUE**: [#105](https://github.com/scottlz0310/Mcp-Docker/issues/105)
+
+docker-compose.yml はすべて外部 ghcr.io イメージ参照に移行済み。
+Makefile の `crm-*` ターゲットがまだローカルビルド前提の実装のため整理が必要。
+
+#### 残作業
+
+- [ ] `CRM_IMAGE` デフォルト値を `ghcr.io/scottlz0310/copilot-review-mcp:latest` に変更（現在: `copilot-review-mcp:latest`）
+- [ ] `crm-start` を `docker run` から `docker compose up -d copilot-review-mcp` に変更
+- [ ] `crm-stop` / `crm-restart` を `docker compose stop/restart copilot-review-mcp` に変更
+- [ ] `crm-build` ターゲット削除（ローカルビルド不要、ghcr.io イメージを使用）
+- [ ] `make help` 説明文を現状に合わせて整理
+
+#### スコープ外（今回やらないこと）
+
+- Makefile ターゲット名のリネーム（`start-gateway` → `gh-start` 等）: 後方互換性を優先。Phase 2（services/ 削除）と同時に対応。
+
+---
+
+## 優先度中
+
+### [#106] services/ ソースコードの段階的削除
+
+**状態**: 保留（#105 安定確認後に着手）  
+**関連 ISSUE**: [#106](https://github.com/scottlz0310/Mcp-Docker/issues/106)  
+**前提**: #105 完了 + 外部イメージからの安定稼働（目安: 1〜2 週間）
+
+#### 削除対象
+
+| 対象 | 理由 |
+|------|------|
+| `services/copilot-review-mcp/` | `ghcr.io/scottlz0310/copilot-review-mcp` に移行済み |
+| `services/github-oauth-proxy/` | `mcp-gateway`（外部リポジトリ）に移行済み |
+| `docs/copilot-review-mcp-tasks.md` | 対象サービスのタスク管理ファイル（本ファイルに統合済み） |
+| `Makefile` の `crm-build`、`CRM_DIR` 等ビルド関連 | ローカルビルド不要 |
+| `.github/workflows/` の不要 CI | 外部リポジトリ側で管理 |
+
+#### Makefile ターゲット名リネーム（#106 と同時）
+
+| 旧 | 新 | 備考 |
+|----|----|----|
+| `start-gateway` | `start`（デフォルト化）| 全サービス起動を標準に |
+| `logs-gateway` | `logs`（全体）| |
+| `status-gateway` | 削除（`status` に統合）| |
+| `crm-start` | 削除（`start` に統合）| |
+
+---
+
+## バックログ（検討中）
+
+### renovate: services/ 配下の依存更新を停止
+
+`services/copilot-review-mcp/go.mod` 等は削除予定のため、
+Renovate の更新対象から外すか `ignorePaths` を設定する。
+
+---
+
+## 完了済み（参考）
+
+- [x] docker-compose.yml を外部 ghcr.io イメージ参照に移行（mcp-gateway, copilot-review-mcp）（#105 部分完了）
+- [x] playwright-mcp を auth=none パターンとして追加（#109/#110）
+- [x] mcp-gateway, copilot-review-mcp の ghcr.io パッケージを public に公開
+- [x] copilot-review-mcp: async watch + notification ベース再設計（#63〜#68）
+- [x] workflow-lint ワークフロー追加（#94 暫定対応）
+- [x] Codecov upload step の secrets 直参照を修正（#94 暫定対応）

--- a/tasks.md
+++ b/tasks.md
@@ -11,7 +11,7 @@
 **状態**: 部分実装済み  
 **関連 ISSUE**: [#105](https://github.com/scottlz0310/Mcp-Docker/issues/105)
 
-docker-compose.yml はすべて外部 ghcr.io イメージ参照に移行済み。
+docker-compose.yml はすべて外部イメージ参照に移行済み（ghcr.io・mcr.microsoft.com）。
 Makefile の `crm-*` ターゲットがまだローカルビルド前提の実装のため整理が必要。
 
 #### 残作業


### PR DESCRIPTION
## 変更概要

Issue整理の一環として、READMEを現在の実態に合わせて全面書き換えし、開発タスク管理ファイル tasks.md を新規追加。

### README の主な変更
- 680行→245行にスリム化
- アーキテクチャ図に playwright-mcp (/mcp/playwright, auth=none) を追加
- 全サービスが外部イメージ使用であることを明記（4サービス構成表）
- HTTPエンドポイント一覧に /mcp/playwright を追加
- services/copilot-review-mcp/ は将来削除予定と注記
- Claude Desktop（stdio）の設定例を明示
- OAuth App 登録手順を整理・簡潔化

### tasks.md（新規）
- #105 残作業（crm-start のイメージ参照・Makefile整理）をタスク化
- #106（services/ 削除）をタスク化
- バックログ・完了済み参考を記録