### PR TITLE
feat: add persistent volume for mcp-gateway token store (#112)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,11 @@ output/*
 examples/github-release-watcher/config/state.json
 examples/github-release-watcher/config/notifications.json
 
+# mcp-gateway token store (local runs outside Docker)
+tokens.db
+*.db-shm
+*.db-wal
+
 # ci-helper
 .ci-helper/
 .actrc

--- a/README.md
+++ b/README.md
@@ -298,17 +298,26 @@ docker volume rm mcp-docker_github-mcp-cache
 `mcp-gateway` はブラウザ認証後に取得した OAuth トークンを `/data/tokens.db` に永続化します。
 このファイルは **検証済み OAuth トークンのキャッシュ**であり、GitHub 認証情報（PAT）そのものではありません。
 
-ボリュームの内容確認：
+ボリューム情報確認（Mountpoint 等のメタデータ）：
+
+> ボリューム名のプレフィックスは Compose プロジェクト名（デフォルト: ディレクトリ名）に依存します。
+> まず `docker volume ls | grep mcp-gateway-data` で実際のボリューム名を確認してください。
 
 ```bash
-docker volume inspect mcp-docker_mcp-gateway-data
+# 実際のボリューム名を確認
+docker volume ls | grep mcp-gateway-data
+
+# メタデータを表示（上記で確認した名前を使用）
+docker volume inspect <実際のボリューム名>
 ```
 
 認証状態のリセット（再認証が必要な場合）：
 
 ```bash
+# 実際のボリューム名を確認してから削除
 docker compose down
-docker volume rm mcp-docker_mcp-gateway-data
+docker volume ls | grep mcp-gateway-data
+docker volume rm <実際のボリューム名>
 docker compose up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,29 @@ make logs-gateway  # mcp-gateway ログ
 docker volume rm mcp-docker_github-mcp-cache
 ```
 
+### mcp-gateway トークンストアボリューム（`mcp-gateway-data`）
+
+`mcp-gateway` はブラウザ認証後に取得した OAuth トークンを `/data/tokens.db` に永続化します。
+このファイルは **検証済み OAuth トークンのキャッシュ**であり、GitHub 認証情報（PAT）そのものではありません。
+
+ボリュームの内容確認：
+
+```bash
+docker volume inspect mcp-docker_mcp-gateway-data
+```
+
+認証状態のリセット（再認証が必要な場合）：
+
+```bash
+docker compose down
+docker volume rm mcp-docker_mcp-gateway-data
+docker compose up -d
+```
+
+**セキュリティ注意事項**:
+- `mcp-gateway-data` ボリュームは `mcp-gateway` コンテナ専用です。他のサービスには公開しないでください。
+- ボリュームパスやトークンファイルの内容を IDE 設定（`settings.json` 等）に含めないでください。IDE へは `http://127.0.0.1:8080/mcp/github` 等の URL のみを記載します。
+
 ## ディレクトリ構成
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,10 @@ services:
       - SESSION_TTL_MIN=${SESSION_TTL_MIN:-10}
       - TOKEN_CACHE_TTL_MIN=${TOKEN_CACHE_TTL_MIN:-30}
       - TOKEN_EXPIRES_IN_SEC=${TOKEN_EXPIRES_IN_SEC:-7776000}
+      - MCP_GATEWAY_TOKEN_STORE_PATH=${MCP_GATEWAY_TOKEN_STORE_PATH:-/data/tokens.db}
+
+    volumes:
+      - mcp-gateway-data:/data
 
     ports:
       - "127.0.0.1:${MCP_GATEWAY_PORT:-8080}:${MCP_GATEWAY_PORT:-8080}"
@@ -172,6 +176,8 @@ volumes:
   github-mcp-cache:
     driver: local
   copilot-review-data:
+    driver: local
+  mcp-gateway-data:
     driver: local
 
 networks:


### PR DESCRIPTION
## 概要

Issue #112 の対応。`mcp-gateway` の OAuth トークン/セッションストアをコンテナ再起動後も保持するための Docker named volume を追加します。

## 変更内容

### `docker-compose.yml`
- `mcp-gateway-data` 名前付きボリュームを定義（top-level `volumes`）
- `mcp-gateway` サービスに `volumes: - mcp-gateway-data:/data` をマウント
- `MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.db` 環境変数を追加

### `.gitignore`
- `tokens.db`、`*.db-shm`、`*.db-wal` を除外（Docker 外でゲートウェイを実行した場合のローカルファイル）

### `README.md`
- `mcp-gateway-data` ボリュームの用途説明を追加
- ボリューム確認コマンド（`docker volume inspect`）
- 認証状態リセット手順（`docker volume rm` + 再起動）
- セキュリティ注意事項（他サービスへの非公開、IDE 設定への非記載）

## Acceptance Criteria チェック

- [x] Named volume `mcp-gateway-data` defined in `docker-compose.yml`
- [x] `MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.db` passed as env var to gateway
- [x] README documents volume purpose, inspect/reset commands, and security notes
- [x] `.gitignore` updated to exclude local token files
- [x] IDE config export does not include volume or token information（IDE へは URL のみ）

Closes #112