### PR TITLE
fix: add init container to fix mcp-gateway-data volume ownership

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,16 +43,32 @@ services:
           cpus: "0.5"
           memory: 256M
 
+  # mcp-gateway-data ボリュームを nonroot (UID=65532) 所有に初期化する。
+  # 空ボリュームは Docker がルート所有で作成するため、起動前に一度だけ chown する。
+  mcp-gateway-init:
+    image: alpine:3
+    container_name: mcp-gateway-init
+    restart: "no"
+    user: root
+    command: ["chown", "-R", "65532:65532", "/data"]
+    volumes:
+      - mcp-gateway-data:/data
+
   mcp-gateway:
     image: ${GITHUB_MCP_GATEWAY_IMAGE:-ghcr.io/scottlz0310/mcp-gateway:latest}
     container_name: mcp-gateway
     restart: unless-stopped
     depends_on:
-      - github-mcp
-      - copilot-review-mcp
+      mcp-gateway-init:
+        condition: service_completed_successfully
+      github-mcp:
+        condition: service_started
+      copilot-review-mcp:
+        condition: service_started
       # playwright-mcp はデフォルトで有効化済み。不要な場合はこの行と
       # ROUTE_PLAYWRIGHT 環境変数・playwright-mcp サービス定義を削除してください。
-      - playwright-mcp
+      playwright-mcp:
+        condition: service_started
 
     environment:
       - GITHUB_MCP_CLIENT_ID=${GITHUB_MCP_CLIENT_ID}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     restart: "no"
     user: root
     command: ["chown", "-R", "65532:65532", "/data"]
+    network_mode: none
     volumes:
       - mcp-gateway-data:/data
 


### PR DESCRIPTION
## 問題

`mcp-gateway` は `nonroot` (UID 65532) で動作するが、Docker が新規作成した named volume はルート所有になるため `/data` への書き込みが `permission denied` で失敗しコンテナが crash loop していた。

```
auth handler init failed: token store parent directory not writable "/data": permission denied
```

## 解決策

`mcp-gateway-init` サービス（alpine, `restart: "no"`）を追加し、`mcp-gateway` 起動前に `chown 65532:65532 /data` を実行する。

`depends_on.condition: service_completed_successfully` により init が完了してから本体が起動する。

## 変更内容

- `docker-compose.yml` に `mcp-gateway-init` サービスを追加
- `mcp-gateway` の `depends_on` を条件付き形式に変更

## 動作確認

ローカルで `docker compose up -d` により全サービス正常起動（`mcp-gateway: Up`）を確認済み。