### PR TITLE
[codex] add mcp-docker register CLI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,8 @@ jobs:
         include:
           - language: actions
             build-mode: none
+          - language: go
+            build-mode: autobuild
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -67,6 +69,10 @@ jobs:
 
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@v4
 
       # If the analyze step fails for one of the languages you are analyzing with
       # "We were unable to automatically build your code", modify the matrix above

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -36,4 +36,21 @@ jobs:
       - name: シェルスクリプトテスト実行
         run: bats tests/shell/*.bats
 
+  test-go:
+    name: Go CLI テスト
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Go セットアップ
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Go テスト
+        run: go test ./...
+
+      - name: Go ビルド
+        run: go build ./cmd/mcp-docker
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pids
 *.pid
 *.seed
 *.pid.lock
+bin/
 
 # Coverage directory used by tools like istanbul
 coverage/

--- a/Makefile
+++ b/Makefile
@@ -116,12 +116,45 @@ status: status-gateway ## 全サービスの状態確認（status-gateway のエ
 gen-config: ## IDE設定ファイルを生成 (IDE=vscode|claude-desktop|kiro|amazonq|codex|copilot-cli)
 	./scripts/generate-ide-config.sh --ide $(or $(IDE),vscode)
 
+# CLI 登録（Primary）
+BIN_DIR      := bin
+MCP_DOCKER   := $(BIN_DIR)/mcp-docker
+GO_SOURCES   := $(shell find cmd internal -name '*.go' 2>/dev/null)
+REGISTER_FLAGS ?=
+
+$(MCP_DOCKER): go.mod go.sum $(GO_SOURCES)
+	"$(SHELL)" -c "mkdir -p $(BIN_DIR)"
+	go build -o $(MCP_DOCKER) ./cmd/mcp-docker
+
+.PHONY: register-claude
+register-claude: $(MCP_DOCKER) ## Claude CLI に MCP サーバーを登録
+	$(MCP_DOCKER) register --agent claude $(REGISTER_FLAGS)
+
+.PHONY: register-copilot
+register-copilot: $(MCP_DOCKER) ## GitHub Copilot CLI に MCP サーバーを登録
+	$(MCP_DOCKER) register --agent copilot $(REGISTER_FLAGS)
+
+.PHONY: register-codex
+register-codex: $(MCP_DOCKER) ## Codex CLI に MCP サーバーを登録
+	$(MCP_DOCKER) register --agent codex $(REGISTER_FLAGS)
+
+.PHONY: register-all
+register-all: $(MCP_DOCKER) ## Claude / Copilot / Codex CLI に MCP サーバーを登録
+	$(MCP_DOCKER) register --agent all $(REGISTER_FLAGS)
+
 # ----------------------------------------
 # 開発
 # ----------------------------------------
 
 .PHONY: lint
 lint: lint-shell ## すべてのLint実行
+
+.PHONY: test-go
+test-go: ## Go CLI のテスト実行
+	go test ./...
+
+.PHONY: build-go
+build-go: $(MCP_DOCKER) ## Go CLI をビルド
 
 .PHONY: lint-shell
 lint-shell: ## シェルスクリプトのlint実行

--- a/README.md
+++ b/README.md
@@ -117,7 +117,26 @@ GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 ## IDE 統合
 
-設定生成スクリプトで IDE 別の JSON/TOML 設定が得られます：
+CLI 登録に対応しているエージェント（Claude CLI / GitHub Copilot CLI / Codex CLI）は、`mcp-docker register` で mcp-gateway の HTTP エンドポイントを直接登録できます。
+
+```bash
+# 事前に make start-gateway で mcp-gateway を起動
+make register-claude   REGISTER_FLAGS=--yes
+make register-copilot  REGISTER_FLAGS=--yes
+make register-codex    REGISTER_FLAGS=--yes
+
+# 3 種類まとめて登録
+make register-all      REGISTER_FLAGS=--yes
+```
+
+登録対象は以下から読み取ります：
+
+- `docker-compose.yml` の `mcp-gateway.environment.ROUTE_*`
+- `config/mcp-external.yml` の外部 MCP サーバー定義
+
+`ROUTE_GITHUB` は `github`、`ROUTE_COPILOT_REVIEW` は `copilot-review` のようにサーバー名へ変換されます。`REGISTER_FLAGS=--yes` を外すと、検出した名前を対話的に変更できます。
+
+設定ファイルしか対応していない IDE 向けには、従来どおり設定生成スクリプトで IDE 別の JSON/TOML 設定が得られます：
 
 ```bash
 make gen-config IDE=vscode       # VS Code / Cursor
@@ -185,7 +204,12 @@ Claude Desktop は HTTP transport 非対応のため、`docker run -i --rm ... s
 | `make logs` / `make logs-gateway` | mcp-gateway ログ表示 |
 | `make pull` / `make pull-gateway` | 全イメージ更新 |
 | `make gen-config` | IDE 設定生成（`IDE=vscode` 等を指定） |
+| `make register-claude` | Claude CLI に MCP サーバーを登録 |
+| `make register-copilot` | GitHub Copilot CLI に MCP サーバーを登録 |
+| `make register-codex` | Codex CLI に MCP サーバーを登録 |
+| `make register-all` | Claude / Copilot / Codex CLI に MCP サーバーを登録 |
 | `make lint` | シェルスクリプト Lint |
+| `make test-go` | Go CLI テスト |
 | `make test-shell` | シェルスクリプトテスト（BATS） |
 | `make clean` | キャッシュ削除 |
 | `make clean-docker` | Docker リソースクリーンアップ |
@@ -314,10 +338,16 @@ docker compose up -d
 
 ```
 Mcp-Docker/
+├── cmd/
+│   └── mcp-docker/             # CLI 登録オーケストレータ
+├── internal/
+│   ├── compose/                # docker-compose.yml の ROUTE_* 抽出
+│   ├── external/               # config/mcp-external.yml 読み込み
+│   └── register/               # Claude / Copilot / Codex adapter
 ├── docker-compose.yml          # メインの Compose 定義（4サービス）
 ├── Makefile                    # 操作コマンド集
-├── tasks.md                    # 開発タスク管理
 ├── config/
+│   ├── mcp-external.yml        # 外部 MCP サーバー定義
 │   └── github-mcp/             # github-mcp-server の設定（ボリュームマウント）
 ├── scripts/
 │   ├── setup.sh                # 初回セットアップ

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -15,9 +15,9 @@ import (
 	"github.com/scottlz0310/mcp-docker/tools/internal/register"
 )
 
-const usage = `mcp-docker manages MCP Docker helper workflows.
+const usage = `mcp-docker は MCP Docker の補助ワークフローを管理します。
 
-Usage:
+使い方:
   mcp-docker register [--agent claude|copilot|codex|all] [--compose path] [--external path] [--yes] [--dry-run]
 `
 
@@ -41,7 +41,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer, stdin io.
 		fmt.Fprint(stdout, usage)
 		return nil
 	default:
-		return fmt.Errorf("unknown command %q\n\n%s", args[0], usage)
+		return fmt.Errorf("不明なコマンド %q\n\n%s", args[0], usage)
 	}
 }
 
@@ -50,16 +50,16 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 	fs.SetOutput(stderr)
 
 	opts := registerOptions{}
-	fs.StringVar(&opts.agent, "agent", "all", "agent to register: claude, copilot, codex, or all")
-	fs.StringVar(&opts.composePath, "compose", "docker-compose.yml", "docker compose file to inspect")
-	fs.StringVar(&opts.externalPath, "external", "config/mcp-external.yml", "external MCP server definition file")
-	fs.BoolVar(&opts.yes, "yes", false, "accept suggested names without prompting")
-	fs.BoolVar(&opts.dryRun, "dry-run", false, "print planned commands without executing them")
+	fs.StringVar(&opts.agent, "agent", "all", "登録対象エージェント: claude, copilot, codex, all")
+	fs.StringVar(&opts.composePath, "compose", "docker-compose.yml", "読み込む docker compose ファイル")
+	fs.StringVar(&opts.externalPath, "external", "config/mcp-external.yml", "外部 MCP サーバー定義ファイル")
+	fs.BoolVar(&opts.yes, "yes", false, "サジェスト名を確認なしで採用")
+	fs.BoolVar(&opts.dryRun, "dry-run", false, "実行せず、登録時に使うコマンドと条件を表示")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+		return fmt.Errorf("想定外の引数です: %s", strings.Join(fs.Args(), " "))
 	}
 
 	servers, err := loadServers(opts.composePath, opts.externalPath)
@@ -67,7 +67,7 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		return err
 	}
 	if len(servers) == 0 {
-		return errors.New("no MCP servers were discovered")
+		return errors.New("MCP サーバーが見つかりませんでした")
 	}
 
 	if !opts.yes {
@@ -149,7 +149,7 @@ func validateUniqueServers(servers []register.Server) error {
 	for _, server := range servers {
 		label := serverLabel(server)
 		if prev, ok := seen[server.Name]; ok {
-			return fmt.Errorf("duplicate MCP server name %q (%s and %s)", server.Name, prev, label)
+			return fmt.Errorf("MCP サーバー名 %q が重複しています（%s と %s）", server.Name, prev, label)
 		}
 		seen[server.Name] = label
 	}
@@ -182,5 +182,5 @@ func selectAgents(name string) ([]agentSpec, error) {
 			return []agentSpec{spec}, nil
 		}
 	}
-	return nil, fmt.Errorf("unknown agent %q", name)
+	return nil, fmt.Errorf("不明なエージェント %q", name)
 }

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/scottlz0310/mcp-docker/tools/internal/compose"
+	"github.com/scottlz0310/mcp-docker/tools/internal/external"
+	"github.com/scottlz0310/mcp-docker/tools/internal/register"
+)
+
+const usage = `mcp-docker manages MCP Docker helper workflows.
+
+Usage:
+  mcp-docker register [--agent claude|copilot|codex|all] [--compose path] [--external path] [--yes] [--dry-run]
+`
+
+func main() {
+	if err := run(context.Background(), os.Args[1:], os.Stdout, os.Stderr, os.Stdin); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer, stdin io.Reader) error {
+	if len(args) == 0 {
+		fmt.Fprint(stdout, usage)
+		return nil
+	}
+
+	switch args[0] {
+	case "register":
+		return runRegister(ctx, args[1:], stdout, stderr, stdin)
+	case "help", "-h", "--help":
+		fmt.Fprint(stdout, usage)
+		return nil
+	default:
+		return fmt.Errorf("unknown command %q\n\n%s", args[0], usage)
+	}
+}
+
+func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, stdin io.Reader) error {
+	fs := flag.NewFlagSet("register", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	opts := registerOptions{}
+	fs.StringVar(&opts.agent, "agent", "all", "agent to register: claude, copilot, codex, or all")
+	fs.StringVar(&opts.composePath, "compose", "docker-compose.yml", "docker compose file to inspect")
+	fs.StringVar(&opts.externalPath, "external", "config/mcp-external.yml", "external MCP server definition file")
+	fs.BoolVar(&opts.yes, "yes", false, "accept suggested names without prompting")
+	fs.BoolVar(&opts.dryRun, "dry-run", false, "print planned commands without executing them")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+
+	servers, err := loadServers(opts.composePath, opts.externalPath)
+	if err != nil {
+		return err
+	}
+	if len(servers) == 0 {
+		return errors.New("no MCP servers were discovered")
+	}
+
+	if !opts.yes {
+		if err := confirmRouteNames(stdin, stdout, servers); err != nil {
+			return err
+		}
+	}
+
+	selected, err := selectAgents(opts.agent)
+	if err != nil {
+		return err
+	}
+	execRunner := register.ExecRunner{}
+	for _, spec := range selected {
+		agent := spec.newAgent(execRunner)
+		if opts.dryRun {
+			register.PrintPlan(stdout, agent, servers)
+			continue
+		}
+		if err := register.Register(ctx, stdout, agent, servers); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type registerOptions struct {
+	agent        string
+	composePath  string
+	externalPath string
+	yes          bool
+	dryRun       bool
+}
+
+func loadServers(composePath, externalPath string) ([]register.Server, error) {
+	composeServers, err := compose.Load(composePath)
+	if err != nil {
+		return nil, err
+	}
+	externalServers, err := external.Load(externalPath)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	var servers []register.Server
+	for _, server := range append(composeServers, externalServers...) {
+		if _, ok := seen[server.Name]; ok {
+			return nil, fmt.Errorf("duplicate MCP server name %q", server.Name)
+		}
+		seen[server.Name] = struct{}{}
+		servers = append(servers, server)
+	}
+	return servers, nil
+}
+
+func confirmRouteNames(stdin io.Reader, stdout io.Writer, servers []register.Server) error {
+	reader := bufio.NewReader(stdin)
+	for i := range servers {
+		if servers[i].Source == "" {
+			continue
+		}
+		fmt.Fprintf(stdout, "%s -> suggested name %q [Enter to accept / type override]: ", servers[i].Source, servers[i].Name)
+		line, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+		override := strings.TrimSpace(line)
+		if override != "" {
+			servers[i].Name = override
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+	}
+	return nil
+}
+
+type agentSpec struct {
+	name     string
+	newAgent func(register.Runner) register.Agent
+}
+
+func selectAgents(name string) ([]agentSpec, error) {
+	all := []agentSpec{
+		{name: "claude", newAgent: register.NewClaudeAgent},
+		{name: "copilot", newAgent: register.NewCopilotAgent},
+		{name: "codex", newAgent: register.NewCodexAgent},
+	}
+	if name == "all" {
+		return all, nil
+	}
+	for _, spec := range all {
+		if name == spec.name {
+			return []agentSpec{spec}, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown agent %q", name)
+}

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -74,6 +74,9 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		if err := confirmRouteNames(stdin, stdout, servers); err != nil {
 			return err
 		}
+		if err := validateUniqueServers(servers); err != nil {
+			return err
+		}
 	}
 
 	selected, err := selectAgents(opts.agent)
@@ -112,16 +115,11 @@ func loadServers(composePath, externalPath string) ([]register.Server, error) {
 		return nil, err
 	}
 
-	seen := make(map[string]struct{})
 	var servers []register.Server
 	for _, server := range append(composeServers, externalServers...) {
-		if _, ok := seen[server.Name]; ok {
-			return nil, fmt.Errorf("duplicate MCP server name %q", server.Name)
-		}
-		seen[server.Name] = struct{}{}
 		servers = append(servers, server)
 	}
-	return servers, nil
+	return servers, validateUniqueServers(servers)
 }
 
 func confirmRouteNames(stdin io.Reader, stdout io.Writer, servers []register.Server) error {
@@ -144,6 +142,25 @@ func confirmRouteNames(stdin io.Reader, stdout io.Writer, servers []register.Ser
 		}
 	}
 	return nil
+}
+
+func validateUniqueServers(servers []register.Server) error {
+	seen := make(map[string]string)
+	for _, server := range servers {
+		label := serverLabel(server)
+		if prev, ok := seen[server.Name]; ok {
+			return fmt.Errorf("duplicate MCP server name %q (%s and %s)", server.Name, prev, label)
+		}
+		seen[server.Name] = label
+	}
+	return nil
+}
+
+func serverLabel(server register.Server) string {
+	if server.Source != "" {
+		return server.Source
+	}
+	return server.URL
 }
 
 type agentSpec struct {

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/scottlz0310/mcp-docker/tools/internal/register"
+)
+
+func TestValidateUniqueServersReportsCollidingSources(t *testing.T) {
+	err := validateUniqueServers([]register.Server{
+		{Name: "github", URL: "http://127.0.0.1:8080/mcp/github", Source: "ROUTE_GITHUB"},
+		{Name: "github", URL: "http://127.0.0.1:8080/mcp/copilot-review", Source: "ROUTE_COPILOT_REVIEW"},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate name error")
+	}
+	got := err.Error()
+	for _, want := range []string{`duplicate MCP server name "github"`, "ROUTE_GITHUB", "ROUTE_COPILOT_REVIEW"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error = %q, missing %q", got, want)
+		}
+	}
+}

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -16,7 +16,7 @@ func TestValidateUniqueServersReportsCollidingSources(t *testing.T) {
 		t.Fatal("expected duplicate name error")
 	}
 	got := err.Error()
-	for _, want := range []string{`duplicate MCP server name "github"`, "ROUTE_GITHUB", "ROUTE_COPILOT_REVIEW"} {
+	for _, want := range []string{`MCP サーバー名 "github" が重複しています`, "ROUTE_GITHUB", "ROUTE_COPILOT_REVIEW"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("error = %q, missing %q", got, want)
 		}

--- a/config/mcp-external.yml
+++ b/config/mcp-external.yml
@@ -1,0 +1,13 @@
+# External MCP servers registered in addition to docker-compose ROUTE_* entries.
+#
+# tokenEnv is currently passed through to Codex via --bearer-token-env-var.
+# Claude and Copilot require concrete HTTP header values for token-protected
+# endpoints, so mcp-docker intentionally skips tokenEnv entries for those agents
+# rather than persisting secrets in their config files.
+servers:
+  - name: cloudflare-api
+    url: https://mcp.cloudflare.com/mcp
+    tokenEnv: CLOUDFLARE_API_TOKEN
+
+  - name: supabase
+    url: https://mcp.supabase.com/mcp

--- a/config/mcp-external.yml
+++ b/config/mcp-external.yml
@@ -1,13 +1,19 @@
-# External MCP servers registered in addition to docker-compose ROUTE_* entries.
+# Optional external MCP servers registered in addition to docker-compose ROUTE_* entries.
 #
 # tokenEnv is currently passed through to Codex via --bearer-token-env-var.
 # Claude and Copilot require concrete HTTP header values for token-protected
 # endpoints, so mcp-docker intentionally skips tokenEnv entries for those agents
 # rather than persisting secrets in their config files.
-servers:
-  - name: cloudflare-api
-    url: https://mcp.cloudflare.com/mcp
-    tokenEnv: CLOUDFLARE_API_TOKEN
+#
+# Keep the default list empty so `mcp-docker register` only registers the local
+# mcp-gateway routes unless the user opts into additional external services.
+servers: []
 
-  - name: supabase
-    url: https://mcp.supabase.com/mcp
+# Example:
+# servers:
+#   - name: cloudflare-api
+#     url: https://mcp.cloudflare.com/mcp
+#     tokenEnv: CLOUDFLARE_API_TOKEN
+#
+#   - name: supabase
+#     url: https://mcp.supabase.com/mcp

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/scottlz0310/mcp-docker/tools
+
+go 1.24
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/compose/parse.go
+++ b/internal/compose/parse.go
@@ -1,0 +1,129 @@
+package compose
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/scottlz0310/mcp-docker/tools/internal/register"
+	"gopkg.in/yaml.v3"
+)
+
+const defaultGatewayPort = "8080"
+
+type composeFile struct {
+	Services map[string]composeService `yaml:"services"`
+}
+
+type composeService struct {
+	Environment yaml.Node `yaml:"environment"`
+}
+
+func Load(path string) ([]register.Server, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return Parse(data, os.LookupEnv)
+}
+
+func Parse(data []byte, lookup func(string) (string, bool)) ([]register.Server, error) {
+	var file composeFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return nil, err
+	}
+	gateway, ok := file.Services["mcp-gateway"]
+	if !ok {
+		return nil, fmt.Errorf("services.mcp-gateway not found")
+	}
+
+	env, err := environmentMap(gateway.Environment)
+	if err != nil {
+		return nil, err
+	}
+	port := defaultGatewayPort
+	if raw, ok := env["MCP_GATEWAY_PORT"]; ok {
+		port = resolveEnvExpression(raw, lookup, defaultGatewayPort)
+	}
+	if val, ok := lookup("MCP_GATEWAY_PORT"); ok && val != "" {
+		port = val
+	}
+
+	var keys []string
+	for key := range env {
+		if strings.HasPrefix(key, "ROUTE_") {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	servers := make([]register.Server, 0, len(keys))
+	for _, key := range keys {
+		path, _, _ := strings.Cut(env[key], "|")
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return nil, fmt.Errorf("%s has empty route path", key)
+		}
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		name := routeName(key)
+		servers = append(servers, register.Server{
+			Name:   name,
+			URL:    fmt.Sprintf("http://127.0.0.1:%s%s", port, path),
+			Source: key,
+		})
+	}
+	return servers, nil
+}
+
+func environmentMap(node yaml.Node) (map[string]string, error) {
+	env := make(map[string]string)
+	switch node.Kind {
+	case 0:
+		return env, nil
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			key, val, ok := strings.Cut(item.Value, "=")
+			if !ok {
+				env[strings.TrimSpace(item.Value)] = ""
+				continue
+			}
+			env[strings.TrimSpace(key)] = strings.TrimSpace(val)
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			env[strings.TrimSpace(node.Content[i].Value)] = strings.TrimSpace(node.Content[i+1].Value)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported mcp-gateway.environment YAML node kind %d", node.Kind)
+	}
+	return env, nil
+}
+
+func routeName(key string) string {
+	name := strings.TrimPrefix(key, "ROUTE_")
+	name = strings.ToLower(name)
+	return strings.ReplaceAll(name, "_", "-")
+}
+
+var envExpr = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*)(:-([^}]*))?\}$`)
+
+func resolveEnvExpression(raw string, lookup func(string) (string, bool), fallback string) string {
+	match := envExpr.FindStringSubmatch(raw)
+	if match == nil {
+		if raw == "" {
+			return fallback
+		}
+		return raw
+	}
+	if val, ok := lookup(match[1]); ok && val != "" {
+		return val
+	}
+	if match[3] != "" {
+		return match[3]
+	}
+	return fallback
+}

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -1,0 +1,57 @@
+package compose
+
+import "testing"
+
+func TestParseRoutesFromComposeEnvironment(t *testing.T) {
+	data := []byte(`
+services:
+  mcp-gateway:
+    environment:
+      - MCP_GATEWAY_PORT=${MCP_GATEWAY_PORT:-8080}
+      - ROUTE_GITHUB=/mcp/github|http://github-mcp:8082
+      - ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
+      - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:8931|auth=none
+`)
+	servers, err := Parse(data, func(string) (string, bool) { return "", false })
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"copilot-review": "http://127.0.0.1:8080/mcp/copilot-review",
+		"github":         "http://127.0.0.1:8080/mcp/github",
+		"playwright":     "http://127.0.0.1:8080/mcp/playwright",
+	}
+	if len(servers) != len(want) {
+		t.Fatalf("got %d servers, want %d", len(servers), len(want))
+	}
+	for _, server := range servers {
+		if got := server.URL; got != want[server.Name] {
+			t.Fatalf("%s URL = %q, want %q", server.Name, got, want[server.Name])
+		}
+		if server.Source == "" {
+			t.Fatalf("%s Source is empty", server.Name)
+		}
+	}
+}
+
+func TestParseUsesEnvironmentPortOverride(t *testing.T) {
+	data := []byte(`
+services:
+  mcp-gateway:
+    environment:
+      MCP_GATEWAY_PORT: ${MCP_GATEWAY_PORT:-8080}
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+`)
+	servers, err := Parse(data, func(key string) (string, bool) {
+		if key == "MCP_GATEWAY_PORT" {
+			return "18080", true
+		}
+		return "", false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := servers[0].URL, "http://127.0.0.1:18080/mcp/github"; got != want {
+		t.Fatalf("URL = %q, want %q", got, want)
+	}
+}

--- a/internal/external/parse.go
+++ b/internal/external/parse.go
@@ -1,0 +1,52 @@
+package external
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/scottlz0310/mcp-docker/tools/internal/register"
+	"gopkg.in/yaml.v3"
+)
+
+type file struct {
+	Servers []server `yaml:"servers"`
+}
+
+type server struct {
+	Name     string `yaml:"name"`
+	URL      string `yaml:"url"`
+	TokenEnv string `yaml:"tokenEnv"`
+}
+
+func Load(path string) ([]register.Server, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return Parse(data)
+}
+
+func Parse(data []byte) ([]register.Server, error) {
+	var cfg file
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	servers := make([]register.Server, 0, len(cfg.Servers))
+	for i, item := range cfg.Servers {
+		if item.Name == "" {
+			return nil, fmt.Errorf("servers[%d].name is required", i)
+		}
+		if item.URL == "" {
+			return nil, fmt.Errorf("servers[%d].url is required", i)
+		}
+		servers = append(servers, register.Server{
+			Name:     item.Name,
+			URL:      item.URL,
+			TokenEnv: item.TokenEnv,
+		})
+	}
+	return servers, nil
+}

--- a/internal/external/parse_test.go
+++ b/internal/external/parse_test.go
@@ -1,0 +1,23 @@
+package external
+
+import "testing"
+
+func TestParseExternalServers(t *testing.T) {
+	servers, err := Parse([]byte(`
+servers:
+  - name: cloudflare-api
+    url: https://mcp.cloudflare.com/mcp
+    tokenEnv: CLOUDFLARE_API_TOKEN
+  - name: supabase
+    url: https://mcp.supabase.com/mcp
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(servers), 2; got != want {
+		t.Fatalf("len = %d, want %d", got, want)
+	}
+	if got, want := servers[0].TokenEnv, "CLOUDFLARE_API_TOKEN"; got != want {
+		t.Fatalf("TokenEnv = %q, want %q", got, want)
+	}
+}

--- a/internal/register/agent.go
+++ b/internal/register/agent.go
@@ -27,7 +27,7 @@ type Agent interface {
 }
 
 func Register(ctx context.Context, out io.Writer, agent Agent, servers []Server) error {
-	fmt.Fprintf(out, "Registering %d MCP server(s) for %s\n", len(servers), agent.Name())
+	fmt.Fprintf(out, "%s に %d 件の MCP サーバーを登録します\n", agent.Name(), len(servers))
 
 	existing := make(map[string]struct{})
 	if !agent.OverwritesOnAdd() {
@@ -42,22 +42,22 @@ func Register(ctx context.Context, out io.Writer, agent Agent, servers []Server)
 
 	for _, server := range servers {
 		if server.Name == "" || server.URL == "" {
-			return fmt.Errorf("invalid MCP server: name and URL are required")
+			return fmt.Errorf("MCP サーバー定義が不正です: name と URL が必要です")
 		}
 		if reason, ok := unsupportedReason(agent, server); ok {
-			fmt.Fprintf(out, "- %s: skipped: %s\n", server.Name, reason)
+			fmt.Fprintf(out, "- %s: スキップ: %s\n", server.Name, reason)
 			continue
 		}
 		if _, ok := existing[server.Name]; ok {
-			fmt.Fprintf(out, "- %s: removing existing registration\n", server.Name)
+			fmt.Fprintf(out, "- %s: 既存登録を削除します\n", server.Name)
 			if err := agent.Remove(ctx, server.Name); err != nil {
 				return fmt.Errorf("%s remove %q: %w", agent.Name(), server.Name, err)
 			}
 		}
-		fmt.Fprintf(out, "- %s: adding %s\n", server.Name, server.URL)
+		fmt.Fprintf(out, "- %s: %s を追加します\n", server.Name, server.URL)
 		if err := agent.Add(ctx, server); err != nil {
 			if errors.Is(err, ErrUnsupported) {
-				fmt.Fprintf(out, "  skipped: %v\n", err)
+				fmt.Fprintf(out, "  スキップ: %v\n", err)
 				continue
 			}
 			return fmt.Errorf("%s add %q: %w", agent.Name(), server.Name, err)
@@ -67,13 +67,35 @@ func Register(ctx context.Context, out io.Writer, agent Agent, servers []Server)
 }
 
 func PrintPlan(out io.Writer, agent Agent, servers []Server) {
-	fmt.Fprintf(out, "Plan for %s:\n", agent.Name())
+	fmt.Fprintf(out, "%s の dry-run 計画:\n", agent.Name())
+	if !agent.OverwritesOnAdd() {
+		fmt.Fprintf(out, "- 既存登録確認: %s\n", shellish(listCommand(agent)))
+	}
 	for _, server := range servers {
 		if reason, ok := unsupportedReason(agent, server); ok {
-			fmt.Fprintf(out, "- skip %s: %s\n", server.Name, reason)
+			fmt.Fprintf(out, "- %s: スキップ: %s\n", server.Name, reason)
 			continue
 		}
-		fmt.Fprintf(out, "- %s\n", shellish(agent.AddCommand(server)))
+		fmt.Fprintf(out, "- %s:\n", server.Name)
+		if agent.OverwritesOnAdd() {
+			fmt.Fprintf(out, "  - 追加/上書き: %s\n", shellish(agent.AddCommand(server)))
+			continue
+		}
+		fmt.Fprintf(out, "  - 既存登録があれば削除: %s\n", shellish(agent.RemoveCommand(server.Name)))
+		fmt.Fprintf(out, "  - 追加: %s\n", shellish(agent.AddCommand(server)))
+	}
+}
+
+func listCommand(agent Agent) []string {
+	switch agent.Name() {
+	case "claude":
+		return []string{"claude", "mcp", "list"}
+	case "copilot":
+		return []string{"gh", "copilot", "--", "mcp", "list"}
+	case "codex":
+		return []string{"codex", "mcp", "list"}
+	default:
+		return []string{agent.Name(), "mcp", "list"}
 	}
 }
 
@@ -84,5 +106,5 @@ func unsupportedReason(agent Agent, server Server) (string, bool) {
 	if _, ok := agent.(tokenEnvAgent); ok {
 		return "", false
 	}
-	return fmt.Sprintf("tokenEnv %s is not supported by %s without storing a secret header", server.TokenEnv, agent.Name()), true
+	return fmt.Sprintf("tokenEnv %s は secret header を保存せずに %s へ登録できません", server.TokenEnv, agent.Name()), true
 }

--- a/internal/register/agent.go
+++ b/internal/register/agent.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
 )
 
 var ErrUnsupported = errors.New("unsupported server for agent")
@@ -45,6 +44,10 @@ func Register(ctx context.Context, out io.Writer, agent Agent, servers []Server)
 		if server.Name == "" || server.URL == "" {
 			return fmt.Errorf("invalid MCP server: name and URL are required")
 		}
+		if reason, ok := unsupportedReason(agent, server); ok {
+			fmt.Fprintf(out, "- %s: skipped: %s\n", server.Name, reason)
+			continue
+		}
 		if _, ok := existing[server.Name]; ok {
 			fmt.Fprintf(out, "- %s: removing existing registration\n", server.Name)
 			if err := agent.Remove(ctx, server.Name); err != nil {
@@ -66,18 +69,20 @@ func Register(ctx context.Context, out io.Writer, agent Agent, servers []Server)
 func PrintPlan(out io.Writer, agent Agent, servers []Server) {
 	fmt.Fprintf(out, "Plan for %s:\n", agent.Name())
 	for _, server := range servers {
-		if server.TokenEnv != "" {
-			if _, ok := agent.(tokenEnvAgent); !ok {
-				fmt.Fprintf(out, "- skip %s: tokenEnv is not supported by %s without storing a secret header\n", server.Name, agent.Name())
-				continue
-			}
+		if reason, ok := unsupportedReason(agent, server); ok {
+			fmt.Fprintf(out, "- skip %s: %s\n", server.Name, reason)
+			continue
 		}
 		fmt.Fprintf(out, "- %s\n", shellish(agent.AddCommand(server)))
 	}
 }
 
-func containsName(names []string, target string) bool {
-	sort.Strings(names)
-	i := sort.SearchStrings(names, target)
-	return i < len(names) && names[i] == target
+func unsupportedReason(agent Agent, server Server) (string, bool) {
+	if server.TokenEnv == "" {
+		return "", false
+	}
+	if _, ok := agent.(tokenEnvAgent); ok {
+		return "", false
+	}
+	return fmt.Sprintf("tokenEnv %s is not supported by %s without storing a secret header", server.TokenEnv, agent.Name()), true
 }

--- a/internal/register/agent.go
+++ b/internal/register/agent.go
@@ -1,0 +1,83 @@
+package register
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+)
+
+var ErrUnsupported = errors.New("unsupported server for agent")
+
+type Server struct {
+	Name     string
+	URL      string
+	TokenEnv string
+	Source   string
+}
+
+type Agent interface {
+	Name() string
+	List(context.Context) ([]string, error)
+	Add(context.Context, Server) error
+	Remove(context.Context, string) error
+	OverwritesOnAdd() bool
+	AddCommand(Server) []string
+	RemoveCommand(string) []string
+}
+
+func Register(ctx context.Context, out io.Writer, agent Agent, servers []Server) error {
+	fmt.Fprintf(out, "Registering %d MCP server(s) for %s\n", len(servers), agent.Name())
+
+	existing := make(map[string]struct{})
+	if !agent.OverwritesOnAdd() {
+		names, err := agent.List(ctx)
+		if err != nil {
+			return fmt.Errorf("%s list: %w", agent.Name(), err)
+		}
+		for _, name := range names {
+			existing[name] = struct{}{}
+		}
+	}
+
+	for _, server := range servers {
+		if server.Name == "" || server.URL == "" {
+			return fmt.Errorf("invalid MCP server: name and URL are required")
+		}
+		if _, ok := existing[server.Name]; ok {
+			fmt.Fprintf(out, "- %s: removing existing registration\n", server.Name)
+			if err := agent.Remove(ctx, server.Name); err != nil {
+				return fmt.Errorf("%s remove %q: %w", agent.Name(), server.Name, err)
+			}
+		}
+		fmt.Fprintf(out, "- %s: adding %s\n", server.Name, server.URL)
+		if err := agent.Add(ctx, server); err != nil {
+			if errors.Is(err, ErrUnsupported) {
+				fmt.Fprintf(out, "  skipped: %v\n", err)
+				continue
+			}
+			return fmt.Errorf("%s add %q: %w", agent.Name(), server.Name, err)
+		}
+	}
+	return nil
+}
+
+func PrintPlan(out io.Writer, agent Agent, servers []Server) {
+	fmt.Fprintf(out, "Plan for %s:\n", agent.Name())
+	for _, server := range servers {
+		if server.TokenEnv != "" {
+			if _, ok := agent.(tokenEnvAgent); !ok {
+				fmt.Fprintf(out, "- skip %s: tokenEnv is not supported by %s without storing a secret header\n", server.Name, agent.Name())
+				continue
+			}
+		}
+		fmt.Fprintf(out, "- %s\n", shellish(agent.AddCommand(server)))
+	}
+}
+
+func containsName(names []string, target string) bool {
+	sort.Strings(names)
+	i := sort.SearchStrings(names, target)
+	return i < len(names) && names[i] == target
+}

--- a/internal/register/agents.go
+++ b/internal/register/agents.go
@@ -1,0 +1,155 @@
+package register
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type baseAgent struct {
+	name   string
+	runner Runner
+}
+
+func (a baseAgent) Name() string { return a.name }
+
+type ClaudeAgent struct{ baseAgent }
+type CopilotAgent struct{ baseAgent }
+type CodexAgent struct{ baseAgent }
+
+type tokenEnvAgent interface {
+	supportsTokenEnv()
+}
+
+func NewClaudeAgent(r Runner) Agent {
+	return ClaudeAgent{baseAgent{name: "claude", runner: r}}
+}
+
+func NewCopilotAgent(r Runner) Agent {
+	return CopilotAgent{baseAgent{name: "copilot", runner: r}}
+}
+
+func NewCodexAgent(r Runner) Agent {
+	return CodexAgent{baseAgent{name: "codex", runner: r}}
+}
+
+func (a ClaudeAgent) List(ctx context.Context) ([]string, error) {
+	out, err := a.runner.Run(ctx, "claude", "mcp", "list")
+	return parseListNames(out), err
+}
+
+func (a ClaudeAgent) Add(ctx context.Context, s Server) error {
+	if s.TokenEnv != "" {
+		return fmt.Errorf("%w: %s tokenEnv requires a header value; refusing to persist secrets for %s", ErrUnsupported, s.TokenEnv, a.Name())
+	}
+	return runCommand(ctx, a.runner, a.AddCommand(s))
+}
+
+func (a ClaudeAgent) Remove(ctx context.Context, name string) error {
+	return runCommand(ctx, a.runner, a.RemoveCommand(name))
+}
+
+func (a ClaudeAgent) OverwritesOnAdd() bool { return false }
+
+func (a ClaudeAgent) AddCommand(s Server) []string {
+	return []string{"claude", "mcp", "add", "--transport", "http", "--scope", "user", s.Name, s.URL}
+}
+
+func (a ClaudeAgent) RemoveCommand(name string) []string {
+	return []string{"claude", "mcp", "remove", "--scope", "user", name}
+}
+
+func (a CopilotAgent) List(ctx context.Context) ([]string, error) {
+	out, err := a.runner.Run(ctx, "gh", "copilot", "--", "mcp", "list")
+	return parseListNames(out), err
+}
+
+func (a CopilotAgent) Add(ctx context.Context, s Server) error {
+	if s.TokenEnv != "" {
+		return fmt.Errorf("%w: %s tokenEnv requires a header value; refusing to persist secrets for %s", ErrUnsupported, s.TokenEnv, a.Name())
+	}
+	return runCommand(ctx, a.runner, a.AddCommand(s))
+}
+
+func (a CopilotAgent) Remove(ctx context.Context, name string) error {
+	return runCommand(ctx, a.runner, a.RemoveCommand(name))
+}
+
+func (a CopilotAgent) OverwritesOnAdd() bool { return false }
+
+func (a CopilotAgent) AddCommand(s Server) []string {
+	return []string{"gh", "copilot", "--", "mcp", "add", "--transport", "http", s.Name, s.URL}
+}
+
+func (a CopilotAgent) RemoveCommand(name string) []string {
+	return []string{"gh", "copilot", "--", "mcp", "remove", name}
+}
+
+func (a CodexAgent) List(ctx context.Context) ([]string, error) {
+	out, err := a.runner.Run(ctx, "codex", "mcp", "list")
+	return parseListNames(out), err
+}
+
+func (a CodexAgent) Add(ctx context.Context, s Server) error {
+	return runCommand(ctx, a.runner, a.AddCommand(s))
+}
+
+func (a CodexAgent) Remove(ctx context.Context, name string) error {
+	return runCommand(ctx, a.runner, a.RemoveCommand(name))
+}
+
+func (a CodexAgent) OverwritesOnAdd() bool { return true }
+
+func (a CodexAgent) supportsTokenEnv() {}
+
+func (a CodexAgent) AddCommand(s Server) []string {
+	args := []string{"codex", "mcp", "add", s.Name, "--url", s.URL}
+	if s.TokenEnv != "" {
+		args = append(args, "--bearer-token-env-var", s.TokenEnv)
+	}
+	return args
+}
+
+func (a CodexAgent) RemoveCommand(name string) []string {
+	return []string{"codex", "mcp", "remove", name}
+}
+
+func runCommand(ctx context.Context, runner Runner, command []string) error {
+	if len(command) == 0 {
+		return nil
+	}
+	_, err := runner.Run(ctx, command[0], command[1:]...)
+	return err
+}
+
+func parseListNames(output string) []string {
+	var names []string
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "no mcp") || strings.Contains(lower, "not configured") || strings.HasPrefix(lower, "name ") {
+			continue
+		}
+
+		name := line
+		if before, _, ok := strings.Cut(name, ":"); ok {
+			name = before
+		} else {
+			name = strings.Fields(name)[0]
+		}
+		name = strings.Trim(name, "`'\"")
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names
+}

--- a/internal/register/agents_test.go
+++ b/internal/register/agents_test.go
@@ -76,11 +76,29 @@ func TestClaudeSkipsTokenEnvServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out.String(), "skipped") {
-		t.Fatalf("output = %q, want skipped message", out.String())
+	if !strings.Contains(out.String(), "スキップ") {
+		t.Fatalf("output = %q, want skip message", out.String())
 	}
 	got := strings.Join(runner.calls, "\n")
 	if strings.Contains(got, "remove cloudflare-api") || strings.Contains(got, "add --transport http --scope user cloudflare-api") {
 		t.Fatalf("unsupported server must not be removed or added, calls =\n%s", got)
+	}
+}
+
+func TestPrintPlanShowsListAndConditionalRemove(t *testing.T) {
+	agent := NewCopilotAgent(&fakeRunner{})
+	var out bytes.Buffer
+
+	PrintPlan(&out, agent, []Server{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}})
+
+	got := out.String()
+	for _, want := range []string{
+		"既存登録確認: gh copilot -- mcp list",
+		"既存登録があれば削除: gh copilot -- mcp remove github",
+		"追加: gh copilot -- mcp add --transport http github http://127.0.0.1:8080/mcp/github",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("plan =\n%s\nmissing %q", got, want)
+		}
 	}
 }

--- a/internal/register/agents_test.go
+++ b/internal/register/agents_test.go
@@ -1,0 +1,82 @@
+package register
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+type fakeRunner struct {
+	output string
+	calls  []string
+}
+
+func (r *fakeRunner) Run(_ context.Context, name string, args ...string) (string, error) {
+	r.calls = append(r.calls, shellish(append([]string{name}, args...)))
+	return r.output, nil
+}
+
+func TestCopilotRegisterRemovesExistingBeforeAdd(t *testing.T) {
+	runner := &fakeRunner{output: "  github (http)\n"}
+	agent := NewCopilotAgent(runner)
+	var out bytes.Buffer
+
+	err := Register(context.Background(), &out, agent, []Server{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.Join(runner.calls, "\n")
+	for _, want := range []string{
+		"gh copilot -- mcp list",
+		"gh copilot -- mcp remove github",
+		"gh copilot -- mcp add --transport http github http://127.0.0.1:8080/mcp/github",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("calls =\n%s\nmissing %q", got, want)
+		}
+	}
+}
+
+func TestCodexRegisterOverwritesWithoutList(t *testing.T) {
+	runner := &fakeRunner{}
+	agent := NewCodexAgent(runner)
+	var out bytes.Buffer
+
+	err := Register(context.Background(), &out, agent, []Server{{
+		Name:     "cloudflare-api",
+		URL:      "https://mcp.cloudflare.com/mcp",
+		TokenEnv: "CLOUDFLARE_API_TOKEN",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.Join(runner.calls, "\n")
+	if strings.Contains(got, "codex mcp list") {
+		t.Fatalf("codex should not list before add, calls =\n%s", got)
+	}
+	want := "codex mcp add cloudflare-api --url https://mcp.cloudflare.com/mcp --bearer-token-env-var CLOUDFLARE_API_TOKEN"
+	if !strings.Contains(got, want) {
+		t.Fatalf("calls =\n%s\nmissing %q", got, want)
+	}
+}
+
+func TestClaudeSkipsTokenEnvServer(t *testing.T) {
+	runner := &fakeRunner{}
+	agent := NewClaudeAgent(runner)
+	var out bytes.Buffer
+
+	err := Register(context.Background(), &out, agent, []Server{{
+		Name:     "cloudflare-api",
+		URL:      "https://mcp.cloudflare.com/mcp",
+		TokenEnv: "CLOUDFLARE_API_TOKEN",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "skipped") {
+		t.Fatalf("output = %q, want skipped message", out.String())
+	}
+}

--- a/internal/register/agents_test.go
+++ b/internal/register/agents_test.go
@@ -64,7 +64,7 @@ func TestCodexRegisterOverwritesWithoutList(t *testing.T) {
 }
 
 func TestClaudeSkipsTokenEnvServer(t *testing.T) {
-	runner := &fakeRunner{}
+	runner := &fakeRunner{output: "cloudflare-api: https://old.example (HTTP)\n"}
 	agent := NewClaudeAgent(runner)
 	var out bytes.Buffer
 
@@ -78,5 +78,9 @@ func TestClaudeSkipsTokenEnvServer(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "skipped") {
 		t.Fatalf("output = %q, want skipped message", out.String())
+	}
+	got := strings.Join(runner.calls, "\n")
+	if strings.Contains(got, "remove cloudflare-api") || strings.Contains(got, "add --transport http --scope user cloudflare-api") {
+		t.Fatalf("unsupported server must not be removed or added, calls =\n%s", got)
 	}
 }

--- a/internal/register/runner.go
+++ b/internal/register/runner.go
@@ -1,0 +1,35 @@
+package register
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Runner interface {
+	Run(context.Context, string, ...string) (string, error)
+}
+
+type ExecRunner struct{}
+
+func (ExecRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("%s: %w\n%s", shellish(append([]string{name}, args...)), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func shellish(parts []string) string {
+	quoted := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" || strings.ContainsAny(part, " \t\"'") {
+			quoted = append(quoted, fmt.Sprintf("%q", part))
+			continue
+		}
+		quoted = append(quoted, part)
+	}
+	return strings.Join(quoted, " ")
+}


### PR DESCRIPTION
## Summary

- add a Go-based `mcp-docker register` CLI for Claude, GitHub Copilot, and Codex MCP registration
- discover gateway routes from `docker-compose.yml` `ROUTE_*` entries and external services from `config/mcp-external.yml`
- add Makefile targets, README guidance, Go tests, and CI coverage for the new CLI

Refs #117

## Notes

- `generate-ide-config.sh` remains as the legacy/fallback config export path.
- `tokenEnv` entries are passed to Codex via `--bearer-token-env-var`; Claude/Copilot skip those entries to avoid persisting secret header values.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./cmd/mcp-docker`
- `make test-go`
- `make build-go`
- `make register-all REGISTER_FLAGS="--yes --dry-run"`
- `git diff --check`

Local shell validation not run:

- `bash scripts/lint-shell.sh` could not run because local `shellcheck` is not installed.
- `make test-shell` could not run because local `bats` is not installed.