### PR TITLE
docs: generate-ide-config.sh を Legacy/Fallback として位置づけ直し (closes #117)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,11 +109,12 @@ pull: pull-gateway ## 全サービスの Docker イメージを取得（pull-gat
 status: status-gateway ## 全サービスの状態確認（status-gateway のエイリアス）
 
 # ----------------------------------------
-# 設定生成
+# 設定生成（フォールバック / Legacy）
+# mcp add 未対応の IDE 向け設定ファイル生成。CLI 登録対応エージェントには register-* を使用する。
 # ----------------------------------------
 
 .PHONY: gen-config
-gen-config: ## IDE設定ファイルを生成 (IDE=vscode|claude-desktop|kiro|amazonq|codex|copilot-cli)
+gen-config: ## [Legacy] IDE設定ファイルを生成 (IDE=vscode|claude-desktop|kiro|amazonq|codex|copilot-cli)
 	./scripts/generate-ide-config.sh --ide $(or $(IDE),vscode)
 
 # CLI 登録（Primary）

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ status: status-gateway ## 全サービスの状態確認（status-gateway のエ
 
 # ----------------------------------------
 # 設定生成（フォールバック / Legacy）
-# mcp add 未対応の IDE 向け設定ファイル生成。CLI 登録対応エージェントには register-* を使用する。
+# CLI 登録（mcp-docker register）が推奨だが、設定ファイル方式が必要な場合のフォールバック。
 # ----------------------------------------
 
 .PHONY: gen-config

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 ## IDE 統合
 
+### Primary: CLI 登録（推奨）
+
 CLI 登録に対応しているエージェント（Claude CLI / GitHub Copilot CLI / Codex CLI）は、`mcp-docker register` で mcp-gateway の HTTP エンドポイントを直接登録できます。
 
 ```bash
@@ -136,7 +138,9 @@ make register-all      REGISTER_FLAGS=--yes
 
 `ROUTE_GITHUB` は `github`、`ROUTE_COPILOT_REVIEW` は `copilot-review` のようにサーバー名へ変換されます。`REGISTER_FLAGS=--yes` を外すと、検出した名前を対話的に変更できます。
 
-設定ファイルしか対応していない IDE 向けには、従来どおり設定生成スクリプトで IDE 別の JSON/TOML 設定が得られます：
+### フォールバック: 設定ファイル生成（Legacy）
+
+`mcp add` コマンドに対応していない IDE（VS Code GUI・Amazon Q・Kiro など）向けには、`generate-ide-config.sh` で IDE 別の JSON/TOML 設定を生成できます：
 
 ```bash
 make gen-config IDE=vscode       # VS Code / Cursor

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Legacy/Fallback: mcp add コマンドに対応していない IDE 向けの設定ファイル生成スクリプト。
-# CLI 登録に対応しているエージェント（Claude CLI / GitHub Copilot CLI / Codex CLI）は
-# 代わりに `mcp-docker register`（make register-*）を使用してください。
+# Legacy/Fallback: IDE/CLI 向けの MCP 設定ファイル生成スクリプト。
+# CLI 登録に対応しているエージェント（Claude CLI / GitHub Copilot CLI / Codex CLI）では
+# `mcp-docker register`（make register-*）の利用を推奨しますが、
+# 設定ファイル方式が必要な場合のフォールバックとしてこのスクリプトも利用できます。
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/generate-ide-config.sh
+++ b/scripts/generate-ide-config.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Legacy/Fallback: mcp add コマンドに対応していない IDE 向けの設定ファイル生成スクリプト。
+# CLI 登録に対応しているエージェント（Claude CLI / GitHub Copilot CLI / Codex CLI）は
+# 代わりに `mcp-docker register`（make register-*）を使用してください。
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## 概要

Issue #117 の最終残タスクを解消します。

scripts/generate-ide-config.sh（make gen-config）を、mcp add CLI 登録に対応していない IDE 向けの **フォールバック（Legacy）** として明示的に位置づけ直します。

## 変更内容

### README.md
- ## IDE 統合 セクションを **Primary: CLI 登録（推奨）** と **フォールバック: 設定ファイル生成（Legacy）** の 2 つのサブセクションに整理
- Primary セクション: \mcp-docker register\ / \make register-*\ が推奨であることを明確化
- Fallback セクション: 見出しと説明文で Legacy/Fallback の位置づけを明記

### Makefile
- \# 設定生成\ セクションコメントを \# 設定生成（フォールバック / Legacy）\ に変更
- CLI 登録対応エージェントには \egister-*\ を使う旨を注釈追加
- \gen-config\ ターゲットの help テキストに \[Legacy]\ プレフィックスを追加

### scripts/generate-ide-config.sh
- ファイル冒頭に Legacy/Fallback であることと、CLI 登録対応エージェントは \mcp-docker register\ を使うべき旨のコメントを追加

## 検証

- \go test ./...\: 全通過
- \go build ./cmd/mcp-docker\: 成功
- スクリプト自体の変更なし（コメント追加のみ）

## Issue #117 チェックボックスとの対応

| タスク | 状態 |
|--------|------|
| Spike 調査（全4件） | ✅ PR #118 で完了 |
| Go CLI 実装（ClaudeAgent / CopilotAgent / CodexAgent） | ✅ PR #119 で完了 |
| Makefile targets (register-\*) | ✅ PR #119 で完了 |
| README 更新 | ✅ PR #119 で完了 |
| generate-ide-config.sh を Legacy/Fallback として位置づけ直し | ✅ **本 PR で完了** |

Closes #117