### PR TITLE
ci: add go vet to lint-test workflow and Makefile lint target

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -48,6 +48,9 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Go vet
+        run: go vet ./...
+
       - name: Go テスト
         run: go test ./...
 

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -37,7 +37,7 @@ jobs:
         run: bats tests/shell/*.bats
 
   test-go:
-    name: Go CLI テスト
+    name: Go CLI チェック（vet/test/build）
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ register-all: $(MCP_DOCKER) ## Claude / Copilot / Codex CLI に MCP サーバー
 # ----------------------------------------
 
 .PHONY: lint
-lint: lint-shell ## すべてのLint実行
+lint: lint-shell lint-go ## すべてのLint実行
 
 .PHONY: test-go
 test-go: ## Go CLI のテスト実行
@@ -160,6 +160,10 @@ build-go: $(MCP_DOCKER) ## Go CLI をビルド
 .PHONY: lint-shell
 lint-shell: ## シェルスクリプトのlint実行
 	./scripts/lint-shell.sh
+
+.PHONY: lint-go
+lint-go: ## Go CLI のvet実行
+	go vet ./...
 
 .PHONY: test-shell
 test-shell: ## シェルスクリプトのテスト実行

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ register-all: $(MCP_DOCKER) ## Claude / Copilot / Codex CLI に MCP サーバー
 # ----------------------------------------
 
 .PHONY: lint
-lint: lint-shell lint-go ## すべてのLint実行
+lint: lint-shell lint-go ## すべてのLint実行（シェルスクリプト lint + Go vet）
 
 .PHONY: test-go
 test-go: ## Go CLI のテスト実行
@@ -162,7 +162,7 @@ lint-shell: ## シェルスクリプトのlint実行
 	./scripts/lint-shell.sh
 
 .PHONY: lint-go
-lint-go: ## Go CLI のvet実行
+lint-go: ## Go 静的解析（go vet）
 	go vet ./...
 
 .PHONY: test-shell


### PR DESCRIPTION
## 概要

CI最適化の確認中に発見したギャップを修正。

- \go vet ./...\ を \lint-test.yml\ の \	est-go\ ジョブに追加
- Makefile に \lint-go\ ターゲットを追加し \lint\ から呼び出すよう変更

コードベース整理後、\go test\ と \go build\ はあったが \go vet\ が抜けていた。ローカルで \go vet ./...\ は問題なし確認済み。