### PR TITLE
feat: add release workflow for Go CLI binary distribution (v2.6.0)

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -52,7 +52,13 @@ jobs:
         run: go vet ./...
 
       - name: Go テスト
-        run: go test ./...
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Codecov アップロード
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          fail_ci_if_error: false
 
       - name: Go ビルド
         run: go build ./cmd/mcp-docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: リリース
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: ビルド (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            suffix: linux-amd64
+          - goos: linux
+            goarch: arm64
+            suffix: linux-arm64
+          - goos: darwin
+            goarch: amd64
+            suffix: darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            suffix: darwin-arm64
+          - goos: windows
+            goarch: amd64
+            suffix: windows-amd64
+            ext: .exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: バイナリビルド
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+        run: |
+          BIN="mcp-docker-${{ matrix.suffix }}${{ matrix.ext }}"
+          go build -trimpath -ldflags="-s -w" -o "${BIN}" ./cmd/mcp-docker
+          sha256sum "${BIN}" > "${BIN}.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bin-${{ matrix.suffix }}
+          path: |
+            mcp-docker-${{ matrix.suffix }}${{ matrix.ext }}
+            mcp-docker-${{ matrix.suffix }}${{ matrix.ext }}.sha256
+
+  release:
+    name: リリース作成
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: チェックサムファイル統合
+        run: |
+          cat dist/*.sha256 | sort > dist/checksums.txt
+
+      - name: GitHub Release 作成
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            dist/mcp-docker-* \
+            dist/checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,27 @@ permissions:
   contents: write
 
 jobs:
+  test:
+    name: テスト・lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test ./...
+
   build:
     name: ビルド (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest
+    needs: test
     strategy:
       matrix:
         include:
@@ -32,9 +50,9 @@ jobs:
             suffix: windows-amd64
             ext: .exe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -61,7 +79,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/download-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,8 @@ v1.x からの移行:
 ### Fixed
 - Initial bug fixes
 
-[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.6.0...HEAD
+[2.6.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.2.0...v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### 🗑️ 削除（#105 #106 相当クリーンアップ）
-
-- `services/copilot-review-mcp/` を削除（外部リポジトリ `ghcr.io/scottlz0310/copilot-review-mcp` に移行済み）
-- `services/github-oauth-proxy/` を削除（外部リポジトリ `ghcr.io/scottlz0310/mcp-gateway` に移行済み）
-- Makefile: ローカルビルド前提の `crm-*` ターゲット群を削除（`crm-build`, `crm-start`, `crm-stop`, `crm-restart`, `crm-logs`, `crm-status`, `crm-health`）
-- Makefile: `start`（github-mcp 単体）、`restart`（単体）、`build`（pull エイリアス）、`gen-config-crm` を削除
-- `.github/workflows/lint-test.yml`: Go テストジョブ（`test-go`）を削除
-- `.github/workflows/security.yml`: `copilot-review-mcp-scan` ジョブを削除（ローカル Dockerfile 不要に）
-- `.github/workflows/codeql.yml`: `go` 言語マトリックスを削除（Go コード消滅のため）
-- `tasks.md`、`scripts/verify-review-status.sh`、`docs/copilot-review-mcp-tasks.md`、`docs/copilot-review-watch-tools.md`、`docs/design/copilot-review-watch-redesign.md`、`docs/observations/`、`docs/bug-reports/` を削除
-
-### ⚠️ 破壊的変更（#105 #106 相当クリーンアップ）
-
-- Makefile ターゲットを `*-gateway` 命名に統一
-  - `start` / `start-gateway` → **`start-gateway`**（単体起動廃止、gateway スタック起動が唯一の標準）
-  - `stop` → **`stop-gateway`**（`stop` は後方互換エイリアスとして維持）
-  - `restart` → **`restart-gateway`**（`stop-gateway` + `start-gateway`）
-  - `logs-gateway` → 維持
-  - `status-gateway` → 維持（`status` は後方互換エイリアス）
-  - `pull` → **`pull-gateway`**（全サービスイメージを `docker compose pull` で一括取得）
+## [2.6.0] - 2026-04-30
 
 ### ✨ 新機能
 
+- `mcp-docker` Go CLI ツールを追加（#117）
+  - `mcp-docker register [--agent claude|copilot|codex|all]` コマンドで MCP サーバーを各 IDE CLI に一括登録
+  - `--dry-run` オプションで実行前に登録コマンドを確認可能
+  - `--compose` / `--external` で `docker-compose.yml` および `config/mcp-external.yml` から自動的にサーバー一覧を取得
+  - バイナリを GitHub Releases で配布（linux/darwin/windows, amd64/arm64）
+- `.github/workflows/release.yml` を追加: タグ push で自動クロスコンパイル＆リリース作成
+- CI に `go vet ./...` を追加し、Makefile に `lint-go` ターゲットを追加（#122）
 - `auth=none` ルートで認証不要 MCP サーバを設定のみで追加できるパターンを追加（#109）
   - `docker-compose.yml` に `playwright-mcp` サービスをデフォルト有効化済みの設定例として追加
   - `mcp-gateway` の `environment` に `ROUTE_PLAYWRIGHT=.../auth=none` をデフォルト有効化
@@ -39,9 +27,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 前提: `mcp-gateway` の `auth=none` サポート（scottlz0310/mcp-gateway#23 でマージ済み）
 - `copilot-review-mcp` のイメージをローカルビルドから公開パッケージ（`ghcr.io/scottlz0310/copilot-review-mcp:latest`）に変更
   - `COPILOT_REVIEW_MCP_IMAGE` 環境変数でオーバーライド可能
+- `mcp-gateway`（`ghcr.io/scottlz0310/mcp-gateway:latest`）をルーティングゲートウェイとして追加
+  - `ROUTE_GITHUB=/mcp/github|http://github-mcp:8082`
+  - `ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083`
+  - `github-mcp` と `copilot-review-mcp` の両サービスを単一ポートから提供
+  - OAuth 2.0 認証フローを gateway に一元化
 
 ### ⚠️ 破壊的変更
 
+- Makefile ターゲットを `*-gateway` 命名に統一
+  - `start` / `start-gateway` → **`start-gateway`**（単体起動廃止、gateway スタック起動が唯一の標準）
+  - `stop` → **`stop-gateway`**（`stop` は後方互換エイリアスとして維持）
+  - `restart` → **`restart-gateway`**（`stop-gateway` + `start-gateway`）
+  - `logs-gateway` → 維持
+  - `status-gateway` → 維持（`status` は後方互換エイリアス）
+  - `pull` → **`pull-gateway`**（全サービスイメージを `docker compose pull` で一括取得）
 - `github-oauth-proxy` を `mcp-gateway` に置き換え (#107)
   - **ポート変更**: `8084` → `8080`（`MCP_GATEWAY_PORT`）
   - **環境変数変更**:
@@ -52,13 +52,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Makefile: `start-oauth` → `start-gateway`、`logs-oauth` → `logs-gateway`、`status-oauth` → `status-gateway`
   - IDE設定スクリプト: `--service github-oauth-proxy` → `--service mcp-gateway`
 
-### ✨ 新機能
+### 🗑️ 削除
 
-- `mcp-gateway`（`ghcr.io/scottlz0310/mcp-gateway:latest`）をルーティングゲートウェイとして追加
-  - `ROUTE_GITHUB=/mcp/github|http://github-mcp:8082`
-  - `ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083`
-  - `github-mcp` と `copilot-review-mcp` の両サービスを単一ポートから提供
-  - OAuth 2.0 認証フローを gateway に一元化
+- `services/copilot-review-mcp/` を削除（外部リポジトリ `ghcr.io/scottlz0310/copilot-review-mcp` に移行済み）
+- `services/github-oauth-proxy/` を削除（外部リポジトリ `ghcr.io/scottlz0310/mcp-gateway` に移行済み）
+- Makefile: ローカルビルド前提の `crm-*` ターゲット群を削除（`crm-build`, `crm-start`, `crm-stop`, `crm-restart`, `crm-logs`, `crm-status`, `crm-health`）
+- Makefile: `start`（github-mcp 単体）、`restart`（単体）、`build`（pull エイリアス）、`gen-config-crm` を削除
+- `.github/workflows/lint-test.yml`: Go テストジョブ（`test-go`）を削除
+- `.github/workflows/security.yml`: `copilot-review-mcp-scan` ジョブを削除（ローカル Dockerfile 不要に）
+- `.github/workflows/codeql.yml`: `go` 言語マトリックスを削除（Go コード消滅のため）
+- `tasks.md`、`scripts/verify-review-status.sh`、`docs/copilot-review-mcp-tasks.md`、`docs/copilot-review-watch-tools.md`、`docs/design/copilot-review-watch-redesign.md`、`docs/observations/`、`docs/bug-reports/` を削除
 
 ## [2.5.0] - 2026-04-24
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+
+comment:
+  layout: reach,diff,flags,files
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "cmd/mcp-docker/main.go"

--- a/docs/e2e-runbook-mcp-docker-cli.md
+++ b/docs/e2e-runbook-mcp-docker-cli.md
@@ -44,9 +44,15 @@ mcp-docker は MCP Docker の補助ワークフローを管理します。
 ```
 claude の dry-run 計画:
 - 既存登録確認: claude mcp list
+- copilot-review:
+  - 既存登録があれば削除: claude mcp remove --scope user copilot-review
+  - 追加: claude mcp add --transport http --scope user copilot-review http://127.0.0.1:8080/mcp/copilot-review
 - github:
+  - 既存登録があれば削除: claude mcp remove --scope user github
   - 追加: claude mcp add --transport http --scope user github http://127.0.0.1:8080/mcp/github
-...
+- playwright:
+  - 既存登録があれば削除: claude mcp remove --scope user playwright
+  - 追加: claude mcp add --transport http --scope user playwright http://127.0.0.1:8080/mcp/playwright
 copilot の dry-run 計画:
 ...
 codex の dry-run 計画:
@@ -166,7 +172,7 @@ codex mcp list
 
 **確認ポイント:**
 - [ ] claude・copilot・codex すべてにエラーなく登録される
-- [ ] 重複登録しても正常終了する（べき等性）
+- [ ] 重複登録しても正常終了する（冪等性）
 
 ---
 
@@ -207,5 +213,5 @@ servers:
 - [ ] ステップ 2: Claude Code に登録・接続確認
 - [ ] ステップ 3: Copilot CLI に登録確認
 - [ ] ステップ 4: Codex に登録確認（任意）
-- [ ] ステップ 5: 全エージェント一括登録・べき等性確認
+- [ ] ステップ 5: 全エージェント一括登録・冪等性確認
 - [ ] ステップ 6: external サーバー追加確認（任意）

--- a/docs/e2e-runbook-mcp-docker-cli.md
+++ b/docs/e2e-runbook-mcp-docker-cli.md
@@ -1,0 +1,211 @@
+# mcp-docker CLI E2E テストランブック
+
+`mcp-docker register` コマンドが各 IDE CLI の MCP 設定ファイルに正しく書き込まれることを手動で確認する手順書。
+
+---
+
+## 前提条件
+
+| 項目 | 確認コマンド |
+|------|------------|
+| `mcp-docker` バイナリ（ビルド済み） | `./mcp-docker --help` |
+| Docker Compose スタック起動済み | `make status` |
+| 確認したい IDE CLI のインストール | 各セクション参照 |
+
+---
+
+## ステップ 0: バイナリビルド
+
+```bash
+# リポジトリルートで実行
+go build -o mcp-docker ./cmd/mcp-docker
+
+# ヘルプ確認
+./mcp-docker --help
+```
+
+**期待出力:**
+```
+mcp-docker は MCP Docker の補助ワークフローを管理します。
+
+使い方:
+  mcp-docker register [--agent claude|copilot|codex|all] [--compose path] [--external path] [--yes] [--dry-run]
+```
+
+---
+
+## ステップ 1: dry-run で登録計画を確認
+
+```bash
+./mcp-docker register --dry-run --yes
+```
+
+**期待出力例（サーバーが 3 件の場合）:**
+```
+claude の dry-run 計画:
+- 既存登録確認: claude mcp list
+- github:
+  - 追加: claude mcp add --transport http --scope user github http://127.0.0.1:8080/mcp/github
+...
+copilot の dry-run 計画:
+...
+codex の dry-run 計画:
+...
+```
+
+**確認ポイント:**
+- [ ] 各エージェントの計画が出力される
+- [ ] `--compose docker-compose.yml` からサーバー一覧が正しく読み込まれる
+- [ ] URL が `http://127.0.0.1:8080/mcp/<name>` 形式になっている
+
+---
+
+## ステップ 2: Claude Code への登録確認
+
+> **前提:** `claude` CLI がインストールされていること (`claude --version`)
+
+### 2-1. 登録前の状態確認
+
+```bash
+claude mcp list
+```
+
+**記録:** 登録前のサーバー一覧をメモしておく。
+
+### 2-2. 登録実行
+
+```bash
+./mcp-docker register --agent claude --yes
+```
+
+**期待動作:**
+- 既存の同名サーバーがあれば削除してから追加
+- エラーなく完了する
+
+### 2-3. 登録後の確認
+
+```bash
+claude mcp list
+```
+
+**確認ポイント:**
+- [ ] `github`、`copilot-review`、`playwright` が一覧に表示される
+- [ ] `transport: http` で登録されている
+
+### 2-4. Claude Code で実際に MCP 接続確認
+
+```
+Claude Code を起動 → /mcp または Tools メニューで MCP サーバー一覧を確認
+```
+
+**確認ポイント:**
+- [ ] `github` サーバーが緑（接続済み）で表示される
+- [ ] `copilot-review` サーバーが緑で表示される
+
+---
+
+## ステップ 3: GitHub Copilot CLI への登録確認
+
+> **前提:** `gh` CLI + `gh copilot` 拡張がインストールされていること
+
+### 3-1. 登録前の状態確認
+
+```bash
+gh copilot -- mcp list
+```
+
+### 3-2. 登録実行
+
+```bash
+./mcp-docker register --agent copilot --yes
+```
+
+### 3-3. 登録後の確認
+
+```bash
+gh copilot -- mcp list
+```
+
+**確認ポイント:**
+- [ ] `github`、`copilot-review`、`playwright` が一覧に表示される
+
+---
+
+## ステップ 4: Codex への登録確認
+
+> **前提:** `codex` CLI がインストールされていること (`codex --version`)
+
+### 4-1. 登録前の状態確認
+
+```bash
+codex mcp list
+```
+
+### 4-2. 登録実行
+
+```bash
+./mcp-docker register --agent codex --yes
+```
+
+### 4-3. 登録後の確認
+
+```bash
+codex mcp list
+```
+
+**確認ポイント:**
+- [ ] `github`、`copilot-review`、`playwright` が一覧に表示される
+
+---
+
+## ステップ 5: 全エージェントまとめて登録
+
+```bash
+./mcp-docker register --yes
+```
+
+**確認ポイント:**
+- [ ] claude・copilot・codex すべてにエラーなく登録される
+- [ ] 重複登録しても正常終了する（べき等性）
+
+---
+
+## ステップ 6: external サーバーの追加確認
+
+`config/mcp-external.yml` にサーバーを追記して動作確認する。
+
+```yaml
+# config/mcp-external.yml 追記例
+servers:
+  - name: my-custom-server
+    url: http://127.0.0.1:9090/mcp
+```
+
+```bash
+./mcp-docker register --dry-run --yes
+```
+
+**確認ポイント:**
+- [ ] `my-custom-server` が dry-run 計画に含まれる
+
+---
+
+## エラーケース確認
+
+| シナリオ | 実行コマンド | 期待動作 |
+|---------|------------|---------|
+| docker-compose.yml が存在しない | `./mcp-docker register --compose missing.yml --yes` | エラーで終了 |
+| 不明なエージェント | `./mcp-docker register --agent unknown --yes` | エラーで終了 |
+| サーバー名の重複 | docker-compose と external に同名サーバーを設定 | エラーで終了 |
+
+---
+
+## チェックリスト（最終確認）
+
+- [ ] ステップ 0: バイナリビルド成功
+- [ ] ステップ 1: dry-run 出力が正しい
+- [ ] ステップ 2: Claude Code に登録・接続確認
+- [ ] ステップ 3: Copilot CLI に登録確認
+- [ ] ステップ 4: Codex に登録確認（任意）
+- [ ] ステップ 5: 全エージェント一括登録・べき等性確認
+- [ ] ステップ 6: external サーバー追加確認（任意）


### PR DESCRIPTION
## 概要
Go CLI (mcp-docker) のバイナリ配布を行うための release workflow と CHANGELOG 更新。

## 変更内容

### 追加
- \.github/workflows/release.yml\: タグ \*\ push 時に自動クロスコンパイル＆リリース作成
  - 対象プラットフォーム: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
  - 各バイナリの SHA256 チェックサムファイルを生成・添付
  - \checksums.txt\ に全バイナリのチェックサムを統合

### 更新
- \CHANGELOG.md\: Unreleased → v2.6.0 (2026-04-30) に移動
  - \mcp-docker\ Go CLI (#117) を主要新機能として追記
  - CI \go vet\ 追加 (#122) を追記

### レビュー後追加（スコープ外・次 PR への繰り延べ検討後に本 PR に含めた変更）

> Copilot レビュー完了後に追加したため、当初スコープ外の変更です。

- \docs/e2e-runbook-mcp-docker-cli.md\: \mcp-docker register\ の E2E 手動確認手順書
  - 各 IDE CLI（Claude Code / Copilot CLI / Codex）への登録・接続確認ステップを記載
- \codecov.yml\: カバレッジ閾値設定（patch 70%、project auto）
- \.github/workflows/lint-test.yml\: \	est-go\ ジョブにカバレッジ計測（\-coverprofile\）と \codecov/codecov-action@v5\ アップロードを追加

## テスト結果
\go build ./cmd/mcp-docker\ + \--dry-run --yes\ で正常動作確認済み
\go test -coverprofile=coverage.out -covermode=atomic ./...\ 全パス（カバレッジ: compose 71.7%、register 69.2%）