### PR TITLE
ci: リリース配布物を tar.gz/zip アーカイブに変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,22 +57,24 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: バイナリビルド
+      - name: バイナリビルド＆アーカイブ
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '0'
         run: |
-          BIN="mcp-docker-${{ matrix.suffix }}${{ matrix.ext }}"
+          BIN="mcp-docker${{ matrix.ext }}"
           go build -trimpath -ldflags="-s -w" -o "${BIN}" ./cmd/mcp-docker
-          sha256sum "${BIN}" > "${BIN}.sha256"
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            zip "mcp-docker-${{ matrix.suffix }}.zip" "${BIN}"
+          else
+            tar czf "mcp-docker-${{ matrix.suffix }}.tar.gz" "${BIN}"
+          fi
 
       - uses: actions/upload-artifact@v4
         with:
           name: bin-${{ matrix.suffix }}
-          path: |
-            mcp-docker-${{ matrix.suffix }}${{ matrix.ext }}
-            mcp-docker-${{ matrix.suffix }}${{ matrix.ext }}.sha256
+          path: mcp-docker-${{ matrix.suffix }}.*
 
   release:
     name: リリース作成
@@ -86,16 +88,18 @@ jobs:
           path: dist/
           merge-multiple: true
 
-      - name: チェックサムファイル統合
+      - name: チェックサムファイル生成
         run: |
-          cat dist/*.sha256 | sort > dist/checksums.txt
+          cd dist
+          sha256sum mcp-docker-*.tar.gz mcp-docker-*.zip 2>/dev/null | sort > checksums.txt
 
       - name: GitHub Release 作成
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          ARCHIVES=$(find dist \( -name "mcp-docker-*.tar.gz" -o -name "mcp-docker-*.zip" \) | sort | tr '\n' ' ')
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --generate-notes \
-            dist/mcp-docker-* \
+            ${ARCHIVES} \
             dist/checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.1] - 2026-04-30
+
+### 🐛 バグ修正・改善
+
+- リリース配布物を生バイナリからアーカイブ形式に変更（#124）
+  - Linux / macOS: `.tar.gz`
+  - Windows: `.zip`
+  - `checksums.txt` をアーカイブファイルの SHA256 に統一
+
 ## [2.6.0] - 2026-04-30
 
 ### ✨ 新機能
@@ -308,7 +317,8 @@ v1.x からの移行:
 ### Fixed
 - Initial bug fixes
 
-[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.6.1...HEAD
+[2.6.1]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.3.0...v2.4.0


### PR DESCRIPTION
## 変更内容

リリース配布物を生バイナリから圧縮アーカイブに変更します。

### 変更後の配布形式
| プラットフォーム | ファイル |
|----------------|---------|
| Linux (amd64) | \mcp-docker-linux-amd64.tar.gz\ |
| Linux (arm64) | \mcp-docker-linux-arm64.tar.gz\ |
| macOS (Intel) | \mcp-docker-darwin-amd64.tar.gz\ |
| macOS (Apple Silicon) | \mcp-docker-darwin-arm64.tar.gz\ |
| Windows (amd64) | \mcp-docker-windows-amd64.zip\ |
| チェックサム | \checksums.txt\ |

### 変更前
生バイナリ（\mcp-docker-linux-amd64\ 等）と個別 \.sha256\ ファイルを配布

### 理由
CLI ツールの配布慣例に合わせ、アーカイブ形式に統一。\checksums.txt\ にアーカイブの SHA256 を記載。