### PR TITLE
chore: mcp-gateway-init コンテナを削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,25 +43,11 @@ services:
           cpus: "0.5"
           memory: 256M
 
-  # mcp-gateway-data ボリュームを nonroot (UID=65532) 所有に初期化する。
-  # 空ボリュームは Docker がルート所有で作成するため、起動前に一度だけ chown する。
-  mcp-gateway-init:
-    image: alpine:3
-    container_name: mcp-gateway-init
-    restart: "no"
-    user: root
-    command: ["chown", "-R", "65532:65532", "/data"]
-    network_mode: none
-    volumes:
-      - mcp-gateway-data:/data
-
   mcp-gateway:
     image: ${GITHUB_MCP_GATEWAY_IMAGE:-ghcr.io/scottlz0310/mcp-gateway:latest}
     container_name: mcp-gateway
     restart: unless-stopped
     depends_on:
-      mcp-gateway-init:
-        condition: service_completed_successfully
       github-mcp:
         condition: service_started
       copilot-review-mcp:


### PR DESCRIPTION
## 概要

`mcp-gateway` イメージの Dockerfile が `/data` ディレクトリを nonroot (UID=65532) 所有で作成するようになったため（scottlz0310/mcp-gateway#28）、起動前に `chown` を行う init コンテナが不要になりました。

## 変更内容

- `docker-compose.yml` から `mcp-gateway-init` サービス定義を削除
- `mcp-gateway` の `depends_on` から `mcp-gateway-init` エントリを削除

## 背景

従来は Docker が名前付きボリュームをルート所有の空ディレクトリとして作成するため、`alpine:3` ベースの init コンテナで `chown -R 65532:65532 /data` を実行していました。この init コンテナは正常終了後も停止コンテナとして残骸が残り、Docker Desktop の UI に表示されてしまう問題がありました。

`mcp-gateway` イメージ側で Dockerfile に `RUN mkdir -p /data && chown 65532:65532 /data` が追加されたことで、Docker の初回ボリュームマウント時の自動コピー機能により ownership が正しく設定されます（`copilot-review-mcp` と同一のアプローチ）。

## 注意事項

既存の `mcp-gateway-data` ボリュームが root 所有になっている環境では、以下の手順で移行してください：

```bash
docker compose down
docker volume rm mcp-docker_mcp-gateway-data
make start-gateway
```
