### PR TITLE
feat: add pull-main / start-main / restart-main targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,10 @@ status: status-gateway ## 全サービスの状態確認（status-gateway のエ
 # :main イメージ（リリース前の最新開発版）
 # mcp-gateway / copilot-review-mcp は :latest がリリース時のみ更新されるため、
 # 最新の main ブランチビルドを使いたい場合はこれらのターゲットを使用する。
-MCP_GATEWAY_MAIN_IMAGE       := ghcr.io/scottlz0310/mcp-gateway:main
-COPILOT_REVIEW_MCP_MAIN_IMAGE := ghcr.io/scottlz0310/copilot-review-mcp:main
+# ?= により環境変数・make コマンドライン引数での上書きが可能
+# 例: make pull-main MCP_GATEWAY_MAIN_IMAGE=ghcr.io/scottlz0310/mcp-gateway:edge
+MCP_GATEWAY_MAIN_IMAGE       ?= ghcr.io/scottlz0310/mcp-gateway:main
+COPILOT_REVIEW_MCP_MAIN_IMAGE ?= ghcr.io/scottlz0310/copilot-review-mcp:main
 
 .PHONY: pull-main
 pull-main: ## 最新開発版イメージを取得（リリース前 main ブランチビルド）
@@ -132,7 +134,7 @@ start-main: ## 最新開発版イメージで全サービスを起動
 	@echo "Started mcp-gateway endpoint (main build): http://127.0.0.1:$(or $(MCP_GATEWAY_PORT),8080)"
 
 .PHONY: restart-main
-restart-main: stop start-main ## 最新開発版イメージで全サービスを再起動
+restart-main: stop-gateway start-main ## 最新開発版イメージで全サービスを再起動
 
 # ----------------------------------------
 # 設定生成（フォールバック / Legacy）

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,32 @@ pull: pull-gateway ## 全サービスの Docker イメージを取得（pull-gat
 .PHONY: status
 status: status-gateway ## 全サービスの状態確認（status-gateway のエイリアス）
 
+# :main イメージ（リリース前の最新開発版）
+# mcp-gateway / copilot-review-mcp は :latest がリリース時のみ更新されるため、
+# 最新の main ブランチビルドを使いたい場合はこれらのターゲットを使用する。
+MCP_GATEWAY_MAIN_IMAGE       := ghcr.io/scottlz0310/mcp-gateway:main
+COPILOT_REVIEW_MCP_MAIN_IMAGE := ghcr.io/scottlz0310/copilot-review-mcp:main
+
+.PHONY: pull-main
+pull-main: ## 最新開発版イメージを取得（リリース前 main ブランチビルド）
+	docker compose pull github-mcp
+	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
+	COPILOT_REVIEW_MCP_IMAGE=$(COPILOT_REVIEW_MCP_MAIN_IMAGE) \
+	docker compose pull mcp-gateway copilot-review-mcp
+	@echo "✓ :main イメージを取得しました。起動: make start-main"
+
+.PHONY: start-main
+start-main: ## 最新開発版イメージで全サービスを起動
+	$(if $(and $(GITHUB_MCP_CLIENT_ID),$(GITHUB_MCP_CLIENT_SECRET)),,$(error ERROR: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET must be set in .env or environment))
+	$(if $(and $(GITHUB_CLIENT_ID),$(GITHUB_CLIENT_SECRET)),,$(error ERROR: GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET must be set in .env or environment (required by copilot-review-mcp)))
+	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
+	COPILOT_REVIEW_MCP_IMAGE=$(COPILOT_REVIEW_MCP_MAIN_IMAGE) \
+	docker compose up -d github-mcp copilot-review-mcp mcp-gateway playwright-mcp
+	@echo "Started mcp-gateway endpoint (main build): http://127.0.0.1:$(or $(MCP_GATEWAY_PORT),8080)"
+
+.PHONY: restart-main
+restart-main: stop start-main ## 最新開発版イメージで全サービスを再起動
+
 # ----------------------------------------
 # 設定生成（フォールバック / Legacy）
 # CLI 登録（mcp-docker register）が推奨だが、設定ファイル方式が必要な場合のフォールバック。


### PR DESCRIPTION
## 概要

リリースを待たずに `mcp-gateway` / `copilot-review-mcp` の `:main` ブランチビルドを取得・起動できる Make ターゲットを追加。

### 背景

現状の `make pull` は `:latest` タグを取得するが、`mcp-gateway` と `copilot-review-mcp` の `:latest` はリリース時のみ更新される。  
`github-mcp-server` は既に `:main` タグを使用しているため、他の 2 サービスも同様に最新の main ビルドを使えるようにしたい。

## 変更内容

| ターゲット | 動作 |
|---|---|
| `make pull-main` | `github-mcp`（既存 `:main`）+ `mcp-gateway:main` + `copilot-review-mcp:main` を pull |
| `make start-main` | `:main` イメージで全サービスを起動 |
| `make restart-main` | 停止 → `:main` イメージで再起動 |

イメージ名は `MCP_GATEWAY_MAIN_IMAGE` / `COPILOT_REVIEW_MCP_MAIN_IMAGE` 変数で一元管理。

## 使い方

```bash
# main ブランチの最新ビルドを取得して起動
make pull-main
make start-main

# または一発で再起動
make restart-main
```