### PR TITLE
[codex] Align gateway E2E compose settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       - GITHUB_MCP_CLIENT_SECRET=${GITHUB_MCP_CLIENT_SECRET}
       - MCP_GATEWAY_BASE_URL=${MCP_GATEWAY_BASE_URL:-http://localhost:8080}
       - MCP_GATEWAY_PORT=${MCP_GATEWAY_PORT:-8080}
+      - MCP_GATEWAY_KEY_PATH=${MCP_GATEWAY_KEY_PATH:-/data/gateway.key}
+      - MCP_CONFIG_FILE=${MCP_CONFIG_FILE:-/data/config.yaml}
       - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}
       - ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:${COPILOT_REVIEW_MCP_PORT:-8083}
       - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
@@ -109,6 +111,7 @@ services:
     user: "65532:65532"
 
     environment:
+      - AUTH_MODE=${COPILOT_REVIEW_AUTH_MODE:-gateway}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
       - BASE_URL=${BASE_URL:-http://localhost:8083}


### PR DESCRIPTION
## Summary
- Set `MCP_GATEWAY_KEY_PATH` and `MCP_CONFIG_FILE` to persist gateway encryption/config state under `/data`.
- Run `copilot-review-mcp` in `AUTH_MODE=gateway` by default so it trusts the gateway-injected identity during routed operation.

## Why
The v0.1.0 E2E runbook depends on persisted gateway key/config files and validates the gateway-mode integration with `copilot-review-mcp`. The local Compose stack was already persisting token state but not gateway key/config paths, and it still launched copilot-review in standalone OAuth mode.

## Validation
- `docker compose config --quiet`
- `git diff --check`
- Used during local E2E verification after recreating `mcp-gateway` and `copilot-review-mcp`.