### PR TITLE
[codex] chore: prepare v2.7.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,8 @@ jobs:
           CGO_ENABLED: '0'
         run: |
           BIN="mcp-docker${{ matrix.ext }}"
-          go build -trimpath -ldflags="-s -w" -o "${BIN}" ./cmd/mcp-docker
+          VERSION="${GITHUB_REF_NAME#v}"
+          go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o "${BIN}" ./cmd/mcp-docker
           if [ "${{ matrix.goos }}" = "windows" ]; then
             zip "mcp-docker-${{ matrix.suffix }}.zip" "${BIN}"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `pull-main` / `start-main` / `restart-main` ターゲットを追加（#126）
   - `mcp-gateway` / `copilot-review-mcp` の `:main` イメージでリリース前の安定確認が可能
-- `mcp-docker version` / `mcp-docker --version` を追加
+- `mcp-docker version` / `mcp-docker --version` / `mcp-docker -v` を追加
   - リリースバイナリではタグ名から内部バージョンを埋め込み
 
 ### 🔧 改善

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `MCP_GATEWAY_PUBLIC_URL` が IDE 設定生成に反映され、`MCP_GATEWAY_BASE_URL` より優先されることを BATS で検証
 - `mcp-docker --version` の Go テストを追加
+- `cmd/mcp-docker/main.go` を Codecov 対象に戻し、CLI 実装コードのカバレッジを可視化
 
 ### 📦 依存関係更新
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-05-07
+
+### ✨ 新機能
+
+- `pull-main` / `start-main` / `restart-main` ターゲットを追加（#126）
+  - `mcp-gateway` / `copilot-review-mcp` の `:main` イメージでリリース前の安定確認が可能
+- `mcp-docker version` / `mcp-docker --version` を追加
+  - リリースバイナリではタグ名から内部バージョンを埋め込み
+
+### 🔧 改善
+
+- `mcp-gateway v0.3.0` / `copilot-review-mcp v3.0.0` の起動・設定変更に対応（#130）
+  - OAuth 管理を `mcp-gateway` 側へ一元化した構成に整理
+  - `MCP_GATEWAY_PUBLIC_URL` / `MCP_GATEWAY_BIND_ADDR` / `MCP_GATEWAY_KEY_PATH` / `MCP_CONFIG_FILE` を compose 設定に追加
+  - `MCP_GATEWAY_BASE_URL` は後方互換エイリアスとして維持
+- `localhost` 表記を `127.0.0.1` に統一し、OAuth callback URL と IDE 設定例の揺れを解消（#128 #129）
+- gateway E2E 確認向けに compose 設定を調整（#127）
+- `generate-ide-config.sh` / `health-check.sh` / README を `MCP_GATEWAY_PUBLIC_URL` 優先の説明に更新
+- README に Makefile を使わず Go ツールチェーンから `mcp-docker` CLI をビルド・実行する手順を追加
+
+### 🗑️ 削除
+
+- `mcp-gateway-init` コンテナを削除（#125）
+  - 現行の `mcp-gateway` イメージでトークンストア用ボリューム初期化を外部 init コンテナに依存しない構成へ移行
+
+### 🧪 テスト
+
+- `MCP_GATEWAY_PUBLIC_URL` が IDE 設定生成に反映され、`MCP_GATEWAY_BASE_URL` より優先されることを BATS で検証
+- `mcp-docker --version` の Go テストを追加
+
+### 📦 依存関係更新
+
+- Go module directive を `1.26.2` に更新（#131）
+
 ## [2.6.1] - 2026-04-30
 
 ### 🐛 バグ修正・改善
@@ -317,7 +351,8 @@ v1.x からの移行:
 ### Fixed
 - Initial bug fixes
 
-[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.6.1...HEAD
+[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.6.1...v2.7.0
 [2.6.1]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.4.0...v2.5.0

--- a/Makefile
+++ b/Makefile
@@ -146,10 +146,12 @@ BIN_DIR      := bin
 MCP_DOCKER   := $(BIN_DIR)/mcp-docker
 GO_SOURCES   := $(shell find cmd internal -name '*.go' 2>/dev/null)
 REGISTER_FLAGS ?=
+VERSION ?= 2.7.0
+GO_LDFLAGS ?= -X main.version=$(VERSION)
 
 $(MCP_DOCKER): go.mod go.sum $(GO_SOURCES)
 	"$(SHELL)" -c "mkdir -p $(BIN_DIR)"
-	go build -o $(MCP_DOCKER) ./cmd/mcp-docker
+	go build -ldflags "$(GO_LDFLAGS)" -o $(MCP_DOCKER) ./cmd/mcp-docker
 
 .PHONY: register-claude
 register-claude: $(MCP_DOCKER) ## Claude CLI に MCP サーバーを登録

--- a/README.md
+++ b/README.md
@@ -129,6 +129,32 @@ make register-codex    REGISTER_FLAGS=--yes
 make register-all      REGISTER_FLAGS=--yes
 ```
 
+Makefile を使わず Go ツールチェーンから直接ビルド・実行する場合：
+
+```bash
+# ビルド
+go build -trimpath -ldflags="-X main.version=2.7.0" -o ./bin/mcp-docker ./cmd/mcp-docker
+
+# バージョン確認
+./bin/mcp-docker --version
+
+# 登録計画の確認
+./bin/mcp-docker register --dry-run --yes
+
+# 登録実行
+./bin/mcp-docker register --agent all --yes
+```
+
+Windows のネイティブシェルで実行する場合は、出力先を `.\bin\mcp-docker.exe` にしてください。
+
+ビルド済みバイナリを残したくない場合は `go run` でも同じ登録フローを実行できます：
+
+```bash
+go run ./cmd/mcp-docker --version
+go run ./cmd/mcp-docker register --dry-run --yes
+go run ./cmd/mcp-docker register --agent all --yes
+```
+
 登録対象は以下から読み取ります：
 
 - `docker-compose.yml` の `mcp-gateway.environment.ROUTE_*`
@@ -205,6 +231,9 @@ Claude Desktop は HTTP transport 非対応のため、`docker run -i --rm ... s
 | `make status` / `make status-gateway` | 全コンテナ状態一覧 |
 | `make logs` / `make logs-gateway` | mcp-gateway ログ表示 |
 | `make pull` / `make pull-gateway` | 全イメージ更新 |
+| `make pull-main` | mcp-gateway / copilot-review-mcp の `:main` イメージ取得 |
+| `make start-main` | 最新開発版イメージで全サービス起動 |
+| `make restart-main` | 最新開発版イメージで全サービス再起動 |
 | `make gen-config` | IDE 設定生成（`IDE=vscode` 等を指定） |
 | `make register-claude` | Claude CLI に MCP サーバーを登録 |
 | `make register-copilot` | GitHub Copilot CLI に MCP サーバーを登録 |
@@ -358,14 +387,12 @@ Mcp-Docker/
 │   └── generate-ide-config.sh  # IDE 設定生成
 ├── docs/
 │   ├── SECURITY_PATCHES.md     # セキュリティ対応履歴
-│   └── copilot-review-mcp-tasks.md  # copilot-review-mcp 固有タスク
+│   ├── e2e-runbook-mcp-docker-cli.md  # CLI E2E 確認手順
+│   ├── plan-mcp-register-go.md # mcp-docker register 実装計画
+│   └── skills/                 # Codex / LLM 向け運用スキル
 ├── tests/
 │   └── shell/                  # BATS シェルテスト
-└── services/
-    └── copilot-review-mcp/     # ※ 将来削除予定（外部リポジトリへ移行済み）
 ```
-
-`services/copilot-review-mcp/` は外部リポジトリ（`scottlz0310/copilot-review-mcp`）への移行に伴い、将来のリリースで削除される予定です。
 
 ## セキュリティ
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,15 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Security updates are provided for the latest minor release line.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| 2.7.x   | :white_check_mark: |
+| < 2.7   | :x:                |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please report vulnerabilities privately through GitHub Security Advisories for this repository.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Do not include credentials, tokens, or `.env` contents in public issues. Include the affected version, relevant service image tags, reproduction steps, and whether the issue affects `mcp-gateway`, `copilot-review-mcp`, or this Docker integration repository.

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -21,6 +21,7 @@ const usage = `mcp-docker は MCP Docker の補助ワークフローを管理し
   mcp-docker register [--agent claude|copilot|codex|all] [--compose path] [--external path] [--yes] [--dry-run]
   mcp-docker version
   mcp-docker --version
+  mcp-docker -v
 `
 
 var version = "2.7.0"

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -19,7 +19,11 @@ const usage = `mcp-docker は MCP Docker の補助ワークフローを管理し
 
 使い方:
   mcp-docker register [--agent claude|copilot|codex|all] [--compose path] [--external path] [--yes] [--dry-run]
+  mcp-docker version
+  mcp-docker --version
 `
+
+var version = "2.7.0"
 
 func main() {
 	if err := run(context.Background(), os.Args[1:], os.Stdout, os.Stderr, os.Stdin); err != nil {
@@ -37,6 +41,9 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer, stdin io.
 	switch args[0] {
 	case "register":
 		return runRegister(ctx, args[1:], stdout, stderr, stdin)
+	case "version", "-v", "--version":
+		fmt.Fprintf(stdout, "mcp-docker %s\n", version)
+		return nil
 	case "help", "-h", "--help":
 		fmt.Fprint(stdout, usage)
 		return nil

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -1,11 +1,27 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/scottlz0310/mcp-docker/tools/internal/register"
 )
+
+func TestVersionCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"--version"}, &stdout, &stderr, strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if got, want := stdout.String(), "mcp-docker 2.7.0\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
 
 func TestValidateUniqueServersReportsCollidingSources(t *testing.T) {
 	err := validateUniqueServers([]register.Server{

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -15,7 +15,7 @@ func TestVersionCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run returned error: %v", err)
 	}
-	if got, want := stdout.String(), "mcp-docker 2.7.0\n"; got != want {
+	if got, want := stdout.String(), "mcp-docker "+version+"\n"; got != want {
 		t.Fatalf("stdout = %q, want %q", got, want)
 	}
 	if stderr.Len() != 0 {

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,3 @@ comment:
   layout: reach,diff,flags,files
   behavior: default
   require_changes: false
-
-ignore:
-  - "cmd/mcp-docker/main.go"

--- a/docs/e2e-runbook-mcp-docker-cli.md
+++ b/docs/e2e-runbook-mcp-docker-cli.md
@@ -8,7 +8,7 @@
 
 | 項目 | 確認コマンド |
 |------|------------|
-| `mcp-docker` バイナリ（ビルド済み） | `./mcp-docker --help` |
+| `mcp-docker` バイナリ（ビルド済み） | `./bin/mcp-docker --version` |
 | Docker Compose スタック起動済み | `make status` |
 | 確認したい IDE CLI のインストール | 各セクション参照 |
 
@@ -18,18 +18,28 @@
 
 ```bash
 # リポジトリルートで実行
-go build -o mcp-docker ./cmd/mcp-docker
+go build -trimpath -ldflags="-X main.version=2.7.0" -o ./bin/mcp-docker ./cmd/mcp-docker
+
+# バージョン確認
+./bin/mcp-docker --version
 
 # ヘルプ確認
-./mcp-docker --help
+./bin/mcp-docker --help
 ```
 
-**期待出力:**
+**期待出力（バージョン）:**
+```
+mcp-docker 2.7.0
+```
+
+**期待出力（ヘルプ）:**
 ```
 mcp-docker は MCP Docker の補助ワークフローを管理します。
 
 使い方:
   mcp-docker register [--agent claude|copilot|codex|all] [--compose path] [--external path] [--yes] [--dry-run]
+  mcp-docker version
+  mcp-docker --version
 ```
 
 ---
@@ -37,7 +47,7 @@ mcp-docker は MCP Docker の補助ワークフローを管理します。
 ## ステップ 1: dry-run で登録計画を確認
 
 ```bash
-./mcp-docker register --dry-run --yes
+./bin/mcp-docker register --dry-run --yes
 ```
 
 **期待出力例（サーバーが 3 件の場合）:**
@@ -81,7 +91,7 @@ claude mcp list
 ### 2-2. 登録実行
 
 ```bash
-./mcp-docker register --agent claude --yes
+./bin/mcp-docker register --agent claude --yes
 ```
 
 **期待動作:**
@@ -123,7 +133,7 @@ gh copilot -- mcp list
 ### 3-2. 登録実行
 
 ```bash
-./mcp-docker register --agent copilot --yes
+./bin/mcp-docker register --agent copilot --yes
 ```
 
 ### 3-3. 登録後の確認
@@ -150,7 +160,7 @@ codex mcp list
 ### 4-2. 登録実行
 
 ```bash
-./mcp-docker register --agent codex --yes
+./bin/mcp-docker register --agent codex --yes
 ```
 
 ### 4-3. 登録後の確認
@@ -167,7 +177,7 @@ codex mcp list
 ## ステップ 5: 全エージェントまとめて登録
 
 ```bash
-./mcp-docker register --yes
+./bin/mcp-docker register --yes
 ```
 
 **確認ポイント:**
@@ -188,7 +198,7 @@ servers:
 ```
 
 ```bash
-./mcp-docker register --dry-run --yes
+./bin/mcp-docker register --dry-run --yes
 ```
 
 **確認ポイント:**
@@ -200,8 +210,8 @@ servers:
 
 | シナリオ | 実行コマンド | 期待動作 |
 |---------|------------|---------|
-| docker-compose.yml が存在しない | `./mcp-docker register --compose missing.yml --yes` | エラーで終了 |
-| 不明なエージェント | `./mcp-docker register --agent unknown --yes` | エラーで終了 |
+| docker-compose.yml が存在しない | `./bin/mcp-docker register --compose missing.yml --yes` | エラーで終了 |
+| 不明なエージェント | `./bin/mcp-docker register --agent unknown --yes` | エラーで終了 |
 | サーバー名の重複 | docker-compose と external に同名サーバーを設定 | エラーで終了 |
 
 ---

--- a/docs/e2e-runbook-mcp-docker-cli.md
+++ b/docs/e2e-runbook-mcp-docker-cli.md
@@ -40,6 +40,7 @@ mcp-docker は MCP Docker の補助ワークフローを管理します。
   mcp-docker register [--agent claude|copilot|codex|all] [--compose path] [--external path] [--yes] [--dry-run]
   mcp-docker version
   mcp-docker --version
+  mcp-docker -v
 ```
 
 ---

--- a/docs/skills/pr-review-cycle.md
+++ b/docs/skills/pr-review-cycle.md
@@ -21,7 +21,7 @@ PR レビュー対応サイクルを自律実行するスキル。
 
 | サーバー | 役割 | 参照 |
 |---------|------|------|
-| `copilot-review-mcp` | Copilot レビュー watch・スレッド操作 | [services/copilot-review-mcp](../../services/copilot-review-mcp/) |
+| `copilot-review-mcp` | Copilot レビュー watch・スレッド操作 | [copilot-review-mcp](https://github.com/scottlz0310/copilot-review-mcp) |
 | GitHub MCP サーバー | Issue/PR コメント投稿 | [README.md](../../README.md) |
 
 ### プレースホルダーの読み替え


### PR DESCRIPTION
## Summary

- Prepare the repository for the v2.7.0 release.
- Add direct Go toolchain build/run instructions for the `mcp-docker` CLI in README and the E2E runbook.
- Add `mcp-docker version` / `mcp-docker --version`, set the internal version to `2.7.0`, and embed the tag-derived version in release artifacts.
- Update CHANGELOG, SECURITY supported versions, README Make targets/directory tree, and the shared review-cycle doc link.

## Why

The sibling repositories `mcp-gateway` and `copilot-review-mcp` are now considered stable, so this repo should cut a minor release that captures the gateway compatibility updates, main-image validation targets, and release documentation cleanup.

## Impact

Users can build and run the CLI without Make via `go build` or `go run`, and release binaries will report a version that matches the Git tag. The release notes now describe the non-dependency changes since v2.6.1.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build -trimpath -ldflags="-X main.version=2.7.0" -o .\\bin\\mcp-docker.exe .\\cmd\\mcp-docker`
- `.\\bin\\mcp-docker.exe --version`
- `.\\bin\\mcp-docker.exe --help`
- `make build-go`
- `.\\bin\\mcp-docker --version`
- `git diff --check`

Shell checks were attempted but the local environment is missing their tools:

- `make test-shell` could not run because `bats` is not installed.
- `bash scripts/lint-shell.sh` could not run because `shellcheck` is not installed.