### PR TITLE
[codex] Fix Windows mcp-docker.exe make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,11 @@ gen-config: ## [Legacy] IDE設定ファイルを生成 (IDE=vscode|claude-deskto
 
 # CLI 登録（Primary）
 BIN_DIR      := bin
-MCP_DOCKER   := $(BIN_DIR)/mcp-docker
+EXE_EXT      :=
+ifeq ($(OS),Windows_NT)
+  EXE_EXT    := .exe
+endif
+MCP_DOCKER   := $(BIN_DIR)/mcp-docker$(EXE_EXT)
 GO_SOURCES   := $(shell find cmd internal -name '*.go' 2>/dev/null)
 REGISTER_FLAGS ?=
 VERSION ?= 2.7.0

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ CLI 登録に対応しているエージェント（Claude CLI / GitHub Copilot 
 
 ```bash
 # 事前に make start-gateway で mcp-gateway を起動
+make build-go
+
 make register-claude   REGISTER_FLAGS=--yes
 make register-copilot  REGISTER_FLAGS=--yes
 make register-codex    REGISTER_FLAGS=--yes
@@ -129,29 +131,32 @@ make register-codex    REGISTER_FLAGS=--yes
 make register-all      REGISTER_FLAGS=--yes
 ```
 
+Makefile 経由のビルド成果物は OS に合わせて決まります。Windows (`OS=Windows_NT`) では `bin/mcp-docker.exe` を生成し、`register-*` も `.exe` 付きのバイナリを実行します。Linux/macOS では従来通り `bin/mcp-docker` です。
+
 Makefile を使わず Go ツールチェーンから直接ビルド・実行する場合：
 
 ```bash
-# ビルド
+# Linux/macOS/Git Bash
 go build -trimpath -ldflags="-X main.version=2.7.0" -o ./bin/mcp-docker ./cmd/mcp-docker
-
-# バージョン確認
 ./bin/mcp-docker --version
-
-# 登録計画の確認
-./bin/mcp-docker register --dry-run --yes
-
-# 登録実行
+./bin/mcp-docker register --dry-run
 ./bin/mcp-docker register --agent all --yes
 ```
 
-Windows のネイティブシェルで実行する場合は、出力先を `.\bin\mcp-docker.exe` にしてください。
+Windows のネイティブシェルで実行する場合：
+
+```powershell
+go build -trimpath -ldflags="-X main.version=2.7.0" -o .\bin\mcp-docker.exe .\cmd\mcp-docker
+.\bin\mcp-docker.exe --version
+.\bin\mcp-docker.exe register --dry-run
+.\bin\mcp-docker.exe register --agent all --yes
+```
 
 ビルド済みバイナリを残したくない場合は `go run` でも同じ登録フローを実行できます：
 
 ```bash
 go run ./cmd/mcp-docker --version
-go run ./cmd/mcp-docker register --dry-run --yes
+go run ./cmd/mcp-docker register --dry-run
 go run ./cmd/mcp-docker register --agent all --yes
 ```
 

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -78,7 +78,7 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		return errors.New("MCP サーバーが見つかりませんでした")
 	}
 
-	if !opts.yes {
+	if !opts.yes && !opts.dryRun {
 		if err := confirmRouteNames(stdin, stdout, servers); err != nil {
 			return err
 		}

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -3,11 +3,22 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/scottlz0310/mcp-docker/tools/internal/register"
 )
+
+var errUnexpectedStdinRead = errors.New("unexpected stdin read")
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, errUnexpectedStdinRead
+}
 
 func TestVersionCommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
@@ -20,6 +31,41 @@ func TestVersionCommand(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRegisterDryRunDoesNotPromptForRouteNames(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	externalPath := filepath.Join(dir, "mcp-external.yml")
+	if err := os.WriteFile(composePath, []byte(`services:
+  mcp-gateway:
+    environment:
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(externalPath, []byte("servers: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"register",
+		"--dry-run",
+		"--compose", composePath,
+		"--external", externalPath,
+	}, &stdout, &stderr, errorReader{})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	got := stdout.String()
+	if strings.Contains(got, "[Enter to accept") {
+		t.Fatalf("stdout = %q, dry-run should not prompt for route names", got)
+	}
+	if !strings.Contains(got, "claude の dry-run 計画:") {
+		t.Fatalf("stdout = %q, want dry-run plan", got)
 	}
 }
 

--- a/docs/e2e-runbook-mcp-docker-cli.md
+++ b/docs/e2e-runbook-mcp-docker-cli.md
@@ -8,7 +8,7 @@
 
 | 項目 | 確認コマンド |
 |------|------------|
-| `mcp-docker` バイナリ（ビルド済み） | `./bin/mcp-docker --version` |
+| `mcp-docker` バイナリ（ビルド済み） | Linux/macOS: `./bin/mcp-docker --version`<br>Windows: `.\bin\mcp-docker.exe --version` |
 | Docker Compose スタック起動済み | `make status` |
 | 確認したい IDE CLI のインストール | 各セクション参照 |
 
@@ -18,13 +18,47 @@
 
 ```bash
 # リポジトリルートで実行
+make build-go
+```
+
+Makefile 経由では OS に応じて成果物名が変わる。
+
+- Linux/macOS: `./bin/mcp-docker`
+- Windows (`OS=Windows_NT`): `.\bin\mcp-docker.exe`
+
+Makefile を使わず直接ビルドする場合：
+
+```bash
+# Linux/macOS/Git Bash
 go build -trimpath -ldflags="-X main.version=2.7.0" -o ./bin/mcp-docker ./cmd/mcp-docker
+```
 
-# バージョン確認
+```powershell
+# Windows PowerShell/cmd.exe
+go build -trimpath -ldflags="-X main.version=2.7.0" -o .\bin\mcp-docker.exe .\cmd\mcp-docker
+```
+
+Linux/macOS または Git Bash で確認する場合：
+
+```bash
 ./bin/mcp-docker --version
-
-# ヘルプ確認
 ./bin/mcp-docker --help
+```
+
+Windows のネイティブシェルで確認する場合：
+
+```powershell
+.\bin\mcp-docker.exe --version
+.\bin\mcp-docker.exe --help
+```
+
+以降の `./bin/mcp-docker` は Linux/macOS または Git Bash 向けの表記。Windows の PowerShell/cmd.exe では `.\bin\mcp-docker.exe` に読み替える。
+
+Makefile 経由の登録ターゲットを確認する場合：
+
+```powershell
+make register-all REGISTER_FLAGS=--dry-run
+make register-claude REGISTER_FLAGS=--dry-run
 ```
 
 **期待出力（バージョン）:**
@@ -48,7 +82,7 @@ mcp-docker は MCP Docker の補助ワークフローを管理します。
 ## ステップ 1: dry-run で登録計画を確認
 
 ```bash
-./bin/mcp-docker register --dry-run --yes
+./bin/mcp-docker register --dry-run
 ```
 
 **期待出力例（サーバーが 3 件の場合）:**
@@ -199,7 +233,7 @@ servers:
 ```
 
 ```bash
-./bin/mcp-docker register --dry-run --yes
+./bin/mcp-docker register --dry-run
 ```
 
 **確認ポイント:**


### PR DESCRIPTION
## Summary

- Treat `bin/mcp-docker.exe` as the Makefile build artifact on Windows while keeping `bin/mcp-docker` for Linux/macOS.
- Make `register --dry-run` non-interactive so `--yes` is not required to print the plan.
- Update README and the E2E runbook with Windows native shell and Makefile dry-run steps.

## Root Cause

The Makefile always used `bin/mcp-docker` regardless of OS, so Windows users did not get the expected `.exe` artifact. Separately, dry-run still entered the route-name confirmation flow unless `--yes` was passed, which caused `mcp-docker.exe register --dry-run` to wait for input.

## Validation

- `go test ./...`
- `make build-go`
- `.\bin\mcp-docker.exe register --dry-run`
- `make register-all REGISTER_FLAGS=--dry-run`
- `git diff --check`

Fixes #133