### PR TITLE
feat: add interactive register flow with multi-select agent/server (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ 新機能
+
+- `mcp-docker register` を対話モード対応に拡張（#134）
+  - 引数なしかつ TTY 実行時は番号入力 UI で agent / MCP サーバーを複数選択
+  - `--server <csv>|all` を新規追加し、`--agent claude,codex` のようなカンマ区切り指定にも対応
+  - `--interactive` を明示指定したまま非 TTY 環境で起動した場合はエラーで終了
+  - `make register` ターゲットを追加（`register-*` は後方互換のため維持）
+
 ## [2.8.0] - 2026-05-09
 
 ### 🐛 修正

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,10 @@ $(MCP_DOCKER): go.mod go.sum $(GO_SOURCES)
 	"$(SHELL)" -c "mkdir -p $(BIN_DIR)"
 	go build -ldflags "$(GO_LDFLAGS)" -o $(MCP_DOCKER) ./cmd/mcp-docker
 
+.PHONY: register
+register: $(MCP_DOCKER) ## 対話的に IDE/CLI と MCP サーバーを選択して登録
+	$(MCP_DOCKER) register $(REGISTER_FLAGS)
+
 .PHONY: register-claude
 register-claude: $(MCP_DOCKER) ## Claude CLI に MCP サーバーを登録
 	$(MCP_DOCKER) register --agent claude $(REGISTER_FLAGS)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ make register-codex    REGISTER_FLAGS=--yes
 make register-all      REGISTER_FLAGS=--yes
 ```
 
-`make register` は引数なしで `mcp-docker register` を呼び出し、TTY であれば agent と MCP サーバーを番号入力で複数選択できます。`--agent`, `--server`, `--yes`, `--dry-run` のいずれかを `REGISTER_FLAGS` で渡した場合は対話モードに入らず、従来通り非対話で実行します。
+`make register` は引数なしで `mcp-docker register` を呼び出し、TTY であれば agent と MCP サーバーを番号入力で複数選択できます。`--interactive`, `--agent`, `--server`, `--yes`, `--dry-run` のいずれかを `REGISTER_FLAGS` で渡した場合は **暗黙的な対話モードには入らず**、従来通りフラグの内容に従って実行します（`--interactive` 明示時はそのまま対話モードに入ります）。
 
 ```bash
 # 例: claude と codex に github / playwright だけ登録（非対話）

--- a/README.md
+++ b/README.md
@@ -113,12 +113,22 @@ CLI 登録に対応しているエージェント（Claude CLI / GitHub Copilot 
 # 事前に make start-gateway で mcp-gateway を起動
 make build-go
 
+# 対話的に agent / MCP サーバーを選択（TTY 環境）
+make register
+
 make register-claude   REGISTER_FLAGS=--yes
 make register-copilot  REGISTER_FLAGS=--yes
 make register-codex    REGISTER_FLAGS=--yes
 
 # 3 種類まとめて登録
 make register-all      REGISTER_FLAGS=--yes
+```
+
+`make register` は引数なしで `mcp-docker register` を呼び出し、TTY であれば agent と MCP サーバーを番号入力で複数選択できます。`--agent`, `--server`, `--yes`, `--dry-run` のいずれかを `REGISTER_FLAGS` で渡した場合は対話モードに入らず、従来通り非対話で実行します。
+
+```bash
+# 例: claude と codex に github / playwright だけ登録（非対話）
+make register REGISTER_FLAGS="--agent claude,codex --server github,playwright --yes"
 ```
 
 Makefile 経由のビルド成果物は OS に合わせて決まります。Windows (`OS=Windows_NT`) では `bin/mcp-docker.exe` を生成し、`register-*` も `.exe` 付きのバイナリを実行します。Linux/macOS では従来通り `bin/mcp-docker` です。
@@ -180,6 +190,7 @@ mcp-docker register --agent all --yes
 | `make pull-main` | mcp-gateway / copilot-review-mcp の `:main` イメージ取得 |
 | `make start-main` | 最新開発版イメージで全サービス起動 |
 | `make restart-main` | 最新開発版イメージで全サービス再起動 |
+| `make register` | 対話的に IDE/CLI と MCP サーバーを選択して登録 |
 | `make register-claude` | Claude CLI に MCP サーバーを登録 |
 | `make register-copilot` | GitHub Copilot CLI に MCP サーバーを登録 |
 | `make register-codex` | Codex CLI に MCP サーバーを登録 |

--- a/cmd/mcp-docker/interactive.go
+++ b/cmd/mcp-docker/interactive.go
@@ -24,11 +24,10 @@ func isTerminal(v any) bool {
 	return (info.Mode() & os.ModeCharDevice) != 0
 }
 
-func promptSelection(stdin io.Reader, stdout io.Writer, label string, items []string) ([]string, error) {
+func promptSelection(reader *bufio.Reader, stdout io.Writer, label string, items []string) ([]string, error) {
 	if len(items) == 0 {
 		return nil, fmt.Errorf("%s: 選択肢がありません", label)
 	}
-	reader := bufio.NewReader(stdin)
 	fmt.Fprintf(stdout, "%s [all]:\n", label)
 	for i, item := range items {
 		fmt.Fprintf(stdout, "  %d) %s\n", i+1, item)

--- a/cmd/mcp-docker/interactive.go
+++ b/cmd/mcp-docker/interactive.go
@@ -38,6 +38,9 @@ func promptSelection(stdin io.Reader, stdout io.Writer, label string, items []st
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
+	if errors.Is(err, io.EOF) && !strings.HasSuffix(line, "\n") {
+		return nil, errAborted
+	}
 	return parseSelection(line, items)
 }
 

--- a/cmd/mcp-docker/interactive.go
+++ b/cmd/mcp-docker/interactive.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var errAborted = errors.New("ユーザーが中止しました")
+
+func isTerminal(v any) bool {
+	f, ok := v.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
+func promptSelection(stdin io.Reader, stdout io.Writer, label string, items []string) ([]string, error) {
+	if len(items) == 0 {
+		return nil, fmt.Errorf("%s: 選択肢がありません", label)
+	}
+	reader := bufio.NewReader(stdin)
+	fmt.Fprintf(stdout, "%s [all]:\n", label)
+	for i, item := range items {
+		fmt.Fprintf(stdout, "  %d) %s\n", i+1, item)
+	}
+	fmt.Fprint(stdout, "入力: ")
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return parseSelection(line, items)
+}
+
+func parseSelection(input string, items []string) ([]string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" || strings.EqualFold(input, "all") {
+		out := make([]string, len(items))
+		copy(out, items)
+		return out, nil
+	}
+	if strings.EqualFold(input, "none") || strings.EqualFold(input, "q") {
+		return nil, errAborted
+	}
+
+	var out []string
+	seen := make(map[string]struct{})
+	for raw := range strings.SplitSeq(input, ",") {
+		tok := strings.TrimSpace(raw)
+		if tok == "" {
+			continue
+		}
+		name, err := resolveSelectionToken(tok, items)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("少なくとも 1 つ選択してください")
+	}
+	return out, nil
+}
+
+func resolveSelectionToken(token string, items []string) (string, error) {
+	if n, err := strconv.Atoi(token); err == nil {
+		if n < 1 || n > len(items) {
+			return "", fmt.Errorf("番号 %d は範囲外です (1-%d)", n, len(items))
+		}
+		return items[n-1], nil
+	}
+	for _, item := range items {
+		if item == token {
+			return item, nil
+		}
+	}
+	return "", fmt.Errorf("不明な選択肢 %q (利用可能: %s)", token, strings.Join(items, ", "))
+}

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -126,19 +126,21 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		}
 	}
 
-	selectedServers := filterServers(servers, selectedServerNames)
-	if len(selectedServers) == 0 {
+	selectedIndices := selectIndices(servers, selectedServerNames)
+	if len(selectedIndices) == 0 {
 		return errors.New("選択された MCP サーバーがありません")
 	}
 
 	if !opts.yes && !opts.dryRun {
-		if err := confirmRouteNames(stdinReader, stdout, selectedServers); err != nil {
+		if err := confirmRouteNames(stdinReader, stdout, servers); err != nil {
 			return err
 		}
-		if err := validateUniqueServers(selectedServers); err != nil {
+		if err := validateUniqueServers(servers); err != nil {
 			return err
 		}
 	}
+
+	selectedServers := pickServers(servers, selectedIndices)
 
 	selected, err := selectAgentsByNames(agentNames)
 	if err != nil {
@@ -241,16 +243,23 @@ func serverNames(servers []register.Server) []string {
 	return names
 }
 
-func filterServers(servers []register.Server, selected []string) []register.Server {
-	want := make(map[string]struct{}, len(selected))
+func selectIndices(servers []register.Server, selected []string) []int {
+	out := make([]int, 0, len(selected))
 	for _, name := range selected {
-		want[name] = struct{}{}
-	}
-	out := make([]register.Server, 0, len(selected))
-	for _, s := range servers {
-		if _, ok := want[s.Name]; ok {
-			out = append(out, s)
+		for i, s := range servers {
+			if s.Name == name {
+				out = append(out, i)
+				break
+			}
 		}
+	}
+	return out
+}
+
+func pickServers(servers []register.Server, indices []int) []register.Server {
+	out := make([]register.Server, 0, len(indices))
+	for _, i := range indices {
+		out = append(out, servers[i])
 	}
 	return out
 }

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -88,7 +88,7 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 	}
 
 	useInteractive := opts.interactive
-	if !useInteractive && !opts.yes && !opts.dryRun &&
+	if !explicit["interactive"] && !opts.yes && !opts.dryRun &&
 		!explicit["agent"] && !explicit["server"] &&
 		stdinIsTTY && stdoutIsTTY {
 		useInteractive = true

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -88,7 +88,7 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 	}
 
 	useInteractive := opts.interactive
-	if !explicit["interactive"] && !opts.yes && !opts.dryRun &&
+	if !explicit["interactive"] && !explicit["yes"] && !explicit["dry-run"] &&
 		!explicit["agent"] && !explicit["server"] &&
 		stdinIsTTY && stdoutIsTTY {
 		useInteractive = true
@@ -103,14 +103,15 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 	}
 
 	availableServerNames := serverNames(servers)
+	stdinReader := bufio.NewReader(stdin)
 
 	var agentNames, selectedServerNames []string
 	if useInteractive {
-		agentNames, err = promptSelection(stdin, stdout, "登録する IDE/CLI を選択", allAgentNames)
+		agentNames, err = promptSelection(stdinReader, stdout, "登録する IDE/CLI を選択", allAgentNames)
 		if err != nil {
 			return err
 		}
-		selectedServerNames, err = promptSelection(stdin, stdout, "登録する MCP サーバーを選択", availableServerNames)
+		selectedServerNames, err = promptSelection(stdinReader, stdout, "登録する MCP サーバーを選択", availableServerNames)
 		if err != nil {
 			return err
 		}
@@ -131,7 +132,7 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 	}
 
 	if !opts.yes && !opts.dryRun {
-		if err := confirmRouteNames(stdin, stdout, selectedServers); err != nil {
+		if err := confirmRouteNames(stdinReader, stdout, selectedServers); err != nil {
 			return err
 		}
 		if err := validateUniqueServers(selectedServers); err != nil {
@@ -184,8 +185,7 @@ func loadServers(composePath, externalPath string) ([]register.Server, error) {
 	return servers, validateUniqueServers(servers)
 }
 
-func confirmRouteNames(stdin io.Reader, stdout io.Writer, servers []register.Server) error {
-	reader := bufio.NewReader(stdin)
+func confirmRouteNames(reader *bufio.Reader, stdout io.Writer, servers []register.Server) error {
 	for i := range servers {
 		if servers[i].Source == "" {
 			continue

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -18,13 +18,18 @@ import (
 const usage = `mcp-docker は MCP Docker の補助ワークフローを管理します。
 
 使い方:
-  mcp-docker register [--agent claude|copilot|codex|all] [--compose path] [--external path] [--yes] [--dry-run]
+  mcp-docker register [--agent <csv>|all] [--server <csv>|all] [--compose path] [--external path] [--interactive] [--yes] [--dry-run]
   mcp-docker version
   mcp-docker --version
   mcp-docker -v
+
+register に何も引数を指定せず TTY から実行した場合は対話モードで起動します
+（agent と MCP サーバーを番号入力で複数選択できます）。
 `
 
 var version = "2.7.0"
+
+var allAgentNames = []string{"claude", "copilot", "codex"}
 
 func main() {
 	if err := run(context.Background(), os.Args[1:], os.Stdout, os.Stderr, os.Stdin); err != nil {
@@ -58,16 +63,35 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 	fs.SetOutput(stderr)
 
 	opts := registerOptions{}
-	fs.StringVar(&opts.agent, "agent", "all", "登録対象エージェント: claude, copilot, codex, all")
+	fs.StringVar(&opts.agent, "agent", "all", "登録対象エージェント（カンマ区切り可）: claude, copilot, codex, all")
+	fs.StringVar(&opts.server, "server", "all", "登録対象 MCP サーバー（カンマ区切り可）: <name>, all")
 	fs.StringVar(&opts.composePath, "compose", "docker-compose.yml", "読み込む docker compose ファイル")
 	fs.StringVar(&opts.externalPath, "external", "config/mcp-external.yml", "外部 MCP サーバー定義ファイル")
 	fs.BoolVar(&opts.yes, "yes", false, "サジェスト名を確認なしで採用")
 	fs.BoolVar(&opts.dryRun, "dry-run", false, "実行せず、登録時に使うコマンドと条件を表示")
+	fs.BoolVar(&opts.interactive, "interactive", false, "agent/server を対話的に選択")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
 		return fmt.Errorf("想定外の引数です: %s", strings.Join(fs.Args(), " "))
+	}
+
+	explicit := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) { explicit[f.Name] = true })
+
+	stdinIsTTY := isTerminal(stdin)
+	stdoutIsTTY := isTerminal(stdout)
+
+	if opts.interactive && (!stdinIsTTY || !stdoutIsTTY) {
+		return errors.New("--interactive は TTY 環境でのみ利用可能です。代わりに --agent / --server / --yes を指定してください")
+	}
+
+	useInteractive := opts.interactive
+	if !useInteractive && !opts.yes && !opts.dryRun &&
+		!explicit["agent"] && !explicit["server"] &&
+		stdinIsTTY && stdoutIsTTY {
+		useInteractive = true
 	}
 
 	servers, err := loadServers(opts.composePath, opts.externalPath)
@@ -78,16 +102,44 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		return errors.New("MCP サーバーが見つかりませんでした")
 	}
 
-	if !opts.yes && !opts.dryRun {
-		if err := confirmRouteNames(stdin, stdout, servers); err != nil {
+	availableServerNames := serverNames(servers)
+
+	var agentNames, selectedServerNames []string
+	if useInteractive {
+		agentNames, err = promptSelection(stdin, stdout, "登録する IDE/CLI を選択", allAgentNames)
+		if err != nil {
 			return err
 		}
-		if err := validateUniqueServers(servers); err != nil {
+		selectedServerNames, err = promptSelection(stdin, stdout, "登録する MCP サーバーを選択", availableServerNames)
+		if err != nil {
+			return err
+		}
+	} else {
+		agentNames, err = resolveSelection(opts.agent, allAgentNames, "agent")
+		if err != nil {
+			return err
+		}
+		selectedServerNames, err = resolveSelection(opts.server, availableServerNames, "server")
+		if err != nil {
 			return err
 		}
 	}
 
-	selected, err := selectAgents(opts.agent)
+	selectedServers := filterServers(servers, selectedServerNames)
+	if len(selectedServers) == 0 {
+		return errors.New("選択された MCP サーバーがありません")
+	}
+
+	if !opts.yes && !opts.dryRun {
+		if err := confirmRouteNames(stdin, stdout, selectedServers); err != nil {
+			return err
+		}
+		if err := validateUniqueServers(selectedServers); err != nil {
+			return err
+		}
+	}
+
+	selected, err := selectAgentsByNames(agentNames)
 	if err != nil {
 		return err
 	}
@@ -95,10 +147,10 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 	for _, spec := range selected {
 		agent := spec.newAgent(execRunner)
 		if opts.dryRun {
-			register.PrintPlan(stdout, agent, servers)
+			register.PrintPlan(stdout, agent, selectedServers)
 			continue
 		}
-		if err := register.Register(ctx, stdout, agent, servers); err != nil {
+		if err := register.Register(ctx, stdout, agent, selectedServers); err != nil {
 			return err
 		}
 	}
@@ -107,10 +159,12 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 
 type registerOptions struct {
 	agent        string
+	server       string
 	composePath  string
 	externalPath string
 	yes          bool
 	dryRun       bool
+	interactive  bool
 }
 
 func loadServers(composePath, externalPath string) ([]register.Server, error) {
@@ -171,24 +225,96 @@ func serverLabel(server register.Server) string {
 	return server.URL
 }
 
+func serverNames(servers []register.Server) []string {
+	names := make([]string, 0, len(servers))
+	seen := make(map[string]struct{}, len(servers))
+	for _, s := range servers {
+		if s.Name == "" {
+			continue
+		}
+		if _, ok := seen[s.Name]; ok {
+			continue
+		}
+		seen[s.Name] = struct{}{}
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+func filterServers(servers []register.Server, selected []string) []register.Server {
+	want := make(map[string]struct{}, len(selected))
+	for _, name := range selected {
+		want[name] = struct{}{}
+	}
+	out := make([]register.Server, 0, len(selected))
+	for _, s := range servers {
+		if _, ok := want[s.Name]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func resolveSelection(value string, items []string, label string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.EqualFold(value, "all") {
+		out := make([]string, len(items))
+		copy(out, items)
+		return out, nil
+	}
+	var out []string
+	seen := make(map[string]struct{})
+	for raw := range strings.SplitSeq(value, ",") {
+		tok := strings.TrimSpace(raw)
+		if tok == "" {
+			continue
+		}
+		name, err := resolveSelectionToken(tok, items)
+		if err != nil {
+			return nil, fmt.Errorf("--%s: %w", label, err)
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--%s: 少なくとも 1 つ指定してください", label)
+	}
+	return out, nil
+}
+
 type agentSpec struct {
 	name     string
 	newAgent func(register.Runner) register.Agent
 }
 
-func selectAgents(name string) ([]agentSpec, error) {
+func selectAgentsByNames(names []string) ([]agentSpec, error) {
 	all := []agentSpec{
 		{name: "claude", newAgent: register.NewClaudeAgent},
 		{name: "copilot", newAgent: register.NewCopilotAgent},
 		{name: "codex", newAgent: register.NewCodexAgent},
 	}
-	if name == "all" {
-		return all, nil
-	}
+	specsByName := make(map[string]agentSpec, len(all))
 	for _, spec := range all {
-		if name == spec.name {
-			return []agentSpec{spec}, nil
-		}
+		specsByName[spec.name] = spec
 	}
-	return nil, fmt.Errorf("不明なエージェント %q", name)
+	out := make([]agentSpec, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		spec, ok := specsByName[name]
+		if !ok {
+			return nil, fmt.Errorf("不明なエージェント %q", name)
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, spec)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("エージェントが選択されていません")
+	}
+	return out, nil
 }

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -84,3 +84,257 @@ func TestValidateUniqueServersReportsCollidingSources(t *testing.T) {
 		}
 	}
 }
+
+func TestParseSelection(t *testing.T) {
+	items := []string{"claude", "copilot", "codex"}
+	cases := []struct {
+		name      string
+		input     string
+		want      []string
+		wantErr   bool
+		wantAbort bool
+	}{
+		{name: "empty means all", input: "", want: items},
+		{name: "only whitespace means all", input: "   \n", want: items},
+		{name: "explicit all", input: "all", want: items},
+		{name: "all uppercase", input: "ALL", want: items},
+		{name: "indices", input: "1,3", want: []string{"claude", "codex"}},
+		{name: "names", input: "claude,codex", want: []string{"claude", "codex"}},
+		{name: "mixed indices and names", input: "1,codex", want: []string{"claude", "codex"}},
+		{name: "deduplicates", input: "1,1,claude", want: []string{"claude"}},
+		{name: "tolerates trailing comma", input: "claude,", want: []string{"claude"}},
+		{name: "abort with none", input: "none", wantAbort: true},
+		{name: "abort with q", input: "q", wantAbort: true},
+		{name: "out of range", input: "9", wantErr: true},
+		{name: "zero is invalid", input: "0", wantErr: true},
+		{name: "unknown name", input: "ghostide", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSelection(tc.input, items)
+			if tc.wantAbort {
+				if !errors.Is(err, errAborted) {
+					t.Fatalf("err = %v, want errAborted", err)
+				}
+				return
+			}
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalStringSlices(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveSelectionRespectsAllAndCSV(t *testing.T) {
+	items := []string{"github", "playwright", "copilot-review"}
+	cases := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{name: "default all", input: "all", want: items},
+		{name: "single", input: "github", want: []string{"github"}},
+		{name: "csv", input: "github,playwright", want: []string{"github", "playwright"}},
+		{name: "indices", input: "1,3", want: []string{"github", "copilot-review"}},
+		{name: "unknown", input: "nope", wantErr: true},
+		{name: "empty rejected when not all", input: "  ,  ", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveSelection(tc.input, items, "server")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalStringSlices(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveSelectionEmptyTreatedAsAll(t *testing.T) {
+	items := []string{"a", "b"}
+	got, err := resolveSelection("", items, "agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !equalStringSlices(got, items) {
+		t.Fatalf("got %v, want %v", got, items)
+	}
+}
+
+func TestSelectAgentsByNamesPreservesOrderAndDeduplicates(t *testing.T) {
+	specs, err := selectAgentsByNames([]string{"codex", "claude", "claude"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	gotNames := make([]string, len(specs))
+	for i, s := range specs {
+		gotNames[i] = s.name
+	}
+	want := []string{"codex", "claude"}
+	if !equalStringSlices(gotNames, want) {
+		t.Fatalf("got %v, want %v", gotNames, want)
+	}
+}
+
+func TestSelectAgentsByNamesRejectsUnknown(t *testing.T) {
+	if _, err := selectAgentsByNames([]string{"copilot", "vim"}); err == nil {
+		t.Fatal("expected error for unknown agent name")
+	}
+}
+
+func TestFilterServersKeepsOnlySelected(t *testing.T) {
+	servers := []register.Server{
+		{Name: "github"},
+		{Name: "playwright"},
+		{Name: "copilot-review"},
+	}
+	got := filterServers(servers, []string{"playwright", "copilot-review"})
+	wantNames := []string{"playwright", "copilot-review"}
+	gotNames := make([]string, len(got))
+	for i, s := range got {
+		gotNames[i] = s.Name
+	}
+	if !equalStringSlices(gotNames, wantNames) {
+		t.Fatalf("got %v, want %v", gotNames, wantNames)
+	}
+}
+
+func TestRegisterMultiAgentMultiServerDryRun(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	externalPath := filepath.Join(dir, "mcp-external.yml")
+	if err := os.WriteFile(composePath, []byte(`services:
+  mcp-gateway:
+    environment:
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+      ROUTE_COPILOT_REVIEW: /mcp/copilot-review|http://copilot-review-mcp:8084
+      ROUTE_PLAYWRIGHT: /mcp/playwright|http://playwright-mcp:8086
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(externalPath, []byte("servers: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"register",
+		"--dry-run",
+		"--agent", "claude,codex",
+		"--server", "github,playwright",
+		"--compose", composePath,
+		"--external", externalPath,
+	}, &stdout, &stderr, errorReader{})
+	if err != nil {
+		t.Fatalf("run returned error: %v\nstderr=%s", err, stderr.String())
+	}
+
+	got := stdout.String()
+	for _, want := range []string{
+		"claude の dry-run 計画:",
+		"codex の dry-run 計画:",
+		"github",
+		"playwright",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout missing %q: %s", want, got)
+		}
+	}
+	if strings.Contains(got, "copilot の dry-run 計画:") {
+		t.Fatalf("copilot should not be selected: %s", got)
+	}
+	if strings.Contains(got, "copilot-review") {
+		t.Fatalf("copilot-review server should not be selected: %s", got)
+	}
+}
+
+func TestRegisterRejectsInteractiveOnNonTTY(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	externalPath := filepath.Join(dir, "mcp-external.yml")
+	if err := os.WriteFile(composePath, []byte(`services:
+  mcp-gateway:
+    environment:
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(externalPath, []byte("servers: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"register",
+		"--interactive",
+		"--compose", composePath,
+		"--external", externalPath,
+	}, &stdout, &stderr, strings.NewReader(""))
+	if err == nil {
+		t.Fatal("expected non-TTY interactive to error")
+	}
+	if !strings.Contains(err.Error(), "TTY") {
+		t.Fatalf("error = %v, want message about TTY", err)
+	}
+}
+
+func TestRegisterUnknownAgentValueErrors(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	externalPath := filepath.Join(dir, "mcp-external.yml")
+	if err := os.WriteFile(composePath, []byte(`services:
+  mcp-gateway:
+    environment:
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(externalPath, []byte("servers: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"register",
+		"--dry-run",
+		"--agent", "claude,vim",
+		"--compose", composePath,
+		"--external", externalPath,
+	}, &stdout, &stderr, errorReader{})
+	if err == nil {
+		t.Fatal("expected unknown agent error")
+	}
+	if !strings.Contains(err.Error(), "vim") {
+		t.Fatalf("error = %v, want to mention unknown agent", err)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -296,6 +296,25 @@ func TestRegisterRejectsInteractiveOnNonTTY(t *testing.T) {
 	}
 }
 
+func TestPromptSelectionEOFAborts(t *testing.T) {
+	var stdout bytes.Buffer
+	_, err := promptSelection(strings.NewReader(""), &stdout, "select", []string{"a", "b"})
+	if !errors.Is(err, errAborted) {
+		t.Fatalf("err = %v, want errAborted on EOF without newline", err)
+	}
+}
+
+func TestPromptSelectionEnterAcceptsAll(t *testing.T) {
+	var stdout bytes.Buffer
+	got, err := promptSelection(strings.NewReader("\n"), &stdout, "select", []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !equalStringSlices(got, []string{"a", "b"}) {
+		t.Fatalf("got %v, want [a b]", got)
+	}
+}
+
 func TestRegisterUnknownAgentValueErrors(t *testing.T) {
 	dir := t.TempDir()
 	composePath := filepath.Join(dir, "docker-compose.yml")

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -298,7 +299,7 @@ func TestRegisterRejectsInteractiveOnNonTTY(t *testing.T) {
 
 func TestPromptSelectionEOFAborts(t *testing.T) {
 	var stdout bytes.Buffer
-	_, err := promptSelection(strings.NewReader(""), &stdout, "select", []string{"a", "b"})
+	_, err := promptSelection(bufio.NewReader(strings.NewReader("")), &stdout, "select", []string{"a", "b"})
 	if !errors.Is(err, errAborted) {
 		t.Fatalf("err = %v, want errAborted on EOF without newline", err)
 	}
@@ -306,12 +307,31 @@ func TestPromptSelectionEOFAborts(t *testing.T) {
 
 func TestPromptSelectionEnterAcceptsAll(t *testing.T) {
 	var stdout bytes.Buffer
-	got, err := promptSelection(strings.NewReader("\n"), &stdout, "select", []string{"a", "b"})
+	got, err := promptSelection(bufio.NewReader(strings.NewReader("\n")), &stdout, "select", []string{"a", "b"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !equalStringSlices(got, []string{"a", "b"}) {
 		t.Fatalf("got %v, want [a b]", got)
+	}
+}
+
+func TestPromptSelectionReusesBufferAcrossCalls(t *testing.T) {
+	var stdout bytes.Buffer
+	reader := bufio.NewReader(strings.NewReader("1,2\nclaude\n"))
+	got, err := promptSelection(reader, &stdout, "first", []string{"a", "b", "c"})
+	if err != nil {
+		t.Fatalf("first call err: %v", err)
+	}
+	if !equalStringSlices(got, []string{"a", "b"}) {
+		t.Fatalf("first got %v, want [a b]", got)
+	}
+	got2, err := promptSelection(reader, &stdout, "second", []string{"claude", "codex"})
+	if err != nil {
+		t.Fatalf("second call err: %v", err)
+	}
+	if !equalStringSlices(got2, []string{"claude"}) {
+		t.Fatalf("second got %v, want [claude]", got2)
 	}
 }
 

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -201,13 +201,23 @@ func TestSelectAgentsByNamesRejectsUnknown(t *testing.T) {
 	}
 }
 
-func TestFilterServersKeepsOnlySelected(t *testing.T) {
+func TestSelectIndicesAndPickServers(t *testing.T) {
 	servers := []register.Server{
 		{Name: "github"},
 		{Name: "playwright"},
 		{Name: "copilot-review"},
 	}
-	got := filterServers(servers, []string{"playwright", "copilot-review"})
+	indices := selectIndices(servers, []string{"playwright", "copilot-review"})
+	wantIdx := []int{1, 2}
+	if len(indices) != len(wantIdx) {
+		t.Fatalf("indices = %v, want %v", indices, wantIdx)
+	}
+	for i, want := range wantIdx {
+		if indices[i] != want {
+			t.Fatalf("indices[%d] = %d, want %d", i, indices[i], want)
+		}
+	}
+	got := pickServers(servers, indices)
 	wantNames := []string{"playwright", "copilot-review"}
 	gotNames := make([]string, len(got))
 	for i, s := range got {
@@ -215,6 +225,29 @@ func TestFilterServersKeepsOnlySelected(t *testing.T) {
 	}
 	if !equalStringSlices(gotNames, wantNames) {
 		t.Fatalf("got %v, want %v", gotNames, wantNames)
+	}
+}
+
+func TestPickServersReflectsOverridesOnOriginalSlice(t *testing.T) {
+	servers := []register.Server{
+		{Name: "github", URL: "u1"},
+		{Name: "playwright", URL: "u2"},
+	}
+	indices := selectIndices(servers, []string{"github"})
+	servers[indices[0]].Name = "github-prod"
+	got := pickServers(servers, indices)
+	if len(got) != 1 || got[0].Name != "github-prod" {
+		t.Fatalf("got %v, want one server with overridden name", got)
+	}
+}
+
+func TestValidateUniqueServersDetectsCollisionAcrossUnselected(t *testing.T) {
+	servers := []register.Server{
+		{Name: "playwright", URL: "u1", Source: "ROUTE_GITHUB"},
+		{Name: "playwright", URL: "u2", Source: "ROUTE_PLAYWRIGHT"},
+	}
+	if err := validateUniqueServers(servers); err == nil {
+		t.Fatal("expected duplicate detection across full server set")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `mcp-docker register` を対話モード対応に拡張（引数なし & TTY 実行時に番号入力 UI で agent / MCP サーバーを複数選択）
- `--server <csv>|all` を新設し、`--agent` もカンマ区切り指定（例: `--agent claude,codex --server github,playwright`）に対応
- `--interactive` を明示しつつ非 TTY で起動した場合は明示エラーで終了
- `make register` ターゲットを追加（既存 `register-claude/copilot/codex/all` は後方互換のため維持）

## 暗黙対話モードの起動条件

以下を **すべて満たす** 場合のみ自動的に対話モードへ入る:

- サブコマンドが `register`
- stdin / stdout が TTY
- `--yes` / `--agent` / `--server` / `--dry-run` / `--interactive` のいずれも未指定

非 TTY 環境（パイプ入力・CI など）では従来通り非対話で実行する。

## 入力仕様（ISSUE 記載通り）

- Enter または `all` → 全選択
- `1,3` → 番号指定
- `claude,codex` → 名前指定（混在も可）
- `none` / `q` → 中止

## Test plan

- [x] `go test ./...` 全パス
- [x] `go vet ./...` クリーン
- [x] `--version` / `--help` / `register --help`
- [x] 後方互換 `--agent all --dry-run`
- [x] CSV 指定 `--agent claude,codex --server github,playwright --dry-run`
- [x] 番号指定 `--agent 1,3 --server 1 --dry-run`
- [x] 不明値拒否（agent / server）
- [x] 非 TTY で `--interactive` 明示 → エラー
- [x] `make register` / `make register-all`（後方互換）
- [x] `parseSelection` / `resolveSelection` のユニットテスト（番号・名前・混在・all・none・q・重複・範囲外）

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)