### PR TITLE
feat: lefthookおよびlint設定の厳格化

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Go vet
         run: go vet ./...
 
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+
       - name: Go テスト
         run: go test -coverprofile=coverage.out -covermode=atomic ./...
 

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.1
 
       - name: Go テスト
         run: go test -coverprofile=coverage.out -covermode=atomic ./...

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -51,9 +51,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Go vet
-        run: go vet ./...
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.12.2
 
       - name: Go テスト
         run: go test -coverprofile=coverage.out -covermode=atomic ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+# golangci-lint v2 設定
+# https://golangci-lint.run/usage/configuration/
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck      # 未チェックのエラー戻り値を検出
+    - govet         # go vet 相当のチェック
+    - staticcheck   # 包括的な静的解析（SA/S/ST/QF チェック群、gosimple を含む）
+    - ineffassign   # 無効な代入を検出
+    - unused        # 未使用コードを検出
+    - misspell      # 英語スペルミスを検出
+
+  settings:
+    errcheck:
+      # fmt.Fprint* への io.Writer 書き込みエラーは慣用的に無視される
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintln
+        - fmt.Fprintf
+    govet:
+      disable:
+        - shadow
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -36,6 +36,3 @@ disable=SC2231
 # SC2094: Make sure not to read and write the same file
 # 理由: パイプラインの順序を理解した上での使用
 disable=SC2094
-
-# SC2317 は引き続き無効化（コールバック関数の誤検知が多い）
-disable=SC2317

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -9,10 +9,6 @@ disable=SC2129
 # 理由: 関数定義内のコードは間接的に呼び出されるため、誤検知が多い
 disable=SC2317
 
-# SC2155: Declare and assign separately to avoid masking return values
-# 理由: 簡潔性を優先し、エラーハンドリングは別途実施
-disable=SC2155
-
 # SC2034: Variable appears unused
 # 理由: 設定ファイルや外部スクリプトで使用される変数を含む
 disable=SC2034
@@ -29,10 +25,6 @@ disable=SC2009
 # 理由: 配列の初期化で意図的に分割している
 disable=SC2206
 
-# SC2086: Double quote to prevent globbing
-# 理由: return文での変数展開は問題ない
-disable=SC2086
-
 # SC2012: Use find instead of ls
 # 理由: lsの方が簡潔で、ファイル名に特殊文字を含まない前提
 disable=SC2012
@@ -44,3 +36,6 @@ disable=SC2231
 # SC2094: Make sure not to read and write the same file
 # 理由: パイプラインの順序を理解した上での使用
 disable=SC2094
+
+# SC2317 は引き続き無効化（コールバック関数の誤検知が多い）
+disable=SC2317

--- a/Makefile
+++ b/Makefile
@@ -183,8 +183,14 @@ lint-shell: ## シェルスクリプトのlint実行
 	./scripts/lint-shell.sh
 
 .PHONY: lint-go
-lint-go: ## Go 静的解析（go vet）
-	go vet ./...
+lint-go: ## Go 静的解析（golangci-lint + go vet フォールバック）
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run ./...; \
+	else \
+		echo "⚠️  golangci-lint が見つかりません。go vet で代替します"; \
+		echo "   インストール: https://golangci-lint.run/welcome/install/"; \
+		go vet ./...; \
+	fi
 
 .PHONY: test-shell
 test-shell: ## シェルスクリプトのテスト実行

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,12 @@ lint-shell: ## シェルスクリプトのlint実行
 
 .PHONY: lint-go
 lint-go: ## Go 静的解析（golangci-lint + go vet フォールバック）
-	@command -v golangci-lint >/dev/null 2>&1 && golangci-lint run ./... || (echo 'golangci-lint not found, falling back to go vet'; go vet ./...)
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run ./...; \
+	else \
+		echo 'golangci-lint not found, falling back to go vet'; \
+		go vet ./...; \
+	fi
 
 .PHONY: test-shell
 test-shell: ## シェルスクリプトのテスト実行

--- a/Makefile
+++ b/Makefile
@@ -184,13 +184,7 @@ lint-shell: ## シェルスクリプトのlint実行
 
 .PHONY: lint-go
 lint-go: ## Go 静的解析（golangci-lint + go vet フォールバック）
-	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run ./...; \
-	else \
-		echo "⚠️  golangci-lint が見つかりません。go vet で代替します"; \
-		echo "   インストール: https://golangci-lint.run/welcome/install/"; \
-		go vet ./...; \
-	fi
+	@command -v golangci-lint >/dev/null 2>&1 && golangci-lint run ./... || (echo 'golangci-lint not found, falling back to go vet'; go vet ./...)
 
 .PHONY: test-shell
 test-shell: ## シェルスクリプトのテスト実行

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -180,10 +180,9 @@ func loadServers(composePath, externalPath string) ([]register.Server, error) {
 		return nil, err
 	}
 
-	var servers []register.Server
-	for _, server := range append(composeServers, externalServers...) {
-		servers = append(servers, server)
-	}
+	servers := make([]register.Server, 0, len(composeServers)+len(externalServers))
+	servers = append(servers, composeServers...)
+	servers = append(servers, externalServers...)
 	return servers, validateUniqueServers(servers)
 }
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,11 +10,11 @@ pre-commit:
 
     - name: shellcheck
       glob: "*.sh"
-      run: shellcheck {staged_files}
+      run: bash -c "command -v shellcheck >/dev/null 2>&1 && shellcheck {staged_files} || echo '⚠️ shellcheck not found, skipping'"
 
     - name: yamllint
       glob: "*.{yml,yaml}"
-      run: yamllint {staged_files}
+      run: bash -c "command -v yamllint >/dev/null 2>&1 && yamllint {staged_files} || echo '⚠️ yamllint not found, skipping'"
 
 pre-push:
   jobs:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,7 +5,6 @@ pre-commit:
   parallel: true
   jobs:
     - name: go-vet
-      glob: "*.go"
       run: go vet ./...
 
     - name: shellcheck

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,11 +10,11 @@ pre-commit:
 
     - name: shellcheck
       glob: "*.sh"
-      run: bash -c "command -v shellcheck >/dev/null 2>&1 && shellcheck {staged_files} || echo '⚠️ shellcheck not found, skipping'"
+      run: bash scripts/pre-commit-shellcheck.sh {staged_files}
 
     - name: yamllint
       glob: "*.{yml,yaml}"
-      run: bash -c "command -v yamllint >/dev/null 2>&1 && yamllint {staged_files} || echo '⚠️ yamllint not found, skipping'"
+      run: bash scripts/pre-commit-yamllint.sh {staged_files}
 
 pre-push:
   jobs:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,25 @@
+# lefthook.yml — pre-commit / pre-push フック設定
+# https://lefthook.dev/configuration/
+
+pre-commit:
+  parallel: true
+  jobs:
+    - name: go-vet
+      glob: "*.go"
+      run: go vet ./...
+
+    - name: shellcheck
+      glob: "*.sh"
+      run: shellcheck {staged_files}
+
+    - name: yamllint
+      glob: "*.{yml,yaml}"
+      run: yamllint {staged_files}
+
+pre-push:
+  jobs:
+    - name: lint
+      run: make lint
+
+    - name: test-go
+      run: make test-go

--- a/scripts/lint-shell.sh
+++ b/scripts/lint-shell.sh
@@ -16,22 +16,22 @@ if ! command -v shellcheck >/dev/null 2>&1; then
     exit 1
 fi
 
-# スクリプトファイルを検索
-SHELL_FILES=$(find "${PROJECT_ROOT}/scripts" -type f -name "*.sh" 2>/dev/null || true)
+# スクリプトファイルを配列に収集 (bash 4.0+ mapfile を使用)
+mapfile -t SHELL_FILES < <(find "${PROJECT_ROOT}/scripts" -type f -name "*.sh" 2>/dev/null)
 
-if [ -z "$SHELL_FILES" ]; then
+if [ "${#SHELL_FILES[@]}" -eq 0 ]; then
     echo "⚠️  シェルスクリプトが見つかりません"
     exit 0
 fi
 
 echo "📋 検査対象:"
-while IFS= read -r file; do
+for file in "${SHELL_FILES[@]}"; do
     echo "  - $file"
-done <<< "$SHELL_FILES"
+done
 echo ""
 
 # リント実行
-for file in $SHELL_FILES; do
+for file in "${SHELL_FILES[@]}"; do
     echo "🔍 検査中: $(basename "$file")"
     if shellcheck "$file"; then
         echo "✅ $(basename "$file"): OK"

--- a/scripts/lint-shell.sh
+++ b/scripts/lint-shell.sh
@@ -11,9 +11,9 @@ EXIT_CODE=0
 
 # コマンドの確認
 if ! command -v shellcheck >/dev/null 2>&1; then
-    echo "❌ shellcheck がインストールされていません"
+    echo "⚠️  shellcheck がインストールされていません（スキップ）"
     echo "   インストール: brew install shellcheck"
-    exit 1
+    exit 0
 fi
 
 # スクリプトファイルを配列に収集 (bash 4.0+ mapfile を使用)

--- a/scripts/lint-shell.sh
+++ b/scripts/lint-shell.sh
@@ -11,6 +11,10 @@ EXIT_CODE=0
 
 # コマンドの確認
 if ! command -v shellcheck >/dev/null 2>&1; then
+    if [ "${CI:-}" = "true" ]; then
+        echo "❌ CI 環境で shellcheck が見つかりません（必須）"
+        exit 1
+    fi
     echo "⚠️  shellcheck がインストールされていません（スキップ）"
     echo "   インストール: brew install shellcheck"
     exit 0

--- a/scripts/pre-commit-shellcheck.sh
+++ b/scripts/pre-commit-shellcheck.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# lefthook pre-commit helper: shellcheck が無ければスキップ
+command -v shellcheck >/dev/null 2>&1 || { echo "warning: shellcheck not found, skipping"; exit 0; }
+shellcheck "$@"

--- a/scripts/pre-commit-yamllint.sh
+++ b/scripts/pre-commit-yamllint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# lefthook pre-commit helper: yamllint が無ければスキップ
+command -v yamllint >/dev/null 2>&1 || { echo "warning: yamllint not found, skipping"; exit 0; }
+yamllint "$@"


### PR DESCRIPTION
## 概要

lefthookのgitフック設定を実装し、Go/シェルのlint設定を厳格化します。

## 変更内容

### lefthook.yml — gitフック設定（新規）
- **pre-commit（並列実行）**: `go vet`, `shellcheck`, `yamllint` を staged ファイルに実行
- **pre-push**: `make lint` + `make test-go` を実行
- shellcheck/yamllint 未インストール時はスキップ（Windows ローカル対応）

### .golangci.yml — golangci-lint v2 設定（新規）
- 有効化: `errcheck` / `govet` / `staticcheck` / `ineffassign` / `unused` / `misspell`
- `fmt.Fprint*` 系は errcheck から除外（慣用的パターン）

### Makefile
- `lint-go` ターゲット: golangci-lint 呼び出し（未インストール時 go vet にフォールバック）

### .github/workflows/lint-test.yml
- `test-go` ジョブに `golangci/golangci-lint-action@v8` を追加

### .shellcheckrc — 厳格化
- `SC2086`（ダブルクォート忘れ）・`SC2155`（declare/assign分離）の disable を削除
- `SC2317`（コールバック誤検知）は継続無効化

### scripts/lint-shell.sh
- SC2086 準拠: `SHELL_FILES` 文字列変数 → `mapfile -t` 配列に移行
- shellcheck 未インストール時は警告してスキップ

### cmd/mcp-docker/main.go
- staticcheck S1011 修正: ループ展開 → `make` + `append` スライス結合

## テスト結果

- `golangci-lint run ./...` → **0 issues**
- `go test ./...` → **全テスト通過**
- lefthook pre-push フック → **通過**
