### PR TITLE
feat: enable Cloudflare Remote MCP routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,8 +80,8 @@ services:
       #   2. 下記2行のコメントを解除
       #   3. make restart
       #
-      # - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required for Cloudflare Remote MCP}
-      # - ROUTE_CLOUDFLARE=/mcp/cloudflare|https://mcp.cloudflare.com/mcp|auth=oauth|upstream_bearer_token_env=CLOUDFLARE_API_TOKEN
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required for Cloudflare Remote MCP}
+      - ROUTE_CLOUDFLARE=/mcp/cloudflare|https://mcp.cloudflare.com/mcp|auth=oauth|upstream_bearer_token_env=CLOUDFLARE_API_TOKEN
       - OAUTH_SCOPES=${OAUTH_SCOPES:-${GITHUB_MCP_OAUTH_SCOPES:-repo,user}}
       - GITHUB_MCP_OAUTH_SCOPES=${OAUTH_SCOPES:-${GITHUB_MCP_OAUTH_SCOPES:-repo,user}}
       - LOG_LEVEL=${LOG_LEVEL:-info}


### PR DESCRIPTION
## Summary
- `docker-compose.yml` の Cloudflare Remote MCP ルーティング設定をコメントアウト解除
- `CLOUDFLARE_API_TOKEN` および `ROUTE_CLOUDFLARE` を有効化
- 環境変数は `.env` または `make start` 時に注入する前提

## Test plan
- [ ] `CLOUDFLARE_API_TOKEN` を環境変数に設定した状態で `make start` が正常に動作するか確認
- [ ] `/mcp/cloudflare` エンドポイントへのルーティングが機能するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)