### PR TITLE
fix: env-var-driven Cloudflare routing + GPAT nested expansion fix

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -127,7 +127,7 @@ LOG_LEVEL=info
 #
 # 有効化手順（Cloudflare Remote MCP の例）:
 #   1. 下記 CLOUDFLARE_API_TOKEN を設定（コメント解除）
-#   2. docker-compose.yml の CLOUDFLARE_API_TOKEN / ROUTE_CLOUDFLARE 行を解除
-#   3. make restart
+#   2. make restart
+#   ※ CLOUDFLARE_API_TOKEN が設定されていれば docker-compose.yml の編集は不要です
 #
 # CLOUDFLARE_API_TOKEN=your-cloudflare-api-token-here

--- a/Makefile
+++ b/Makefile
@@ -31,23 +31,37 @@ endif
 # ?= はシェルの export 済み変数を優先するので、環境変数が設定済みの場合は .env を無視する。
 ENV_GET = $(strip $(shell awk -v key='$(1)' '/^[[:space:]]*#/{next} $$0 ~ ("^[[:space:]]*" key "[[:space:]]*=") {val=substr($$0,index($$0,"=")+1); gsub(/^[[:space:]"'"'"']+|[[:space:]"'"'"']+$$/,"",val); print val; exit}' .env 2>/dev/null))
 ifneq (,$(wildcard .env))
+  OAUTH_CLIENT_ID              ?= $(call ENV_GET,OAUTH_CLIENT_ID)
+  OAUTH_CLIENT_SECRET          ?= $(call ENV_GET,OAUTH_CLIENT_SECRET)
   GITHUB_CLIENT_ID             ?= $(call ENV_GET,GITHUB_CLIENT_ID)
   GITHUB_CLIENT_SECRET         ?= $(call ENV_GET,GITHUB_CLIENT_SECRET)
   GITHUB_MCP_CLIENT_ID         ?= $(call ENV_GET,GITHUB_MCP_CLIENT_ID)
   GITHUB_MCP_CLIENT_SECRET     ?= $(call ENV_GET,GITHUB_MCP_CLIENT_SECRET)
   GITHUB_PERSONAL_ACCESS_TOKEN ?= $(call ENV_GET,GITHUB_PERSONAL_ACCESS_TOKEN)
+  MCP_GITHUB_PAT               ?= $(call ENV_GET,MCP_GITHUB_PAT)
   MCP_GATEWAY_PORT             ?= $(call ENV_GET,MCP_GATEWAY_PORT)
 endif
 
-# mcp-gateway 向け変数が空または未設定なら既存 OAuth 変数をフォールバック利用
+# OAUTH_* → GITHUB_MCP_* → GITHUB_* の優先順位でフォールバック解決
+ifeq ($(strip $(OAUTH_CLIENT_ID)),)
+  OAUTH_CLIENT_ID := $(or $(GITHUB_MCP_CLIENT_ID),$(GITHUB_CLIENT_ID))
+endif
+ifeq ($(strip $(OAUTH_CLIENT_SECRET)),)
+  OAUTH_CLIENT_SECRET := $(or $(GITHUB_MCP_CLIENT_SECRET),$(GITHUB_CLIENT_SECRET))
+endif
+# 旧変数名も OAUTH_* から補完（docker-compose.yml 後方互換エイリアス向け）
 ifeq ($(strip $(GITHUB_MCP_CLIENT_ID)),)
-  GITHUB_MCP_CLIENT_ID := $(GITHUB_CLIENT_ID)
+  GITHUB_MCP_CLIENT_ID := $(OAUTH_CLIENT_ID)
 endif
 ifeq ($(strip $(GITHUB_MCP_CLIENT_SECRET)),)
-  GITHUB_MCP_CLIENT_SECRET := $(GITHUB_CLIENT_SECRET)
+  GITHUB_MCP_CLIENT_SECRET := $(OAUTH_CLIENT_SECRET)
+endif
+# MCP_GITHUB_PAT: docker-compose はネスト変数展開非対応のため Makefile 側で解決する
+ifeq ($(strip $(MCP_GITHUB_PAT)),)
+  MCP_GITHUB_PAT := $(GITHUB_PERSONAL_ACCESS_TOKEN)
 endif
 # 子プロセス（docker compose）に確実に渡す
-export GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET GITHUB_MCP_CLIENT_ID GITHUB_MCP_CLIENT_SECRET GITHUB_PERSONAL_ACCESS_TOKEN MCP_GATEWAY_PORT
+export OAUTH_CLIENT_ID OAUTH_CLIENT_SECRET GITHUB_CLIENT_ID GITHUB_CLIENT_SECRET GITHUB_MCP_CLIENT_ID GITHUB_MCP_CLIENT_SECRET GITHUB_PERSONAL_ACCESS_TOKEN MCP_GITHUB_PAT MCP_GATEWAY_PORT
 
 .DEFAULT_GOAL := help
 
@@ -62,7 +76,7 @@ help: ## 利用可能なターゲット一覧を表示
 
 .PHONY: start-gateway
 start-gateway: ## 全サービスを mcp-gateway 経由で起動（127.0.0.1:8080）
-	$(if $(and $(GITHUB_MCP_CLIENT_ID),$(GITHUB_MCP_CLIENT_SECRET)),,$(error ERROR: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET must be set in .env or environment))
+	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET (または旧変数 GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET) を .env または環境変数に設定してください))
 	docker compose up -d github-mcp copilot-review-mcp mcp-gateway playwright-mcp
 	@echo "Started mcp-gateway endpoint: http://127.0.0.1:$(or $(MCP_GATEWAY_PORT),8080)"
 
@@ -119,7 +133,7 @@ pull-main: ## 最新開発版イメージを取得（リリース前 main ブラ
 
 .PHONY: start-main
 start-main: ## 最新開発版イメージで全サービスを起動
-	$(if $(and $(GITHUB_MCP_CLIENT_ID),$(GITHUB_MCP_CLIENT_SECRET)),,$(error ERROR: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET must be set in .env or environment))
+	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET (または旧変数 GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET) を .env または環境変数に設定してください))
 	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
 	COPILOT_REVIEW_MCP_IMAGE=$(COPILOT_REVIEW_MCP_MAIN_IMAGE) \
 	docker compose up -d github-mcp copilot-review-mcp mcp-gateway playwright-mcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     command: ["http", "--port", "${GITHUB_MCP_HTTP_PORT:-8082}"]
 
     environment:
-      - MCP_GITHUB_PAT=${MCP_GITHUB_PAT:-${GITHUB_PERSONAL_ACCESS_TOKEN}}
+      - MCP_GITHUB_PAT=${MCP_GITHUB_PAT}
       - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
       - GITHUB_API_URL=${GITHUB_API_URL:-https://api.github.com}
       - LOG_LEVEL=${LOG_LEVEL:-info}
@@ -75,13 +75,13 @@ services:
       # Remote MCP プロバイダー（upstream_bearer_token_env）— mcp-gateway v0.5.0 以降
       # =============================================================================
       # 外部 Remote MCP サービスを mcp-gateway 配下に収容する例（Cloudflare）。
+      # CLOUDFLARE_API_TOKEN が設定されている場合のみ自動的にルートが有効化されます。
       # 有効化手順:
       #   1. .env に CLOUDFLARE_API_TOKEN=<token> を設定
-      #   2. 下記2行のコメントを解除
-      #   3. make restart
+      #   2. make restart
       #
-      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required for Cloudflare Remote MCP}
-      - ROUTE_CLOUDFLARE=/mcp/cloudflare|https://mcp.cloudflare.com/mcp|auth=oauth|upstream_bearer_token_env=CLOUDFLARE_API_TOKEN
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:-}
+      - ROUTE_CLOUDFLARE=${CLOUDFLARE_API_TOKEN:+/mcp/cloudflare|https://mcp.cloudflare.com/mcp|auth=oauth|upstream_bearer_token_env=CLOUDFLARE_API_TOKEN}
       - OAUTH_SCOPES=${OAUTH_SCOPES:-${GITHUB_MCP_OAUTH_SCOPES:-repo,user}}
       - GITHUB_MCP_OAUTH_SCOPES=${OAUTH_SCOPES:-${GITHUB_MCP_OAUTH_SCOPES:-repo,user}}
       - LOG_LEVEL=${LOG_LEVEL:-info}


### PR DESCRIPTION
## 概要

- **Cloudflare ルートの環境変数駆動化**: `docker-compose.yml` を編集せず `.env` の `CLOUDFLARE_API_TOKEN` 設定だけで ON/OFF できるようにした
- **`MCP_GITHUB_PAT` ネスト変数展開バグ修正**: Docker Compose の単一パス展開の制約により、`MCP_GITHUB_PAT` 未設定時にリテラル文字列が渡っていたバグを修正
- **`OAUTH_*` 変数サポート追加** (#147 フォロー): Makefile が `OAUTH_CLIENT_ID`/`OAUTH_CLIENT_SECRET` を読み取るよう修正

## 変更詳細

### Cloudflare 環境変数駆動化

**Before:** `:?`（必須・未設定でエラー）で常にアクティブな行をコメントアウトで制御
```yaml
# - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:?...}  ← 手動でコメント解除が必要
# - ROUTE_CLOUDFLARE=...
```

**After:** `:+`（条件付き展開）でトークン有無を自動判定
```yaml
- CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:-}
- ROUTE_CLOUDFLARE=${CLOUDFLARE_API_TOKEN:+/mcp/cloudflare|...|upstream_bearer_token_env=CLOUDFLARE_API_TOKEN}
```

トークン未設定時は `ROUTE_CLOUDFLARE=`（空文字）が mcp-gateway に渡るが、scottlz0310/mcp-gateway#86 の修正で空の `ROUTE_*` がスキップされる（同時リリースが前提）。

### MCP_GITHUB_PAT バグ

Docker Compose は `${VAR:-${OTHER}}` のネスト展開を非サポート。`MCP_GITHUB_PAT` 未設定時にコンテナへリテラル文字列 `${GITHUB_PERSONAL_ACCESS_TOKEN}` が渡っていた。Makefile 側でフォールバックを解決し `docker-compose.yml` は単純パススルーに変更。

### Makefile OAUTH_* 対応

`.env` に `OAUTH_CLIENT_ID`/`OAUTH_CLIENT_SECRET` を設定した場合に正しく読み取られ、旧変数名（`GITHUB_MCP_CLIENT_ID` 等）へのフォールバックも機能するよう整備。

## 依存

- scottlz0310/mcp-gateway#86（マージ済み）— 空の `ROUTE_*` スキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)