### PR TITLE
fix: Makefile の日本語 echo が Windows 環境で文字化けする問題を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ ifeq ($(OS),Windows_NT)
       D:/PROGRA~2/Git/bin/bash.exe))
   endif
   ifeq ($(strip $(GIT_BASH)),)
-    $(error Windows では Git for Windows の bash.exe が必要です。\
-      インストール後に再実行するか GIT_BASH=<bash.exeのフルパス> を指定してください)
+    $(error Git for Windows bash.exe is required on Windows. \
+      Install Git for Windows and retry, or specify: GIT_BASH=<path/to/bash.exe>)
   endif
   SHELL       := $(GIT_BASH)
   .SHELLFLAGS := -c
@@ -78,7 +78,7 @@ help: ## 利用可能なターゲット一覧を表示
 
 .PHONY: start-gateway
 start-gateway: ## 全サービスを mcp-gateway 経由で起動（127.0.0.1:8080）
-	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET (または旧変数 GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET) を .env または環境変数に設定してください))
+	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET are required (legacy: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET). Set them in .env or as environment variables.))
 	docker compose up -d github-mcp copilot-review-mcp mcp-gateway playwright-mcp
 	@echo "Started mcp-gateway endpoint: http://127.0.0.1:$(or $(MCP_GATEWAY_PORT),8080)"
 
@@ -131,11 +131,15 @@ pull-main: ## 最新開発版イメージを取得（リリース前 main ブラ
 	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
 	COPILOT_REVIEW_MCP_IMAGE=$(COPILOT_REVIEW_MCP_MAIN_IMAGE) \
 	docker compose pull mcp-gateway copilot-review-mcp
+ifeq ($(OS),Windows_NT)
 	@echo $$'\u2713 :main \u30a4\u30e1\u30fc\u30b8\u3092\u53d6\u5f97\u3057\u307e\u3057\u305f\u3002\u8d77\u52d5: make start-main'
+else
+	@echo "✓ :main イメージを取得しました。起動: make start-main"
+endif
 
 .PHONY: start-main
 start-main: ## 最新開発版イメージで全サービスを起動
-	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET (または旧変数 GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET) を .env または環境変数に設定してください))
+	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET are required (legacy: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET). Set them in .env or as environment variables.))
 	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
 	COPILOT_REVIEW_MCP_IMAGE=$(COPILOT_REVIEW_MCP_MAIN_IMAGE) \
 	docker compose up -d github-mcp copilot-review-mcp mcp-gateway playwright-mcp
@@ -212,8 +216,8 @@ test-shell: ## シェルスクリプトのテスト実行
 	@if command -v bats >/dev/null 2>&1; then \
 		bats tests/shell/*.bats; \
 	else \
-		echo "❌ bats がインストールされていません"; \
-		echo "   インストール: brew install bats-core"; \
+		echo "bats is not installed"; \
+		echo "   Install: brew install bats-core"; \
 		exit 1; \
 	fi
 
@@ -223,17 +227,37 @@ test-shell: ## シェルスクリプトのテスト実行
 
 .PHONY: clean
 clean: ## 一時ファイル削除
+ifeq ($(OS),Windows_NT)
 	@echo $$'\u30ad\u30e3\u30c3\u30b7\u30e5\u3092\u30af\u30ea\u30fc\u30f3\u30a2\u30c3\u30d7\u4e2d...'
+else
+	@echo "キャッシュをクリーンアップ中..."
+endif
 	rm -rf .tmp test-results coverage.out
+ifeq ($(OS),Windows_NT)
 	@echo $$'\u30ad\u30e3\u30c3\u30b7\u30e5\u30af\u30ea\u30fc\u30f3\u30a2\u30c3\u30d7\u5b8c\u4e86'
+else
+	@echo "キャッシュクリーンアップ完了"
+endif
 
 .PHONY: clean-docker
 clean-docker: ## Dockerリソースクリーンアップ
+ifeq ($(OS),Windows_NT)
 	@echo $$'Docker\u30ea\u30bd\u30fc\u30b9\u3092\u30af\u30ea\u30fc\u30f3\u30a2\u30c3\u30d7\u4e2d...'
+else
+	@echo "Dockerリソースをクリーンアップ中..."
+endif
 	docker compose down -v
 	docker system prune -f
+ifeq ($(OS),Windows_NT)
 	@echo $$'Docker\u30af\u30ea\u30fc\u30f3\u30a2\u30c3\u30d7\u5b8c\u4e86'
+else
+	@echo "Dockerクリーンアップ完了"
+endif
 
 .PHONY: clean-all
 clean-all: clean clean-docker ## 全てクリーンアップ
+ifeq ($(OS),Windows_NT)
 	@echo $$'\u3059\u3079\u3066\u306e\u30af\u30ea\u30fc\u30f3\u30a2\u30c3\u30d7\u5b8c\u4e86'
+else
+	@echo "すべてのクリーンアップ完了"
+endif

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ ifeq ($(OS),Windows_NT)
   endif
   SHELL       := $(GIT_BASH)
   .SHELLFLAGS := -c
+  export LANG   := C.UTF-8
+  export LC_ALL := C.UTF-8
 endif
 
 # 環境変数優先、.env フォールバック（安全な awk テキスト抽出）
@@ -129,7 +131,7 @@ pull-main: ## 最新開発版イメージを取得（リリース前 main ブラ
 	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
 	COPILOT_REVIEW_MCP_IMAGE=$(COPILOT_REVIEW_MCP_MAIN_IMAGE) \
 	docker compose pull mcp-gateway copilot-review-mcp
-	@echo "✓ :main イメージを取得しました。起動: make start-main"
+	@echo $$'\u2713 :main \u30a4\u30e1\u30fc\u30b8\u3092\u53d6\u5f97\u3057\u307e\u3057\u305f\u3002\u8d77\u52d5: make start-main'
 
 .PHONY: start-main
 start-main: ## 最新開発版イメージで全サービスを起動
@@ -221,17 +223,17 @@ test-shell: ## シェルスクリプトのテスト実行
 
 .PHONY: clean
 clean: ## 一時ファイル削除
-	@echo "キャッシュをクリーンアップ中..."
+	@echo $$'\u30ad\u30e3\u30c3\u30b7\u30e5\u3092\u30af\u30ea\u30fc\u30f3\u30a2\u30c3\u30d7\u4e2d...'
 	rm -rf .tmp test-results coverage.out
-	@echo "キャッシュクリーンアップ完了"
+	@echo $$'\u30ad\u30e3\u30c3\u30b7\u30e5\u30af\u30ea\u30fc\u30f3\u30a2\u30c3\u30d7\u5b8c\u4e86'
 
 .PHONY: clean-docker
 clean-docker: ## Dockerリソースクリーンアップ
-	@echo "Dockerリソースをクリーンアップ中..."
+	@echo $$'Docker\u30ea\u30bd\u30fc\u30b9\u3092\u30af\u30ea\u30fc\u30f3\u30a2\u30c3\u30d7\u4e2d...'
 	docker compose down -v
 	docker system prune -f
-	@echo "Dockerクリーンアップ完了"
+	@echo $$'Docker\u30af\u30ea\u30fc\u30f3\u30a2\u30c3\u30d7\u5b8c\u4e86'
 
 .PHONY: clean-all
 clean-all: clean clean-docker ## 全てクリーンアップ
-	@echo "すべてのクリーンアップ完了"
+	@echo $$'\u3059\u3079\u3066\u306e\u30af\u30ea\u30fc\u30f3\u30a2\u30c3\u30d7\u5b8c\u4e86'


### PR DESCRIPTION
## Summary

- Windows ネイティブ `make.exe`（Scoop）は Makefile をファイル読み込み時に ACP（CP932）で解釈するため、UTF-8 の日本語文字列が bash に渡る前に破損する
- `@echo` の日本語文字列を bash の ANSI-C quoting（`$$'\uXXXX'`）による Unicode エスケープに置換し、make が読む内容を ASCII のみにすることで回避
- Git Bash 経由で実行されるツール（awk 等）のロケールを `C.UTF-8` に統一（`LANG`/`LC_ALL` export）

## Root Cause

`chcp`/`[Console]::OutputEncoding` はコンソール I/O や PowerShell キャプチャ出力の解釈に影響するが、`make.exe` がファイルを読む際の ACP（Windows システムロケール）は変更できない。`LANG`/`LC_ALL` は bash 内ツールのロケールには効くが、make 自身のファイル読み込みには効かない。

## How it works

```makefile
# make が読む：ASCII のみ（CP932 で化けない）
@echo $$'✓ :main イメージ...'
# ↓ make が bash に渡す（$$ → $）
echo $'✓ :main イ...'
# ↓ bash の ANSI-C quoting が Unicode → UTF-8 変換して出力
✓ :main イメージを取得しました。
```

## Test plan

- [ ] Windows 環境（Scoop make, pwsh）で `make pull-main` を実行し日本語が正しく表示されること
- [ ] `make clean` / `make clean-docker` / `make clean-all` で日本語メッセージが正しく表示されること
- [ ] Linux/macOS 環境で既存の動作が壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)