### PR TITLE
feat: add thread-owl MCP server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       # ROUTE_PLAYWRIGHT 環境変数・playwright-mcp サービス定義を削除してください。
       playwright-mcp:
         condition: service_started
+      thread-owl:
+        condition: service_started
 
     environment:
       - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID:-${GITHUB_MCP_CLIENT_ID}}
@@ -71,6 +73,7 @@ services:
       - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}
       - ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:${COPILOT_REVIEW_MCP_PORT:-8083}
       - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
+      - ROUTE_THREAD_OWL=/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}
       # =============================================================================
       # Remote MCP プロバイダー（upstream_bearer_token_env）— mcp-gateway v0.5.0 以降
       # =============================================================================
@@ -161,6 +164,46 @@ services:
           cpus: "0.5"
           memory: 256M
 
+  thread-owl:
+    image: ${THREAD_OWL_IMAGE:-ghcr.io/scottlz0310/thread-owl:latest}
+    container_name: thread-owl
+    restart: unless-stopped
+    command: ["--mcp-http"]
+
+    environment:
+      - GITHUB_APP_ID=${THREAD_OWL_GITHUB_APP_ID}
+      # 秘密鍵は B64 形式を推奨（ファイルマウント不要）。
+      # FILE 形式を使う場合は GITHUB_APP_PRIVATE_KEY_FILE=/data/github-app.pem を指定し
+      # volumes に ${THREAD_OWL_PEM_PATH}:/data/github-app.pem:ro を追加してください。
+      - GITHUB_APP_PRIVATE_KEY_B64=${THREAD_OWL_GITHUB_APP_PRIVATE_KEY_B64}
+      - ALLOWED_REPOS=${THREAD_OWL_ALLOWED_REPOS}
+      - HOST=0.0.0.0
+      - PORT=${THREAD_OWL_PORT:-3000}
+      # mcp-gateway がプレフィックスをストリップせず転送するため、gateway 側の route prefix に合わせる。
+      - MCP_HTTP_PATH=/mcp/thread-owl
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+
+    expose:
+      - "${THREAD_OWL_PORT:-3000}"
+
+    networks:
+      - mcp-network
+
+    healthcheck:
+      disable: true
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+
   # =============================================================================
   # auth=none ルートの例: 認証不要な MCP サーバを追加するパターン（上記が有効化済み）
   # =============================================================================
@@ -195,6 +238,8 @@ volumes:
   copilot-review-data:
     driver: local
   mcp-gateway-data:
+    driver: local
+  thread-owl-data:
     driver: local
 
 networks:


### PR DESCRIPTION
## Summary

- `thread-owl` サービスを docker-compose に追加（`command: ["--mcp-http"]`、`HOST=0.0.0.0`、`MCP_HTTP_PATH=/mcp/thread-owl`、`expose: 3000`、`mcp-network`）
- `mcp-gateway` に `ROUTE_THREAD_OWL=/mcp/thread-owl|http://thread-owl:3000` を追加
- `mcp-gateway.depends_on` に `thread-owl` を追加
- `thread-owl-data` volume を追加

## 設定方法

`.env` に以下を追加：
```
THREAD_OWL_GITHUB_APP_ID=<app-id>
THREAD_OWL_GITHUB_APP_PRIVATE_KEY_B64=<base64-encoded-pem>
THREAD_OWL_ALLOWED_REPOS=owner/repo1,owner/repo2
```

## クライアント URL

```
http://127.0.0.1:8080/mcp/thread-owl
```

## Test plan

- [ ] `make start-gateway` で全サービス起動
- [ ] `docker ps` で thread-owl コンテナが起動していることを確認
- [ ] mcp-gateway 経由で `http://127.0.0.1:8080/mcp/thread-owl` にアクセスできることを確認
- [ ] `make register-claude` で `thread-owl` が登録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)