### PR TITLE
[codex] fix: development targets に thread-owl を含める

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,23 +118,25 @@ pull: pull-gateway ## 全サービスの Docker イメージを取得（pull-gat
 status: status-gateway ## 全サービスの状態確認（status-gateway のエイリアス）
 
 # :main イメージ（リリース前の最新開発版）
-# mcp-gateway / review-raven は :latest がリリース時のみ更新されるため、
-# 最新の main ブランチビルドを使いたい場合はこれらのターゲットを使用する。
+# mcp-gateway / review-raven の :main と、main push ごとに更新される
+# thread-owl の :latest を使いたい場合はこれらのターゲットを使用する。
 # ?= により環境変数・make コマンドライン引数での上書きが可能
 # 例: make pull-main MCP_GATEWAY_MAIN_IMAGE=ghcr.io/scottlz0310/mcp-gateway:edge
-MCP_GATEWAY_MAIN_IMAGE       ?= ghcr.io/scottlz0310/mcp-gateway:main
+MCP_GATEWAY_MAIN_IMAGE ?= ghcr.io/scottlz0310/mcp-gateway:main
 REVIEW_RAVEN_MAIN_IMAGE ?= ghcr.io/scottlz0310/review-raven:main
+THREAD_OWL_MAIN_IMAGE ?= ghcr.io/scottlz0310/thread-owl:latest
 
 .PHONY: pull-main
 pull-main: ## 最新開発版イメージを取得（リリース前 main ブランチビルド）
 	docker compose pull github-mcp
 	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
 	REVIEW_RAVEN_IMAGE=$(REVIEW_RAVEN_MAIN_IMAGE) \
-	docker compose pull mcp-gateway review-raven
+	THREAD_OWL_IMAGE=$(THREAD_OWL_MAIN_IMAGE) \
+	docker compose pull mcp-gateway review-raven thread-owl
 ifeq ($(OS),Windows_NT)
-	@echo $$'\u2713 :main \u30a4\u30e1\u30fc\u30b8\u3092\u53d6\u5f97\u3057\u307e\u3057\u305f\u3002\u8d77\u52d5: make start-main'
+	@echo $$'\u2713 \u958b\u767a\u7248\u30a4\u30e1\u30fc\u30b8\u3092\u53d6\u5f97\u3057\u307e\u3057\u305f\u3002\u8d77\u52d5: make start-main'
 else
-	@echo "✓ :main イメージを取得しました。起動: make start-main"
+	@echo "✓ 開発版イメージを取得しました。起動: make start-main"
 endif
 
 .PHONY: start-main
@@ -142,7 +144,8 @@ start-main: ## 最新開発版イメージで全サービスを起動
 	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET are required (legacy: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET). Set them in .env or as environment variables.))
 	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
 	REVIEW_RAVEN_IMAGE=$(REVIEW_RAVEN_MAIN_IMAGE) \
-	docker compose up -d github-mcp review-raven mcp-gateway playwright-mcp
+	THREAD_OWL_IMAGE=$(THREAD_OWL_MAIN_IMAGE) \
+	docker compose up -d github-mcp review-raven thread-owl mcp-gateway playwright-mcp
 	@echo "Started mcp-gateway endpoint (main build): http://127.0.0.1:$(or $(MCP_GATEWAY_PORT),8080)"
 
 .PHONY: restart-main

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ mcp-docker register --agent all --yes
 | `make status` / `make status-gateway` | 全コンテナ状態一覧 |
 | `make logs` / `make logs-gateway` | mcp-gateway ログ表示 |
 | `make pull` / `make pull-gateway` | 全イメージ更新 |
-| `make pull-main` | mcp-gateway / review-raven の `:main` イメージ取得 |
+| `make pull-main` | mcp-gateway / review-raven の `:main` と thread-owl の main build（`:latest`）を取得 |
 | `make start-main` | 最新開発版イメージで全サービス起動 |
 | `make restart-main` | 最新開発版イメージで全サービス再起動 |
 | `make register` | 対話的に IDE/CLI と MCP サーバーを選択して登録 |


### PR DESCRIPTION
## 概要

`make pull-main` / `make start-main` の開発版対象に `thread-owl` を追加します。

## 背景

`thread-owl` の main push で更新されるイメージは `ghcr.io/scottlz0310/thread-owl:latest` ですが、既存ターゲットは `mcp-gateway` と `review-raven` だけを明示していました。そのためローカルに古い `thread-owl:latest` がある環境では、PR #78 の JWT クロックドリフト修正を含む新しいイメージへ更新されませんでした。

## 変更内容

- `THREAD_OWL_MAIN_IMAGE` を追加（既定値は main build が公開される `thread-owl:latest`）
- `pull-main` で `thread-owl` を pull
- `start-main` で同じイメージ指定を使って `thread-owl` を起動
- README の対象サービス説明を更新

## 検証

- `make -n pull-main`
- `make -n start-main OAUTH_CLIENT_ID=dummy OAUTH_CLIENT_SECRET=dummy`
- 対象3イメージの manifest 存在確認
- `make pull-main` の実行成功
- pre-commit: `go vet ./...`
- pre-push: shell lint / `go test ./...`

## 依存関係

PR #161 の名称変更後の Makefile を前提とする stacked PR です。#161 マージ後に base を `main` へ変更します。