### PR TITLE
fix: Makefile の pull-main / start-main に thread-owl を追加 (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `scripts/health-check.sh --service` の対象名も `copilot-review-mcp` → `review-raven`
   - MCP ツール名（`start_copilot_review_watch` 等）は review-raven でも同名のため変更なし
 
+### 🔧 改善
+
+- `make pull-main` / `make start-main` の開発版対象に thread-owl を追加 — #163
+  - thread-owl のタグ分離（`:main` = 開発ビルド / `:latest` + `:vX.Y.Z` = 安定リリース）に追従
+  - `THREAD_OWL_MAIN_IMAGE ?= ghcr.io/scottlz0310/thread-owl:main` を追加し、`pull-main` / `start-main` が thread-owl も `:main` を取得・起動
+  - `make start-gateway` は従来通り `:latest`（安定版）で起動
+
 ### 📝 ドキュメント
 
 - review platform における Mcp-Docker の責務を明文化 — #158

--- a/Makefile
+++ b/Makefile
@@ -119,19 +119,21 @@ pull: pull-gateway ## 全サービスの Docker イメージを取得（pull-gat
 status: status-gateway ## 全サービスの状態確認（status-gateway のエイリアス）
 
 # :main イメージ（リリース前の最新開発版）
-# mcp-gateway / review-raven は :latest がリリース時のみ更新されるため、
+# mcp-gateway / review-raven / thread-owl は :latest がリリース時のみ更新されるため、
 # 最新の main ブランチビルドを使いたい場合はこれらのターゲットを使用する。
 # ?= により環境変数・make コマンドライン引数での上書きが可能
 # 例: make pull-main MCP_GATEWAY_MAIN_IMAGE=ghcr.io/scottlz0310/mcp-gateway:edge
 MCP_GATEWAY_MAIN_IMAGE       ?= ghcr.io/scottlz0310/mcp-gateway:main
 REVIEW_RAVEN_MAIN_IMAGE ?= ghcr.io/scottlz0310/review-raven:main
+THREAD_OWL_MAIN_IMAGE ?= ghcr.io/scottlz0310/thread-owl:main
 
 .PHONY: pull-main
 pull-main: ## 最新開発版イメージを取得（リリース前 main ブランチビルド）
 	docker compose pull github-mcp
 	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
 	REVIEW_RAVEN_IMAGE=$(REVIEW_RAVEN_MAIN_IMAGE) \
-	docker compose pull mcp-gateway review-raven
+	THREAD_OWL_IMAGE=$(THREAD_OWL_MAIN_IMAGE) \
+	docker compose pull mcp-gateway review-raven thread-owl
 ifeq ($(OS),Windows_NT)
 	@echo $$'\u2713 :main \u30a4\u30e1\u30fc\u30b8\u3092\u53d6\u5f97\u3057\u307e\u3057\u305f\u3002\u8d77\u52d5: make start-main'
 else
@@ -143,7 +145,8 @@ start-main: ## 最新開発版イメージで全サービスを起動
 	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET are required (legacy: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET). Set them in .env or as environment variables.))
 	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
 	REVIEW_RAVEN_IMAGE=$(REVIEW_RAVEN_MAIN_IMAGE) \
-	docker compose up -d --remove-orphans github-mcp review-raven mcp-gateway playwright-mcp
+	THREAD_OWL_IMAGE=$(THREAD_OWL_MAIN_IMAGE) \
+	docker compose up -d --remove-orphans github-mcp review-raven thread-owl mcp-gateway playwright-mcp
 	@echo "Started mcp-gateway endpoint (main build): http://127.0.0.1:$(or $(MCP_GATEWAY_PORT),8080)"
 
 .PHONY: restart-main

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ mcp-docker register --agent all --yes
 | `make status` / `make status-gateway` | 全コンテナ状態一覧 |
 | `make logs` / `make logs-gateway` | mcp-gateway ログ表示 |
 | `make pull` / `make pull-gateway` | 全イメージ更新 |
-| `make pull-main` | mcp-gateway / review-raven の `:main` イメージ取得 |
+| `make pull-main` | mcp-gateway / review-raven / thread-owl の `:main` イメージ取得 |
 | `make start-main` | 最新開発版イメージで全サービス起動 |
 | `make restart-main` | 最新開発版イメージで全サービス再起動 |
 | `make register` | 対話的に IDE/CLI と MCP サーバーを選択して登録 |


### PR DESCRIPTION
## Summary

- `THREAD_OWL_MAIN_IMAGE ?= ghcr.io/scottlz0310/thread-owl:main` 変数を追加
- `make pull-main` が thread-owl の `:main` イメージも取得するよう対応
- `make start-main` が thread-owl も `:main` イメージで起動するよう対応
- README.md の `pull-main` 説明文を更新
- CHANGELOG.md に改善内容を追記

## 背景

thread-owl はタグ分離設計（`:main` = 開発ビルド / `:latest` + `:vX.Y.Z` = 安定リリース）を採用しているため、`pull-main` / `start-main` が `:main` を取得・起動する必要がある。`make start-gateway` は従来通り `:latest`（安定版）で動作する。

## Test plan

- [ ] `make pull-main` が `mcp-gateway`, `review-raven`, `thread-owl` の `:main` イメージを取得することを確認
- [ ] `make start-main` が thread-owl を `:main` イメージで起動することを確認
- [ ] `THREAD_OWL_MAIN_IMAGE=...` の環境変数上書きが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)