### PR TITLE
fix: verify-mcp-endpoint.js が Accept ヘッダー不足で HTTP 406 エラーになる問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `scripts/verify-mcp-endpoint.js` が `Accept` ヘッダー不足で HTTP 406 エラーになる問題を修正 — #168
   - mcp-gateway が要求する `Accept: application/json, text/event-stream` を送信するように変更
+  - レスポンスが `text/event-stream` (SSE フレーミング) の場合に `data:` 行を抽出して JSON パースするように変更
 
 ## [2.13.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 バグ修正
+
+- `scripts/verify-mcp-endpoint.js` が `Accept` ヘッダー不足で HTTP 406 エラーになる問題を修正 — #168
+  - mcp-gateway が要求する `Accept: application/json, text/event-stream` を送信するように変更
+
 ## [2.13.0] - 2026-06-11
 
 ### ⚠️ 破壊的変更

--- a/scripts/verify-mcp-endpoint.js
+++ b/scripts/verify-mcp-endpoint.js
@@ -31,6 +31,7 @@ const options = {
   headers: {
     'Content-Type': 'application/json',
     'Content-Length': Buffer.byteLength(body),
+    'Accept': 'application/json, text/event-stream',
   },
 };
 

--- a/scripts/verify-mcp-endpoint.js
+++ b/scripts/verify-mcp-endpoint.js
@@ -53,7 +53,18 @@ const req = transport.request(options, (res) => {
 
     console.log(`✅ HTTP Status: ${status}`);
     try {
-      const json = JSON.parse(data);
+      let rawData = data;
+      const contentType = res.headers['content-type'] || '';
+      if (contentType.includes('text/event-stream')) {
+        const lines = data.split(/\r?\n/);
+        const dataLine = lines.find(line => line.startsWith('data:'));
+        if (dataLine) {
+          rawData = dataLine.slice(5).trim();
+        } else {
+          throw new Error('SSE レスポンス内に data: 行が見つかりませんでした。');
+        }
+      }
+      const json = JSON.parse(rawData);
       const hasValidResult =
         json &&
         typeof json === 'object' &&


### PR DESCRIPTION
## 概要

`scripts/verify-mcp-endpoint.js` で MCP エンドポイントの疎通確認を行うと、mcp-gateway のバリデーションにより HTTP 406 (Not Acceptable) が返され失敗する問題を修正します。

## 変更内容

- HTTP リクエストの headers に `Accept: application/json, text/event-stream` を追加
- CHANGELOG.md の `[Unreleased]` に記載

## 背景

mcp-gateway はクライアントの `Accept` ヘッダーに `application/json` と `text/event-stream` の両方が含まれることを要求するが、本スクリプトは `Accept` ヘッダーを送信していなかった。

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)