### PR TITLE
fix(compose): ROUTE_* に Compose 互換の変数展開を適用し cloudflare の serverUrl 破損を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 バグ修正
+
+- `mcp-docker register` が `ROUTE_*` の Compose 変数展開に未対応で、cloudflare の serverUrl が壊れた値のまま agent に登録される問題を修正 — #167
+  - `ROUTE_*` 値に Compose 互換の変数展開（`${VAR}` / `${VAR:-default}` / `${VAR:+alternative}`）を適用
+  - `${VAR:+...}` の変数未設定などで展開後に空になったルートは登録対象からスキップ（gateway 側の空 `ROUTE_*` スキップと整合）
+
 ## [2.13.0] - 2026-06-11
 
 ### ⚠️ 破壊的変更

--- a/internal/compose/parse.go
+++ b/internal/compose/parse.go
@@ -45,7 +45,9 @@ func Parse(data []byte, lookup func(string) (string, bool)) ([]register.Server, 
 	}
 	port := defaultGatewayPort
 	if raw, ok := env["MCP_GATEWAY_PORT"]; ok {
-		port = resolveEnvExpression(raw, lookup, defaultGatewayPort)
+		if expanded := strings.TrimSpace(expandComposeVars(raw, lookup)); expanded != "" {
+			port = expanded
+		}
 	}
 	if val, ok := lookup("MCP_GATEWAY_PORT"); ok && val != "" {
 		port = val
@@ -61,7 +63,13 @@ func Parse(data []byte, lookup func(string) (string, bool)) ([]register.Server, 
 
 	servers := make([]register.Server, 0, len(keys))
 	for _, key := range keys {
-		path, _, _ := strings.Cut(env[key], "|")
+		value := strings.TrimSpace(expandComposeVars(env[key], lookup))
+		if value == "" {
+			// ${VAR:+...} の変数未設定などで空になったルートは、
+			// gateway 側（空 ROUTE_* スキップ）と同様に登録対象外とする
+			continue
+		}
+		path, _, _ := strings.Cut(value, "|")
 		path = strings.TrimSpace(path)
 		if path == "" {
 			return nil, fmt.Errorf("%s has empty route path", key)
@@ -109,21 +117,28 @@ func routeName(key string) string {
 	return strings.ReplaceAll(name, "_", "-")
 }
 
-var envExpr = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*)(:-([^}]*))?\}$`)
+var composeVarExpr = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)(?::([-+])([^}]*))?\}`)
 
-func resolveEnvExpression(raw string, lookup func(string) (string, bool), fallback string) string {
-	match := envExpr.FindStringSubmatch(raw)
-	if match == nil {
-		if raw == "" {
-			return fallback
+// expandComposeVars は Compose 互換の変数展開
+// （${VAR} / ${VAR:-default} / ${VAR:+alternative}）を raw 全体に適用する。
+func expandComposeVars(raw string, lookup func(string) (string, bool)) string {
+	return composeVarExpr.ReplaceAllStringFunc(raw, func(expr string) string {
+		match := composeVarExpr.FindStringSubmatch(expr)
+		val, ok := lookup(match[1])
+		hasValue := ok && val != ""
+		switch match[2] {
+		case "-":
+			if hasValue {
+				return val
+			}
+			return match[3]
+		case "+":
+			if hasValue {
+				return match[3]
+			}
+			return ""
+		default:
+			return val
 		}
-		return raw
-	}
-	if val, ok := lookup(match[1]); ok && val != "" {
-		return val
-	}
-	if match[3] != "" {
-		return match[3]
-	}
-	return fallback
+	})
 }

--- a/internal/compose/parse.go
+++ b/internal/compose/parse.go
@@ -45,7 +45,11 @@ func Parse(data []byte, lookup func(string) (string, bool)) ([]register.Server, 
 	}
 	port := defaultGatewayPort
 	if raw, ok := env["MCP_GATEWAY_PORT"]; ok {
-		if expanded := strings.TrimSpace(expandComposeVars(raw, lookup)); expanded != "" {
+		expanded := expandComposeVars(raw, lookup)
+		if strings.Contains(expanded, "${") {
+			fmt.Fprintf(os.Stderr, "warning: MCP_GATEWAY_PORT contains unsupported variable expansion syntax: %s\n", expanded)
+		}
+		if expanded = strings.TrimSpace(expanded); expanded != "" {
 			port = expanded
 		}
 	}
@@ -63,7 +67,11 @@ func Parse(data []byte, lookup func(string) (string, bool)) ([]register.Server, 
 
 	servers := make([]register.Server, 0, len(keys))
 	for _, key := range keys {
-		value := strings.TrimSpace(expandComposeVars(env[key], lookup))
+		expanded := expandComposeVars(env[key], lookup)
+		if strings.Contains(expanded, "${") {
+			fmt.Fprintf(os.Stderr, "warning: %s contains unsupported variable expansion syntax: %s\n", key, expanded)
+		}
+		value := strings.TrimSpace(expanded)
 		if value == "" {
 			// ${VAR:+...} の変数未設定などで空になったルートは、
 			// gateway 側（空 ROUTE_* スキップ）と同様に登録対象外とする

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -1,6 +1,9 @@
 package compose
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseRoutesFromComposeEnvironment(t *testing.T) {
 	data := []byte(`
@@ -53,5 +56,66 @@ services:
 	}
 	if got, want := servers[0].URL, "http://127.0.0.1:18080/mcp/github"; got != want {
 		t.Fatalf("URL = %q, want %q", got, want)
+	}
+}
+
+func TestParseExpandsRouteVariables(t *testing.T) {
+	const cloudflareRoute = "ROUTE_CLOUDFLARE=${CLOUDFLARE_API_TOKEN:+/mcp/cloudflare|https://mcp.cloudflare.com/mcp|auth=oauth|upstream_bearer_token_env=CLOUDFLARE_API_TOKEN}"
+
+	tests := []struct {
+		name   string
+		env    map[string]string
+		routes []string
+		want   map[string]string
+	}{
+		{
+			name:   "変数設定済みなら :+ ルートが登録される",
+			env:    map[string]string{"CLOUDFLARE_API_TOKEN": "dummy-token"},
+			routes: []string{cloudflareRoute},
+			want:   map[string]string{"cloudflare": "http://127.0.0.1:8080/mcp/cloudflare"},
+		},
+		{
+			name:   "変数未設定なら :+ ルートはスキップされる",
+			env:    map[string]string{},
+			routes: []string{cloudflareRoute},
+			want:   map[string]string{},
+		},
+		{
+			name: "path 内の ${VAR} と ${VAR:-default} を展開する",
+			env:  map[string]string{"GITHUB_PATH": "/mcp/github"},
+			routes: []string{
+				"ROUTE_GITHUB=${GITHUB_PATH}|http://github-mcp:8082",
+				"ROUTE_PLAYWRIGHT=${PLAYWRIGHT_PATH:-/mcp/playwright}|http://playwright-mcp:8931|auth=none",
+			},
+			want: map[string]string{
+				"github":     "http://127.0.0.1:8080/mcp/github",
+				"playwright": "http://127.0.0.1:8080/mcp/playwright",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := []string{"services:", "  mcp-gateway:", "    environment:"}
+			for _, route := range tt.routes {
+				lines = append(lines, "      - "+route)
+			}
+			data := []byte(strings.Join(lines, "\n") + "\n")
+
+			servers, err := Parse(data, func(key string) (string, bool) {
+				val, ok := tt.env[key]
+				return val, ok
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(servers) != len(tt.want) {
+				t.Fatalf("got %d servers (%v), want %d", len(servers), servers, len(tt.want))
+			}
+			for _, server := range servers {
+				if got := server.URL; got != tt.want[server.Name] {
+					t.Fatalf("%s URL = %q, want %q", server.Name, got, tt.want[server.Name])
+				}
+			}
+		})
 	}
 }

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -119,3 +119,25 @@ func TestParseExpandsRouteVariables(t *testing.T) {
 		})
 	}
 }
+
+func TestParseHandlesUnsupportedVariables(t *testing.T) {
+	data := []byte(`
+services:
+  mcp-gateway:
+    environment:
+      - ROUTE_GITHUB=${UNSUPPORTED-default}|http://github-mcp:8082
+`)
+	servers, err := Parse(data, func(key string) (string, bool) {
+		return "", false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("got %d servers, want 1", len(servers))
+	}
+	if got, want := servers[0].URL, "http://127.0.0.1:8080/${UNSUPPORTED-default}"; got != want {
+		t.Fatalf("URL = %q, want %q", got, want)
+	}
+}
+


### PR DESCRIPTION
## 概要

`make register`（`mcp-docker register`）で生成される agent 設定の cloudflare エントリが、`${CLOUDFLARE_API_TOKEN:+...}` 構文を含む壊れた serverUrl になる問題を修正します。

## 変更内容

- `internal/compose/parse.go` に Compose 互換の変数展開 `expandComposeVars` を追加
  - `${VAR}` / `${VAR:-default}` / `${VAR:+alternative}` に対応し、値全体（文字列途中の埋め込みも含む）を展開
  - `ROUTE_*` 値と `MCP_GATEWAY_PORT` の両方に適用
- 展開後に空になったルート（`${VAR:+...}` で変数未設定の場合など）は登録対象からスキップ
  - mcp-gateway v0.5.1 の空 `ROUTE_*` スキップ挙動と整合
- `${VAR:-default}` の全体一致のみ対応だった `resolveEnvExpression` を削除し、`expandComposeVars` に統一
- テーブル駆動テストを追加（cloudflare ルートの登録/スキップ、path 内変数の展開）

## 動作確認

`mcp-docker register --agent claude --server all --dry-run --yes` にて:

- `CLOUDFLARE_API_TOKEN` 設定時: `http://127.0.0.1:8080/mcp/cloudflare` が正しく登録計画に含まれる
- 未設定時: cloudflare ルートがスキップされる

`go vet ./...` / `go test ./...` パス済み。

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)