### PR TITLE
feat(register): 計画外になった gateway 配下エントリの削除（prune）を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ 機能追加
+
+- `mcp-docker register` に stale エントリ削除（prune）を追加 — #171
+  - `--prune` で、登録計画に含まれなくなった gateway 配下（`http://127.0.0.1:<port>/...`）の既存登録を削除候補として提示・削除
+  - gateway 配下以外の URL・URL 不明のエントリ（mcp-docker 管理外の可能性があるもの）は候補に含めない
+  - 対話モードでは削除候補を番号選択（既定は削除しない）し、削除実行前に対象一覧つきの最終確認を表示
+  - 非対話モードでは候補一覧と y/N 確認を表示し、`--yes` 指定時のみ確認を省略
+  - 選択プロンプトに複数選択の入力例（`1,3 / all / none`）を表示
+
 ### 🐛 バグ修正
 
 - `mcp-docker register` が `ROUTE_*` の Compose 変数展開に未対応で、cloudflare の serverUrl が壊れた値のまま agent に登録される問題を修正 — #167

--- a/README.md
+++ b/README.md
@@ -132,6 +132,23 @@ make register-all          REGISTER_FLAGS=--yes
 make register REGISTER_FLAGS="--agent claude,antigravity --server github,playwright --yes"
 ```
 
+#### stale エントリの削除（prune）
+
+route の削除や `${VAR:+...}` の変数未設定スキップなどで登録計画から外れたエントリは、登録だけでは agent 設定に残り続けます。`--prune` を指定すると、**gateway 配下（`http://127.0.0.1:<port>/...`）の URL を持ち、かつ現在の計画に含まれない**既存登録を削除候補として提示・削除します。gateway 配下以外の URL や URL を特定できないエントリ（mcp-docker 管理外の可能性があるもの）は候補に含めません。
+
+```bash
+# 候補の確認だけ（削除しない）
+make register REGISTER_FLAGS="--agent claude --dry-run --prune"
+
+# 候補一覧を表示し y/N 確認のうえ削除
+make register REGISTER_FLAGS="--agent claude --prune"
+
+# 確認なしで削除（自動化向け）
+make register REGISTER_FLAGS="--agent all --yes --prune"
+```
+
+対話モード（`make register`）では `--prune` の指定がなくても、登録後に削除候補があれば番号選択で提示します。既定（Enter）は「削除しない」で、削除実行前には必ず対象一覧つきの最終確認が入ります。
+
 Makefile 経由のビルド成果物は OS に合わせて決まります。Windows (`OS=Windows_NT`) では `bin/mcp-docker.exe` を生成し、`register-*` も `.exe` 付きのバイナリを実行します。Linux/macOS では従来通り `bin/mcp-docker` です。
 
 Makefile を使わず Go ツールチェーンから直接ビルド・実行する場合：

--- a/cmd/mcp-docker/interactive.go
+++ b/cmd/mcp-docker/interactive.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/scottlz0310/mcp-docker/v2/internal/register"
 )
 
 var errAborted = errors.New("ユーザーが中止しました")
@@ -32,7 +34,7 @@ func promptSelection(reader *bufio.Reader, stdout io.Writer, label string, items
 	for i, item := range items {
 		fmt.Fprintf(stdout, "  %d) %s\n", i+1, item)
 	}
-	fmt.Fprint(stdout, "入力: ")
+	fmt.Fprint(stdout, "入力 (例: 1,3 / all / none): ")
 	line, err := reader.ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
@@ -54,6 +56,35 @@ func parseSelection(input string, items []string) ([]string, error) {
 		return nil, errAborted
 	}
 
+	out, err := parseSelectionTokens(input, items)
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("少なくとも 1 つ選択してください")
+	}
+	return out, nil
+}
+
+// parsePruneSelection は削除対象の選択を解析する。
+// 削除は安全側に倒すため、parseSelection と異なり空入力・none は「何も削除しない」を意味する。
+func parsePruneSelection(input string, items []string) ([]string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" || strings.EqualFold(input, "none") {
+		return nil, nil
+	}
+	if strings.EqualFold(input, "q") {
+		return nil, errAborted
+	}
+	if strings.EqualFold(input, "all") {
+		out := make([]string, len(items))
+		copy(out, items)
+		return out, nil
+	}
+	return parseSelectionTokens(input, items)
+}
+
+func parseSelectionTokens(input string, items []string) ([]string, error) {
 	var out []string
 	seen := make(map[string]struct{})
 	for raw := range strings.SplitSeq(input, ",") {
@@ -71,9 +102,6 @@ func parseSelection(input string, items []string) ([]string, error) {
 		seen[name] = struct{}{}
 		out = append(out, name)
 	}
-	if len(out) == 0 {
-		return nil, fmt.Errorf("少なくとも 1 つ選択してください")
-	}
 	return out, nil
 }
 
@@ -90,4 +118,49 @@ func resolveSelectionToken(token string, items []string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("不明な選択肢 %q (利用可能: %s)", token, strings.Join(items, ", "))
+}
+
+func promptPruneSelection(reader *bufio.Reader, stdout io.Writer, agentName string, entries []register.Entry) ([]register.Entry, error) {
+	fmt.Fprintf(stdout, "%s: 計画に含まれない gateway 配下の登録が見つかりました。削除するものを選択 [none]:\n", agentName)
+	for i, entry := range entries {
+		fmt.Fprintf(stdout, "  %d) %s (%s)\n", i+1, entry.Name, entry.URL)
+	}
+	fmt.Fprint(stdout, "入力 (例: 1,3 / all / none): ")
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	if errors.Is(err, io.EOF) && !strings.HasSuffix(line, "\n") {
+		return nil, errAborted
+	}
+
+	names := make([]string, len(entries))
+	byName := make(map[string]register.Entry, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name
+		byName[entry.Name] = entry
+	}
+	selected, err := parsePruneSelection(line, names)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]register.Entry, 0, len(selected))
+	for _, name := range selected {
+		out = append(out, byName[name])
+	}
+	return out, nil
+}
+
+func confirmPrune(reader *bufio.Reader, stdout io.Writer, agentName string, entries []register.Entry) (bool, error) {
+	fmt.Fprintf(stdout, "%s: 以下の %d 件を削除します:\n", agentName, len(entries))
+	for _, entry := range entries {
+		fmt.Fprintf(stdout, "  - %s (%s)\n", entry.Name, entry.URL)
+	}
+	fmt.Fprint(stdout, "削除を実行しますか？ [y/N]: ")
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
 }

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -18,7 +18,7 @@ import (
 const usage = `mcp-docker は MCP Docker の補助ワークフローを管理します。
 
 使い方:
-  mcp-docker register [--agent <csv>|all] [--server <csv>|all] [--compose path] [--external path] [--interactive] [--yes] [--dry-run]
+  mcp-docker register [--agent <csv>|all] [--server <csv>|all] [--compose path] [--external path] [--interactive] [--yes] [--dry-run] [--prune]
   mcp-docker version
   mcp-docker --version
   mcp-docker -v
@@ -70,6 +70,7 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 	fs.BoolVar(&opts.yes, "yes", false, "サジェスト名を確認なしで採用")
 	fs.BoolVar(&opts.dryRun, "dry-run", false, "実行せず、登録時に使うコマンドと条件を表示")
 	fs.BoolVar(&opts.interactive, "interactive", false, "agent/server を対話的に選択")
+	fs.BoolVar(&opts.prune, "prune", false, "計画に含まれない gateway 配下の既存登録を削除（候補確認のため各 agent の list を実行）")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -146,18 +147,71 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 	if err != nil {
 		return err
 	}
+	pruneEnabled := opts.prune || useInteractive
+	var gatewayOrigin string
+	if pruneEnabled {
+		gatewayOrigin, err = compose.GatewayOrigin(opts.composePath)
+		if err != nil {
+			return err
+		}
+	}
+
 	execRunner := register.ExecRunner{}
 	for _, spec := range selected {
 		agent := spec.newAgent(execRunner)
 		if opts.dryRun {
 			register.PrintPlan(stdout, agent, selectedServers)
+		} else if err := register.Register(ctx, stdout, agent, selectedServers); err != nil {
+			return err
+		}
+		if !pruneEnabled {
 			continue
 		}
-		if err := register.Register(ctx, stdout, agent, selectedServers); err != nil {
+		if err := pruneAgent(ctx, stdinReader, stdout, agent, servers, gatewayOrigin, opts, useInteractive); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// pruneAgent は agent に登録済みで現在の登録計画に含まれない gateway 配下のエントリを削除する。
+// interactive では候補を個別選択（既定は削除しない）し、削除前に必ず最終確認を行う。
+// 非対話では --yes 指定時のみ確認を省略する。
+func pruneAgent(ctx context.Context, reader *bufio.Reader, stdout io.Writer, agent register.Agent, available []register.Server, gatewayOrigin string, opts registerOptions, interactive bool) error {
+	stale, err := register.StaleEntries(ctx, agent, available, gatewayOrigin)
+	if err != nil {
+		return err
+	}
+	if len(stale) == 0 {
+		fmt.Fprintf(stdout, "%s: 削除対象の stale エントリはありません\n", agent.Name())
+		return nil
+	}
+	if opts.dryRun {
+		register.PrintPrunePlan(stdout, agent, stale)
+		return nil
+	}
+	targets := stale
+	if interactive {
+		targets, err = promptPruneSelection(reader, stdout, agent.Name(), stale)
+		if err != nil {
+			return err
+		}
+		if len(targets) == 0 {
+			fmt.Fprintf(stdout, "%s: stale エントリの削除をスキップしました\n", agent.Name())
+			return nil
+		}
+	}
+	if interactive || !opts.yes {
+		ok, err := confirmPrune(reader, stdout, agent.Name(), targets)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintf(stdout, "%s: stale エントリの削除を中止しました\n", agent.Name())
+			return nil
+		}
+	}
+	return register.Prune(ctx, stdout, agent, targets)
 }
 
 type registerOptions struct {
@@ -168,6 +222,7 @@ type registerOptions struct {
 	yes          bool
 	dryRun       bool
 	interactive  bool
+	prune        bool
 }
 
 func loadServers(composePath, externalPath string) ([]register.Server, error) {

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -410,3 +410,164 @@ func equalStringSlices(a, b []string) bool {
 	}
 	return true
 }
+
+func TestParsePruneSelection(t *testing.T) {
+	items := []string{"cloudflare", "old-route", "legacy"}
+	cases := []struct {
+		name      string
+		input     string
+		want      []string
+		wantErr   bool
+		wantAbort bool
+	}{
+		{name: "empty means none", input: "", want: nil},
+		{name: "only whitespace means none", input: "   \n", want: nil},
+		{name: "explicit none", input: "none", want: nil},
+		{name: "none uppercase", input: "NONE", want: nil},
+		{name: "all selects everything", input: "all", want: items},
+		{name: "indices", input: "1,3", want: []string{"cloudflare", "legacy"}},
+		{name: "names", input: "old-route", want: []string{"old-route"}},
+		{name: "abort with q", input: "q", wantAbort: true},
+		{name: "out of range", input: "9", wantErr: true},
+		{name: "unknown name", input: "ghost", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePruneSelection(tc.input, items)
+			if tc.wantAbort {
+				if !errors.Is(err, errAborted) {
+					t.Fatalf("err = %v, want errAborted", err)
+				}
+				return
+			}
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalStringSlices(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type fakePruneAgent struct {
+	name    string
+	entries []register.Entry
+	removed []string
+}
+
+func (f *fakePruneAgent) Name() string { return f.name }
+
+func (f *fakePruneAgent) ListEntries(context.Context) ([]register.Entry, error) {
+	return f.entries, nil
+}
+
+func (f *fakePruneAgent) Add(context.Context, register.Server) error { return nil }
+
+func (f *fakePruneAgent) Remove(_ context.Context, name string) error {
+	f.removed = append(f.removed, name)
+	return nil
+}
+
+func (f *fakePruneAgent) OverwritesOnAdd() bool { return true }
+
+func (f *fakePruneAgent) AddCommand(s register.Server) []string { return []string{"add", s.Name} }
+
+func (f *fakePruneAgent) RemoveCommand(name string) []string { return []string{"remove", name} }
+
+func TestPruneAgent(t *testing.T) {
+	staleEntries := []register.Entry{
+		{Name: "cloudflare", URL: "http://127.0.0.1:8080/mcp/cloudflare"},
+		{Name: "old-route", URL: "http://127.0.0.1:8080/mcp/old-route"},
+	}
+	available := []register.Server{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}}
+	const origin = "http://127.0.0.1:8080/"
+
+	cases := []struct {
+		name        string
+		entries     []register.Entry
+		opts        registerOptions
+		interactive bool
+		input       string
+		wantRemoved []string
+		wantOutput  string
+	}{
+		{
+			name:       "stale なしは何もしない",
+			entries:    []register.Entry{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}},
+			opts:       registerOptions{prune: true, yes: true},
+			wantOutput: "削除対象の stale エントリはありません",
+		},
+		{
+			name:       "dry-run は計画のみ表示",
+			entries:    staleEntries,
+			opts:       registerOptions{prune: true, dryRun: true},
+			wantOutput: "stale エントリ削除計画",
+		},
+		{
+			name:        "非対話 --yes は全候補を削除",
+			entries:     staleEntries,
+			opts:        registerOptions{prune: true, yes: true},
+			wantRemoved: []string{"cloudflare", "old-route"},
+		},
+		{
+			name:        "非対話で y 入力なら削除",
+			entries:     staleEntries,
+			opts:        registerOptions{prune: true},
+			input:       "y\n",
+			wantRemoved: []string{"cloudflare", "old-route"},
+		},
+		{
+			name:       "非対話で n 入力なら中止",
+			entries:    staleEntries,
+			opts:       registerOptions{prune: true},
+			input:      "n\n",
+			wantOutput: "削除を中止しました",
+		},
+		{
+			name:        "対話で番号選択した候補だけ削除",
+			entries:     staleEntries,
+			interactive: true,
+			input:       "2\ny\n",
+			wantRemoved: []string{"old-route"},
+		},
+		{
+			name:        "対話で Enter は削除しない",
+			entries:     staleEntries,
+			interactive: true,
+			input:       "\n",
+			wantOutput:  "削除をスキップしました",
+		},
+		{
+			name:        "対話の最終確認で n なら中止",
+			entries:     staleEntries,
+			interactive: true,
+			input:       "all\nn\n",
+			wantOutput:  "削除を中止しました",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := &fakePruneAgent{name: "claude", entries: tc.entries}
+			var stdout bytes.Buffer
+			reader := bufio.NewReader(strings.NewReader(tc.input))
+
+			err := pruneAgent(context.Background(), reader, &stdout, agent, available, origin, tc.opts, tc.interactive)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !equalStringSlices(agent.removed, tc.wantRemoved) {
+				t.Fatalf("removed = %v, want %v", agent.removed, tc.wantRemoved)
+			}
+			if tc.wantOutput != "" && !strings.Contains(stdout.String(), tc.wantOutput) {
+				t.Fatalf("output = %q, missing %q", stdout.String(), tc.wantOutput)
+			}
+		})
+	}
+}

--- a/internal/compose/parse.go
+++ b/internal/compose/parse.go
@@ -30,32 +30,16 @@ func Load(path string) ([]register.Server, error) {
 }
 
 func Parse(data []byte, lookup func(string) (string, bool)) ([]register.Server, error) {
-	var file composeFile
-	if err := yaml.Unmarshal(data, &file); err != nil {
-		return nil, err
-	}
-	gateway, ok := file.Services["mcp-gateway"]
-	if !ok {
-		return nil, fmt.Errorf("services.mcp-gateway not found")
-	}
-
-	env, err := environmentMap(gateway.Environment)
+	env, err := gatewayEnv(data)
 	if err != nil {
 		return nil, err
 	}
-	port := defaultGatewayPort
 	if raw, ok := env["MCP_GATEWAY_PORT"]; ok {
-		expanded := expandComposeVars(raw, lookup)
-		if strings.Contains(expanded, "${") {
+		if expanded := expandComposeVars(raw, lookup); strings.Contains(expanded, "${") {
 			fmt.Fprintf(os.Stderr, "warning: MCP_GATEWAY_PORT contains unsupported variable expansion syntax: %s\n", expanded)
 		}
-		if expanded = strings.TrimSpace(expanded); expanded != "" {
-			port = expanded
-		}
 	}
-	if val, ok := lookup("MCP_GATEWAY_PORT"); ok && val != "" {
-		port = val
-	}
+	port := gatewayPort(env, lookup)
 
 	var keys []string
 	for key := range env {
@@ -93,6 +77,48 @@ func Parse(data []byte, lookup func(string) (string, bool)) ([]register.Server, 
 		})
 	}
 	return servers, nil
+}
+
+// GatewayOrigin は register が生成する URL の接頭辞（http://127.0.0.1:<port>/）を返す。
+func GatewayOrigin(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return gatewayOrigin(data, os.LookupEnv)
+}
+
+func gatewayOrigin(data []byte, lookup func(string) (string, bool)) (string, error) {
+	env, err := gatewayEnv(data)
+	if err != nil {
+		return "", err
+	}
+	return "http://127.0.0.1:" + gatewayPort(env, lookup) + "/", nil
+}
+
+func gatewayEnv(data []byte) (map[string]string, error) {
+	var file composeFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return nil, err
+	}
+	gateway, ok := file.Services["mcp-gateway"]
+	if !ok {
+		return nil, fmt.Errorf("services.mcp-gateway not found")
+	}
+	return environmentMap(gateway.Environment)
+}
+
+func gatewayPort(env map[string]string, lookup func(string) (string, bool)) string {
+	port := defaultGatewayPort
+	if raw, ok := env["MCP_GATEWAY_PORT"]; ok {
+		if expanded := strings.TrimSpace(expandComposeVars(raw, lookup)); expanded != "" {
+			port = expanded
+		}
+	}
+	if val, ok := lookup("MCP_GATEWAY_PORT"); ok && val != "" {
+		port = val
+	}
+	return port
 }
 
 func environmentMap(node yaml.Node) (map[string]string, error) {

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -120,6 +120,52 @@ func TestParseExpandsRouteVariables(t *testing.T) {
 	}
 }
 
+func TestGatewayOrigin(t *testing.T) {
+	const portYAML = `
+services:
+  mcp-gateway:
+    environment:
+      - MCP_GATEWAY_PORT=${MCP_GATEWAY_PORT:-9090}
+`
+	cases := []struct {
+		name string
+		yaml string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "environment 未定義ならデフォルトポート",
+			yaml: "services:\n  mcp-gateway: {}\n",
+			want: "http://127.0.0.1:8080/",
+		},
+		{
+			name: "compose の既定値を展開",
+			yaml: portYAML,
+			want: "http://127.0.0.1:9090/",
+		},
+		{
+			name: "実環境変数が優先される",
+			yaml: portYAML,
+			env:  map[string]string{"MCP_GATEWAY_PORT": "7000"},
+			want: "http://127.0.0.1:7000/",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := gatewayOrigin([]byte(tc.yaml), func(key string) (string, bool) {
+				val, ok := tc.env[key]
+				return val, ok
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("origin = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseHandlesUnsupportedVariables(t *testing.T) {
 	data := []byte(`
 services:
@@ -140,4 +186,3 @@ services:
 		t.Fatalf("URL = %q, want %q", got, want)
 	}
 }
-

--- a/internal/register/agent.go
+++ b/internal/register/agent.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 )
 
 var ErrUnsupported = errors.New("unsupported server for agent")
@@ -16,9 +17,15 @@ type Server struct {
 	Source   string
 }
 
+// Entry は agent に登録済みの MCP サーバー。URL が特定できない場合は空文字。
+type Entry struct {
+	Name string
+	URL  string
+}
+
 type Agent interface {
 	Name() string
-	List(context.Context) ([]string, error)
+	ListEntries(context.Context) ([]Entry, error)
 	Add(context.Context, Server) error
 	Remove(context.Context, string) error
 	OverwritesOnAdd() bool
@@ -31,12 +38,12 @@ func Register(ctx context.Context, out io.Writer, agent Agent, servers []Server)
 
 	existing := make(map[string]struct{})
 	if !agent.OverwritesOnAdd() {
-		names, err := agent.List(ctx)
+		entries, err := agent.ListEntries(ctx)
 		if err != nil {
 			return fmt.Errorf("%s list: %w", agent.Name(), err)
 		}
-		for _, name := range names {
-			existing[name] = struct{}{}
+		for _, entry := range entries {
+			existing[entry.Name] = struct{}{}
 		}
 	}
 
@@ -64,6 +71,49 @@ func Register(ctx context.Context, out io.Writer, agent Agent, servers []Server)
 		}
 	}
 	return nil
+}
+
+// StaleEntries は agent に登録済みのエントリのうち、gateway 配下の URL を持ち、
+// かつ現在の登録計画（available）に含まれないものを返す。
+// URL が特定できないエントリは mcp-docker 管理外の可能性があるため候補にしない。
+func StaleEntries(ctx context.Context, agent Agent, available []Server, gatewayOrigin string) ([]Entry, error) {
+	entries, err := agent.ListEntries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s list: %w", agent.Name(), err)
+	}
+	availableNames := make(map[string]struct{}, len(available))
+	for _, server := range available {
+		availableNames[server.Name] = struct{}{}
+	}
+	var stale []Entry
+	for _, entry := range entries {
+		if _, ok := availableNames[entry.Name]; ok {
+			continue
+		}
+		if entry.URL == "" || !strings.HasPrefix(entry.URL, gatewayOrigin) {
+			continue
+		}
+		stale = append(stale, entry)
+	}
+	return stale, nil
+}
+
+func Prune(ctx context.Context, out io.Writer, agent Agent, entries []Entry) error {
+	for _, entry := range entries {
+		fmt.Fprintf(out, "- %s: %s を削除します\n", entry.Name, entry.URL)
+		if err := agent.Remove(ctx, entry.Name); err != nil {
+			return fmt.Errorf("%s remove %q: %w", agent.Name(), entry.Name, err)
+		}
+	}
+	return nil
+}
+
+func PrintPrunePlan(out io.Writer, agent Agent, entries []Entry) {
+	fmt.Fprintf(out, "%s の stale エントリ削除計画:\n", agent.Name())
+	for _, entry := range entries {
+		fmt.Fprintf(out, "- %s (%s):\n", entry.Name, entry.URL)
+		fmt.Fprintf(out, "  - 削除: %s\n", shellish(agent.RemoveCommand(entry.Name)))
+	}
 }
 
 func PrintPlan(out io.Writer, agent Agent, servers []Server) {

--- a/internal/register/agents.go
+++ b/internal/register/agents.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -40,9 +41,9 @@ func NewAntigravityAgent(r Runner) Agent {
 	return AntigravityAgent{baseAgent: baseAgent{name: "antigravity", runner: r}}
 }
 
-func (a ClaudeAgent) List(ctx context.Context) ([]string, error) {
+func (a ClaudeAgent) ListEntries(ctx context.Context) ([]Entry, error) {
 	out, err := a.runner.Run(ctx, "claude", "mcp", "list")
-	return parseListNames(out), err
+	return parseListEntries(out), err
 }
 
 func (a ClaudeAgent) Add(ctx context.Context, s Server) error {
@@ -66,9 +67,9 @@ func (a ClaudeAgent) RemoveCommand(name string) []string {
 	return []string{"claude", "mcp", "remove", "--scope", "user", name}
 }
 
-func (a CopilotAgent) List(ctx context.Context) ([]string, error) {
+func (a CopilotAgent) ListEntries(ctx context.Context) ([]Entry, error) {
 	out, err := a.runner.Run(ctx, "gh", "copilot", "--", "mcp", "list")
-	return parseListNames(out), err
+	return parseListEntries(out), err
 }
 
 func (a CopilotAgent) Add(ctx context.Context, s Server) error {
@@ -92,9 +93,9 @@ func (a CopilotAgent) RemoveCommand(name string) []string {
 	return []string{"gh", "copilot", "--", "mcp", "remove", name}
 }
 
-func (a CodexAgent) List(ctx context.Context) ([]string, error) {
+func (a CodexAgent) ListEntries(ctx context.Context) ([]Entry, error) {
 	out, err := a.runner.Run(ctx, "codex", "mcp", "list")
-	return parseListNames(out), err
+	return parseListEntries(out), err
 }
 
 func (a CodexAgent) Add(ctx context.Context, s Server) error {
@@ -129,10 +130,10 @@ func runCommand(ctx context.Context, runner Runner, command []string) error {
 	return err
 }
 
-func parseListNames(output string) []string {
-	var names []string
+func parseListEntries(output string) []Entry {
+	var entries []Entry
 	seen := make(map[string]struct{})
-	for _, line := range strings.Split(output, "\n") {
+	for line := range strings.SplitSeq(output, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -142,12 +143,8 @@ func parseListNames(output string) []string {
 			continue
 		}
 
-		name := line
-		if before, _, ok := strings.Cut(name, ":"); ok {
-			name = before
-		} else {
-			name = strings.Fields(name)[0]
-		}
+		name := strings.Fields(line)[0]
+		name = strings.TrimSuffix(name, ":")
 		name = strings.Trim(name, "`'\"")
 		if name == "" {
 			continue
@@ -156,9 +153,19 @@ func parseListNames(output string) []string {
 			continue
 		}
 		seen[name] = struct{}{}
-		names = append(names, name)
+		entries = append(entries, Entry{Name: name, URL: firstURL(line)})
 	}
-	return names
+	return entries
+}
+
+// firstURL は行内の最初の http(s) URL トークンを返す。見つからなければ空文字。
+func firstURL(line string) string {
+	for field := range strings.FieldsSeq(line) {
+		if strings.HasPrefix(field, "http://") || strings.HasPrefix(field, "https://") {
+			return field
+		}
+	}
+	return ""
 }
 
 type AntigravityAgent struct {
@@ -177,7 +184,7 @@ func (a AntigravityAgent) getConfigPath() (string, error) {
 	return filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json"), nil
 }
 
-func (a AntigravityAgent) List(ctx context.Context) ([]string, error) {
+func (a AntigravityAgent) ListEntries(ctx context.Context) ([]Entry, error) {
 	path, err := a.getConfigPath()
 	if err != nil {
 		return nil, err
@@ -201,11 +208,18 @@ func (a AntigravityAgent) List(ctx context.Context) ([]string, error) {
 	if !ok {
 		return nil, nil
 	}
-	var names []string
-	for name := range mcpServers {
-		names = append(names, name)
+	entries := make([]Entry, 0, len(mcpServers))
+	for name, raw := range mcpServers {
+		entry := Entry{Name: name}
+		if obj, ok := raw.(map[string]any); ok {
+			if u, ok := obj["serverUrl"].(string); ok {
+				entry.URL = u
+			}
+		}
+		entries = append(entries, entry)
 	}
-	return names, nil
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	return entries, nil
 }
 
 func (a AntigravityAgent) Add(ctx context.Context, s Server) error {
@@ -213,9 +227,9 @@ func (a AntigravityAgent) Add(ctx context.Context, s Server) error {
 	if err != nil {
 		return err
 	}
-	
+
 	var config map[string]any
-	
+
 	data, err := os.ReadFile(path)
 	if err == nil {
 		if err := json.Unmarshal(data, &config); err != nil {
@@ -224,11 +238,11 @@ func (a AntigravityAgent) Add(ctx context.Context, s Server) error {
 	} else if !os.IsNotExist(err) {
 		return err
 	}
-	
+
 	if config == nil {
 		config = make(map[string]any)
 	}
-	
+
 	mcpServersAny, exists := config["mcpServers"]
 	var mcpServers map[string]any
 	if exists {
@@ -239,18 +253,18 @@ func (a AntigravityAgent) Add(ctx context.Context, s Server) error {
 	if mcpServers == nil {
 		mcpServers = make(map[string]any)
 	}
-	
+
 	mcpServers[s.Name] = map[string]string{
 		"serverUrl": s.URL,
 	}
-	
+
 	config["mcpServers"] = mcpServers
-	
+
 	newData, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
 		return err
 	}
-	
+
 	return safeWriteFile(path, newData, 0644)
 }
 
@@ -259,7 +273,7 @@ func (a AntigravityAgent) Remove(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -267,12 +281,12 @@ func (a AntigravityAgent) Remove(ctx context.Context, name string) error {
 		}
 		return err
 	}
-	
+
 	var config map[string]any
 	if err := json.Unmarshal(data, &config); err != nil {
 		return err
 	}
-	
+
 	mcpServersAny, exists := config["mcpServers"]
 	if exists {
 		if mcpServers, ok := mcpServersAny.(map[string]any); ok {
@@ -280,12 +294,12 @@ func (a AntigravityAgent) Remove(ctx context.Context, name string) error {
 			config["mcpServers"] = mcpServers
 		}
 	}
-	
+
 	newData, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
 		return err
 	}
-	
+
 	return safeWriteFile(path, newData, 0644)
 }
 
@@ -315,7 +329,7 @@ func safeWriteFile(path string, data []byte, perm os.FileMode) error {
 		_ = tmpFile.Close()
 		_ = os.Remove(tmpPath)
 	}()
-	
+
 	if err := tmpFile.Chmod(perm); err != nil {
 		return err
 	}

--- a/internal/register/agents_test.go
+++ b/internal/register/agents_test.go
@@ -20,6 +20,65 @@ func (r *fakeRunner) Run(_ context.Context, name string, args ...string) (string
 	return r.output, nil
 }
 
+func listNames(agent Agent) ([]string, error) {
+	entries, err := agent.ListEntries(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name)
+	}
+	return names, nil
+}
+
+func TestParseListEntries(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   []Entry
+	}{
+		{
+			name:   "claude 形式は名前と URL を抽出",
+			output: "github: http://127.0.0.1:8080/mcp/github (HTTP) - ✓ Connected\n",
+			want:   []Entry{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}},
+		},
+		{
+			name:   "URL のない行は URL 空のエントリになる",
+			output: "  github (http)\n",
+			want:   []Entry{{Name: "github", URL: ""}},
+		},
+		{
+			name:   "codex のテーブルヘッダーはスキップし行から URL を拾う",
+			output: "Name  Transport  Url\ngithub  streamable_http  http://127.0.0.1:8080/mcp/github\n",
+			want:   []Entry{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}},
+		},
+		{
+			name:   "未登録メッセージは無視",
+			output: "No MCP servers configured\n",
+			want:   nil,
+		},
+		{
+			name:   "同名の行は重複排除",
+			output: "github: http://127.0.0.1:8080/mcp/github (HTTP)\ngithub: http://127.0.0.1:8080/mcp/github (HTTP)\n",
+			want:   []Entry{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseListEntries(tc.output)
+			if len(got) != len(tc.want) {
+				t.Fatalf("entries = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("entries = %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
 func TestCopilotRegisterRemovesExistingBeforeAdd(t *testing.T) {
 	runner := &fakeRunner{output: "  github (http)\n"}
 	agent := NewCopilotAgent(runner)
@@ -120,7 +179,7 @@ func TestAntigravityRegister(t *testing.T) {
 	}
 
 	// 1. List when file does not exist
-	names, err := agent.List(context.Background())
+	names, err := listNames(agent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +208,7 @@ func TestAntigravityRegister(t *testing.T) {
 	}
 
 	// 4. Verify list contains both servers
-	names, err = agent.List(context.Background())
+	names, err = listNames(agent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +247,7 @@ func TestAntigravityRegister(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	names, err = agent.List(context.Background())
+	names, err = listNames(agent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +286,7 @@ func TestAntigravityErrorPaths(t *testing.T) {
 	}
 
 	// List should error
-	_, err = agent.List(context.Background())
+	_, err = listNames(agent)
 	if err == nil {
 		t.Error("expected error from List with invalid JSON")
 	}
@@ -275,7 +334,7 @@ func TestNewAntigravityAgentAndRegister(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	configPath := filepath.Join(tmpDir, "mcp_config.json")
-	
+
 	testAgent := AntigravityAgent{
 		baseAgent:  baseAgent{name: "antigravity", runner: runner},
 		configPath: configPath,
@@ -292,7 +351,7 @@ func TestNewAntigravityAgentAndRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	names, err := testAgent.List(context.Background())
+	names, err := listNames(testAgent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +380,7 @@ func TestAntigravityMcpServersNotObject(t *testing.T) {
 	}
 
 	// List should return nil, nil (not crash or fail)
-	names, err := agent.List(context.Background())
+	names, err := listNames(agent)
 	if err != nil {
 		t.Fatalf("List returned error when mcpServers is not an object: %v", err)
 	}
@@ -335,7 +394,7 @@ func TestAntigravityMcpServersNotObject(t *testing.T) {
 		t.Fatalf("Add failed when mcpServers is not an object: %v", err)
 	}
 
-	names, err = agent.List(context.Background())
+	names, err = listNames(agent)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/register/prune_test.go
+++ b/internal/register/prune_test.go
@@ -1,0 +1,133 @@
+package register
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+type fakeAgent struct {
+	name    string
+	entries []Entry
+	removed []string
+}
+
+func (f *fakeAgent) Name() string { return f.name }
+
+func (f *fakeAgent) ListEntries(context.Context) ([]Entry, error) { return f.entries, nil }
+
+func (f *fakeAgent) Add(context.Context, Server) error { return nil }
+
+func (f *fakeAgent) Remove(_ context.Context, name string) error {
+	f.removed = append(f.removed, name)
+	return nil
+}
+
+func (f *fakeAgent) OverwritesOnAdd() bool { return true }
+
+func (f *fakeAgent) AddCommand(s Server) []string { return []string{"add", s.Name} }
+
+func (f *fakeAgent) RemoveCommand(name string) []string { return []string{"remove", name} }
+
+func TestStaleEntries(t *testing.T) {
+	available := []Server{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}}
+	const origin = "http://127.0.0.1:8080/"
+
+	cases := []struct {
+		name    string
+		entries []Entry
+		want    []string
+	}{
+		{
+			name:    "計画内のエントリは候補外",
+			entries: []Entry{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}},
+			want:    nil,
+		},
+		{
+			name:    "gateway 配下で計画外なら候補",
+			entries: []Entry{{Name: "cloudflare", URL: "http://127.0.0.1:8080/${CLOUDFLARE_API_TOKEN:+/mcp/cloudflare"}},
+			want:    []string{"cloudflare"},
+		},
+		{
+			name:    "gateway 配下以外の URL は候補外",
+			entries: []Entry{{Name: "personal", URL: "https://example.com/mcp"}},
+			want:    nil,
+		},
+		{
+			name:    "URL 不明のエントリは候補外",
+			entries: []Entry{{Name: "stdio-server"}},
+			want:    nil,
+		},
+		{
+			name: "複数候補は登録順を保持",
+			entries: []Entry{
+				{Name: "old-a", URL: "http://127.0.0.1:8080/mcp/old-a"},
+				{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"},
+				{Name: "old-b", URL: "http://127.0.0.1:8080/mcp/old-b"},
+			},
+			want: []string{"old-a", "old-b"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := &fakeAgent{name: "claude", entries: tc.entries}
+			stale, err := StaleEntries(context.Background(), agent, available, origin)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := make([]string, 0, len(stale))
+			for _, entry := range stale {
+				got = append(got, entry.Name)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("stale = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("stale = %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestPruneRemovesEntriesInOrder(t *testing.T) {
+	agent := &fakeAgent{name: "claude"}
+	var out bytes.Buffer
+
+	err := Prune(context.Background(), &out, agent, []Entry{
+		{Name: "old-a", URL: "http://127.0.0.1:8080/mcp/old-a"},
+		{Name: "old-b", URL: "http://127.0.0.1:8080/mcp/old-b"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agent.removed) != 2 || agent.removed[0] != "old-a" || agent.removed[1] != "old-b" {
+		t.Fatalf("removed = %v, want [old-a old-b]", agent.removed)
+	}
+	if !strings.Contains(out.String(), "old-a: http://127.0.0.1:8080/mcp/old-a を削除します") {
+		t.Fatalf("output = %q, want delete message", out.String())
+	}
+}
+
+func TestPrintPrunePlan(t *testing.T) {
+	agent := &fakeAgent{name: "claude"}
+	var out bytes.Buffer
+
+	PrintPrunePlan(&out, agent, []Entry{{Name: "old-a", URL: "http://127.0.0.1:8080/mcp/old-a"}})
+
+	got := out.String()
+	for _, want := range []string{
+		"claude の stale エントリ削除計画:",
+		"old-a (http://127.0.0.1:8080/mcp/old-a)",
+		"削除: remove old-a",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("plan =\n%s\nmissing %q", got, want)
+		}
+	}
+	if len(agent.removed) != 0 {
+		t.Fatalf("plan must not remove entries, removed = %v", agent.removed)
+	}
+}


### PR DESCRIPTION
## 概要

`mcp-docker register` に stale エントリ削除（prune）を追加します。route 削除や `${VAR:+...}` の変数未設定スキップで登録計画から外れたエントリが agent 設定に残留し続ける問題（#167 の後始末が register で完結しない問題）を解消します。

## 変更内容

- `Agent` インターフェースの `List`（名前のみ）を `ListEntries`（URL 付き）に置き換え
  - 削除候補は **gateway 配下（`http://127.0.0.1:<port>/...`）の URL を持ち、かつ現在の計画に含まれない**エントリのみ
  - gateway 配下以外の URL・URL を特定できないエントリ（mcp-docker 管理外の可能性）は候補に含めない（fail-safe）
- `--prune` フラグを追加
  - 非対話: 候補一覧を表示し y/N 確認。`--yes` 指定時のみ確認を省略（自動化向け）
  - `--dry-run --prune`: 削除計画の表示のみ（候補確認のため各 agent の list を実行）
- 対話モード: `--prune` 指定がなくても登録後に削除候補を番号選択で提示
  - 既定（Enter / `none`）は「削除しない」（既存の選択プロンプトと既定値を反転）
  - 削除実行前に対象一覧つきの最終確認を必ず表示
- 選択プロンプトに複数選択の入力例（`入力 (例: 1,3 / all / none): `）を表示（既存の agent / server 選択にも適用）
- `compose.GatewayOrigin` を追加し、gateway origin を prune の判定基準として共有
- 副次修正: codex のテーブル形式 list 出力で URL の `://` により名前抽出が壊れる潜在バグを修正（旧実装では codex が `OverwritesOnAdd` のため未露出）

## 動作確認

- `go vet ./...` / `gofmt -l .` / `go test ./...` パス
- 実環境で `register --agent antigravity --server all --dry-run --prune` を実行し、登録計画の表示と「削除対象の stale エントリはありません」（既存 4 エントリすべて計画内）を確認

## 設計判断

- 候補判定を gateway 配下 URL に限定（名前ベースの「計画外すべて」は個人エントリの誤削除リスクがあるため不採用）
- `--prune --yes` は確認なし削除を許可（候補が gateway 配下に限定されるため誤削除リスクは構造的に低い）

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)