### PR TITLE
fix(register): add timeout for agent CLI registration commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 バグ修正
+
+- `mcp-docker register` コマンドでエージェント（特に Codex CLI など）の登録・登録確認を行う際、OAuth 認証のキャンセルや失敗によって外部コマンドが応答なしのままハングアップする問題を修正 — #175
+  - 各エージェントに対する外部コマンド実行（登録確認 `ListEntries`、登録 `Register`、削除 `pruneAgent`）にデフォルト 3 分のタイムアウトを設定
+  - タイムアウト発生時は安全にエラー終了させるとともに、OAuth認証フローの失敗やキャンセルが発生した可能性を示す親切なエラーメッセージを出力
+  - タイムアウト時間は環境変数 `MCP_DOCKER_REGISTER_TIMEOUT` からカスタマイズ可能に
+
+
 ## [2.14.0] - 2026-06-12
 
 ### ✨ 機能追加

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 
+	"time"
+
 	"github.com/scottlz0310/mcp-docker/v2/internal/compose"
 	"github.com/scottlz0310/mcp-docker/v2/internal/external"
 	"github.com/scottlz0310/mcp-docker/v2/internal/register"
@@ -156,27 +158,48 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		}
 	}
 
+	timeout := getRegisterTimeout()
+
 	execRunner := register.ExecRunner{}
 	for _, spec := range selected {
 		agent := spec.newAgent(execRunner)
 		var existing []register.Entry
 		if pruneEnabled || (!opts.dryRun && !agent.OverwritesOnAdd()) {
 			var err error
-			existing, err = agent.ListEntries(ctx)
+			listCtx, cancel := context.WithTimeout(ctx, timeout)
+			existing, err = agent.ListEntries(listCtx)
+			cancel()
 			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					return fmt.Errorf("%s list: 外部コマンドの実行がタイムアウトしました。OAuth認証フローがキャンセルされたか、接続に失敗した可能性があります (%s)", agent.Name(), timeout)
+				}
 				return fmt.Errorf("%s list: %w", agent.Name(), err)
 			}
 		}
 
 		if opts.dryRun {
 			register.PrintPlan(stdout, agent, selectedServers)
-		} else if err := register.Register(ctx, stdout, agent, selectedServers, existing); err != nil {
-			return err
+		} else {
+			regCtx, cancel := context.WithTimeout(ctx, timeout)
+			err := register.Register(regCtx, stdout, agent, selectedServers, existing)
+			cancel()
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					return fmt.Errorf("%s register: 外部コマンドの実行がタイムアウトしました。OAuth認証フローがキャンセルされたか、接続に失敗した可能性があります (%s)", agent.Name(), timeout)
+				}
+				return err
+			}
 		}
 		if !pruneEnabled {
 			continue
 		}
-		if err := pruneAgent(ctx, stdinReader, stdout, agent, existing, servers, gatewayOrigin, opts, useInteractive); err != nil {
+		pruneCtx, cancel := context.WithTimeout(ctx, timeout)
+		err := pruneAgent(pruneCtx, stdinReader, stdout, agent, existing, servers, gatewayOrigin, opts, useInteractive)
+		cancel()
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("%s prune: 外部コマンドの実行がタイムアウトしました。OAuth認証フローがキャンセルされたか、接続に失敗した可能性があります (%s)", agent.Name(), timeout)
+			}
 			return err
 		}
 	}
@@ -389,3 +412,15 @@ func selectAgentsByNames(names []string) ([]agentSpec, error) {
 	}
 	return out, nil
 }
+
+const defaultRegisterTimeout = 3 * time.Minute
+
+func getRegisterTimeout() time.Duration {
+	if val := os.Getenv("MCP_DOCKER_REGISTER_TIMEOUT"); val != "" {
+		if d, err := time.ParseDuration(val); err == nil {
+			return d
+		}
+	}
+	return defaultRegisterTimeout
+}
+

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -193,13 +193,8 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		if !pruneEnabled {
 			continue
 		}
-		pruneCtx, cancel := context.WithTimeout(ctx, timeout)
-		err := pruneAgent(pruneCtx, stdinReader, stdout, agent, existing, servers, gatewayOrigin, opts, useInteractive)
-		cancel()
+		err := pruneAgent(ctx, stdinReader, stdout, agent, existing, servers, gatewayOrigin, opts, useInteractive)
 		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) {
-				return fmt.Errorf("%s prune: 外部コマンドの実行がタイムアウトしました。OAuth認証フローがキャンセルされたか、接続に失敗した可能性があります (%s)", agent.Name(), timeout)
-			}
 			return err
 		}
 	}
@@ -241,7 +236,16 @@ func pruneAgent(ctx context.Context, reader *bufio.Reader, stdout io.Writer, age
 			return nil
 		}
 	}
-	return register.Prune(ctx, stdout, agent, targets)
+	timeout := getRegisterTimeout()
+	pruneCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := register.Prune(pruneCtx, stdout, agent, targets); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("%s prune: 外部コマンドの実行がタイムアウトしました。OAuth認証フローがキャンセルされたか、接続に失敗した可能性があります (%s)", agent.Name(), timeout)
+		}
+		return err
+	}
+	return nil
 }
 
 type registerOptions struct {

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -706,4 +706,167 @@ func TestGetRegisterTimeout(t *testing.T) {
 	}
 }
 
+func TestRegisterTimeoutOnAddCommand(t *testing.T) {
+	dir := t.TempDir()
+	var binName string
+	var binContent []byte
+
+	selfPath, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if runtime.GOOS == "windows" {
+		binName = "claude.bat"
+		binContent = []byte(fmt.Sprintf(`@echo off
+if "%%1"=="mcp" if "%%2"=="list" (
+    echo.
+    exit /b 0
+)
+set GO_WANT_HELPER_PROCESS=1
+"%s" -test.run=TestHelperProcess -- %%*
+`, selfPath))
+	} else {
+		binName = "claude"
+		binContent = []byte(fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "mcp" ] && [ "$2" = "list" ]; then
+    echo ""
+    exit 0
+fi
+export GO_WANT_HELPER_PROCESS=1
+exec "%s" -test.run=TestHelperProcess -- "$@"
+`, selfPath))
+	}
+	binPath := filepath.Join(dir, binName)
+	if err := os.WriteFile(binPath, binContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", dir+string(filepath.ListSeparator)+oldPath); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Setenv("PATH", oldPath)
+	}()
+
+	t.Setenv("MCP_DOCKER_REGISTER_TIMEOUT", "100ms")
+
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	externalPath := filepath.Join(dir, "mcp-external.yml")
+	if err := os.WriteFile(composePath, []byte(`services:
+  mcp-gateway:
+    environment:
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(externalPath, []byte("servers: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = run(context.Background(), []string{
+		"register",
+		"--agent", "claude",
+		"--server", "github",
+		"--compose", composePath,
+		"--external", externalPath,
+		"--yes",
+	}, &stdout, &stderr, strings.NewReader(""))
+
+	if err == nil {
+		t.Fatal("expected timeout error on add, but got nil")
+	}
+	if !strings.Contains(err.Error(), "外部コマンドの実行がタイムアウトしました") || !strings.Contains(err.Error(), "register:") {
+		t.Fatalf("expected error message to contain register timeout explanation, but got: %v", err)
+	}
+}
+
+func TestRegisterTimeoutOnPruneCommand(t *testing.T) {
+	dir := t.TempDir()
+	var binName string
+	var binContent []byte
+
+	selfPath, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if runtime.GOOS == "windows" {
+		binName = "claude.bat"
+		binContent = []byte(fmt.Sprintf(`@echo off
+if "%%1"=="mcp" if "%%2"=="list" (
+    echo old-server: http://127.0.0.1:8080/mcp/old-server
+    exit /b 0
+)
+if "%%1"=="mcp" if "%%2"=="remove" (
+    set GO_WANT_HELPER_PROCESS=1
+    "%s" -test.run=TestHelperProcess -- %%*
+    exit /b 0
+)
+exit /b 0
+`, selfPath))
+	} else {
+		binName = "claude"
+		binContent = []byte(fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "mcp" ] && [ "$2" = "list" ]; then
+    echo "old-server: http://127.0.0.1:8080/mcp/old-server"
+    exit 0
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "remove" ]; then
+    export GO_WANT_HELPER_PROCESS=1
+    exec "%s" -test.run=TestHelperProcess -- "$@"
+fi
+exit 0
+`, selfPath))
+	}
+	binPath := filepath.Join(dir, binName)
+	if err := os.WriteFile(binPath, binContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", dir+string(filepath.ListSeparator)+oldPath); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Setenv("PATH", oldPath)
+	}()
+
+	t.Setenv("MCP_DOCKER_REGISTER_TIMEOUT", "100ms")
+
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	externalPath := filepath.Join(dir, "mcp-external.yml")
+	if err := os.WriteFile(composePath, []byte(`services:
+  mcp-gateway:
+    environment:
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(externalPath, []byte("servers: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = run(context.Background(), []string{
+		"register",
+		"--agent", "claude",
+		"--server", "github",
+		"--compose", composePath,
+		"--external", externalPath,
+		"--prune",
+		"--yes",
+	}, &stdout, &stderr, strings.NewReader(""))
+
+	if err == nil {
+		t.Fatal("expected timeout error on prune, but got nil")
+	}
+	if !strings.Contains(err.Error(), "外部コマンドの実行がタイムアウトしました") || !strings.Contains(err.Error(), "prune:") {
+		t.Fatalf("expected error message to contain prune timeout explanation, but got: %v", err)
+	}
+}
+
+
 

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -615,16 +616,31 @@ func TestRunRegisterListEntriesError(t *testing.T) {
 	}
 }
 
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	// タイムアウトするまで待機
+	time.Sleep(10 * time.Second)
+	os.Exit(0)
+}
+
 func TestRegisterTimeoutOnExternalCommand(t *testing.T) {
 	dir := t.TempDir()
 	var binName string
 	var binContent []byte
+
+	selfPath, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if runtime.GOOS == "windows" {
 		binName = "claude.bat"
-		binContent = []byte("@echo off\r\necho ok\r\n")
+		binContent = []byte(fmt.Sprintf("@echo off\r\nset GO_WANT_HELPER_PROCESS=1\r\n\"%s\" -test.run=TestHelperProcess -- %%*\r\n", selfPath))
 	} else {
 		binName = "claude"
-		binContent = []byte("#!/bin/sh\necho ok\n")
+		binContent = []byte(fmt.Sprintf("#!/bin/sh\nexport GO_WANT_HELPER_PROCESS=1\nexec \"%s\" -test.run=TestHelperProcess -- \"$@\"\n", selfPath))
 	}
 	binPath := filepath.Join(dir, binName)
 	if err := os.WriteFile(binPath, binContent, 0o755); err != nil {
@@ -639,10 +655,8 @@ func TestRegisterTimeoutOnExternalCommand(t *testing.T) {
 		_ = os.Setenv("PATH", oldPath)
 	}()
 
-	// すでに期限切れの context を渡して即座にタイムアウトエラーを誘発させる
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Microsecond)
-	time.Sleep(2 * time.Millisecond)
-	defer cancel()
+	// タイムアウトを 100ms に設定
+	t.Setenv("MCP_DOCKER_REGISTER_TIMEOUT", "100ms")
 
 	composePath := filepath.Join(dir, "docker-compose.yml")
 	externalPath := filepath.Join(dir, "mcp-external.yml")
@@ -658,7 +672,7 @@ func TestRegisterTimeoutOnExternalCommand(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := run(ctx, []string{
+	err = run(context.Background(), []string{
 		"register",
 		"--agent", "claude",
 		"--server", "github",

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -675,3 +675,21 @@ func TestRegisterTimeoutOnExternalCommand(t *testing.T) {
 	}
 }
 
+func TestGetRegisterTimeout(t *testing.T) {
+	t.Setenv("MCP_DOCKER_REGISTER_TIMEOUT", "")
+	if got := getRegisterTimeout(); got != defaultRegisterTimeout {
+		t.Fatalf("getRegisterTimeout() = %v, want default %v", got, defaultRegisterTimeout)
+	}
+
+	t.Setenv("MCP_DOCKER_REGISTER_TIMEOUT", "10s")
+	if got := getRegisterTimeout(); got != 10*time.Second {
+		t.Fatalf("getRegisterTimeout() = %v, want 10s", got)
+	}
+
+	t.Setenv("MCP_DOCKER_REGISTER_TIMEOUT", "invalid-duration")
+	if got := getRegisterTimeout(); got != defaultRegisterTimeout {
+		t.Fatalf("getRegisterTimeout() = %v, want default %v on invalid input", got, defaultRegisterTimeout)
+	}
+}
+
+

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/scottlz0310/mcp-docker/v2/internal/register"
 )
@@ -612,3 +613,55 @@ func TestRunRegisterListEntriesError(t *testing.T) {
 		t.Fatalf("expected error message to contain 'list:', but got: %v", err)
 	}
 }
+
+func TestRegisterTimeoutOnExternalCommand(t *testing.T) {
+	dir := t.TempDir()
+	batPath := filepath.Join(dir, "claude.bat")
+	if err := os.WriteFile(batPath, []byte("@echo off\r\necho ok\r\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", dir+string(filepath.ListSeparator)+oldPath); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Setenv("PATH", oldPath)
+	}()
+
+	// すでに期限切れの context を渡して即座にタイムアウトエラーを誘発させる
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Microsecond)
+	time.Sleep(2 * time.Millisecond)
+	defer cancel()
+
+	composePath := filepath.Join(dir, "docker-compose.yml")
+	externalPath := filepath.Join(dir, "mcp-external.yml")
+	if err := os.WriteFile(composePath, []byte(`services:
+  mcp-gateway:
+    environment:
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(externalPath, []byte("servers: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := run(ctx, []string{
+		"register",
+		"--agent", "claude",
+		"--server", "github",
+		"--compose", composePath,
+		"--external", externalPath,
+		"--yes",
+	}, &stdout, &stderr, strings.NewReader(""))
+
+	if err == nil {
+		t.Fatal("expected timeout error, but got nil")
+	}
+	if !strings.Contains(err.Error(), "外部コマンドの実行がタイムアウトしました") {
+		t.Fatalf("expected error message to contain timeout explanation, but got: %v", err)
+	}
+}
+

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -616,8 +617,17 @@ func TestRunRegisterListEntriesError(t *testing.T) {
 
 func TestRegisterTimeoutOnExternalCommand(t *testing.T) {
 	dir := t.TempDir()
-	batPath := filepath.Join(dir, "claude.bat")
-	if err := os.WriteFile(batPath, []byte("@echo off\r\necho ok\r\n"), 0o755); err != nil {
+	var binName string
+	var binContent []byte
+	if runtime.GOOS == "windows" {
+		binName = "claude.bat"
+		binContent = []byte("@echo off\r\necho ok\r\n")
+	} else {
+		binName = "claude"
+		binContent = []byte("#!/bin/sh\necho ok\n")
+	}
+	binPath := filepath.Join(dir, binName)
+	if err := os.WriteFile(binPath, binContent, 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/register/runner.go
+++ b/internal/register/runner.go
@@ -16,6 +16,9 @@ type ExecRunner struct{}
 func (ExecRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return string(out), ctx.Err()
+	}
 	if err != nil {
 		return string(out), fmt.Errorf("%s: %w\n%s", shellish(append([]string{name}, args...)), err, strings.TrimSpace(string(out)))
 	}


### PR DESCRIPTION
# 概要

OAuth認証を必要とするルートへの接続時（特にエージェント登録・登録確認時）に、ブラウザでの認証フローのキャンセルや失敗によって外部コマンド（特に Codex CLI など）が応答なしのままハングアップする問題に対処します。

Closes #175

## 変更点

* **タイムアウトの導入**:
  * エージェント登録処理（ListEntries、Register、pruneAgent）を呼び出す外部コマンド実行に対して、デフォルト 3 分（環境変数 MCP_DOCKER_REGISTER_TIMEOUT から調整可能）のタイムアウトを設定しました。
  * タイムアウト時には安全にプロセスを終了し、OAuth認証フローの失敗やキャンセルが発生した可能性を伝えるエラーメッセージを表示するようにしました。
* **タイムアウト検知の堅牢化 (フィードバック対応)**:
  * \CombinedOutput()\ がタイムアウトで Kill された際に \context.DeadlineExceeded\ ではなく \*exec.ExitError\ を返す問題を考慮し、runner.go の \ExecRunner.Run\ で \ctx.Err()\ を優先して返すように改善しました。
* **Prune時のタイムアウト遅延 (フィードバック対応)**:
  * ユーザー入力待ち時間がタイムアウト時間に含まれないよう、\pruneAgent\ 内のプロンプト処理が完了した直後（\egister.Prune\ 実行直前）にタイムアウト用の \context\ を適用するように修正しました。
* **テストの追加と改善**:
  * タイムアウト値のパースを検証する \TestGetRegisterTimeout\ の追加。
  * Go 標準の \helper process\ パターンを採用し、実際に実行途中でタイムアウトして Kill されるプロセスツリーを再現・検証する3つのタイムアウトテストケース（\TestRegisterTimeoutOnExternalCommand\、\TestRegisterTimeoutOnAddCommand\、\TestRegisterTimeoutOnPruneCommand\）を実装しました。これにより、タイムアウトエラー処理のパッチカバレッジを 100% に担保しています。