### PR TITLE
[codex] fix: route prefix strip 後の upstream endpoint を整合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 バグ修正
 
+- mcp-gateway の route prefix strip 後に `review-raven` / `thread-owl` の root へ転送され、MCP initialize が 404 になる問題を修正 — #180
+  - 各 route の upstream URL に内部 MCP endpoint `/mcp` を明記
+  - `thread-owl` の `MCP_HTTP_PATH=/mcp/thread-owl` を削除し、外部 route prefix と内部 endpoint の責務を分離
 - `mcp-docker register` コマンドでエージェント（特に Codex CLI など）の登録・登録確認を行う際、OAuth 認証のキャンセルや失敗によって外部コマンドが応答なしのままハングアップする問題を修正 — #175
   - 各エージェントに対する外部コマンド実行（登録確認 `ListEntries`、登録 `Register`、削除 `pruneAgent`）にデフォルト 3 分のタイムアウトを設定
   - タイムアウト発生時は安全にエラー終了させるとともに、OAuth認証フローの失敗やキャンセルが発生した可能性を示す親切なエラーメッセージを出力

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,9 +71,9 @@ services:
       - MCP_GATEWAY_KEY_PATH=${MCP_GATEWAY_KEY_PATH:-/data/gateway.key}
       - MCP_CONFIG_FILE=${MCP_CONFIG_FILE:-/data/config.yaml}
       - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}
-      - ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}
+      - ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp
       - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
-      - ROUTE_THREAD_OWL=/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}
+      - ROUTE_THREAD_OWL=/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp
       # =============================================================================
       # Remote MCP プロバイダー（upstream_bearer_token_env）— mcp-gateway v0.5.0 以降
       # =============================================================================
@@ -180,8 +180,6 @@ services:
       - GITHUB_WEBHOOK_SECRET=${THREAD_OWL_GITHUB_WEBHOOK_SECRET}
       - HOST=0.0.0.0
       - PORT=${THREAD_OWL_PORT:-3000}
-      # mcp-gateway がプレフィックスをストリップせず転送するため、gateway 側の route prefix に合わせる。
-      - MCP_HTTP_PATH=/mcp/thread-owl
       - LOG_LEVEL=${LOG_LEVEL:-info}
 
     expose:

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -1,8 +1,12 @@
 package compose
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseRoutesFromComposeEnvironment(t *testing.T) {
@@ -34,6 +38,58 @@ services:
 		if server.Source == "" {
 			t.Fatalf("%s Source is empty", server.Name)
 		}
+	}
+}
+
+func TestRepositoryComposeMCPRouteContract(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "docker-compose.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gateway, err := gatewayEnv(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{
+			name: "review-raven の upstream endpoint",
+			key:  "ROUTE_REVIEW_RAVEN",
+			want: "/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp",
+		},
+		{
+			name: "thread-owl の upstream endpoint",
+			key:  "ROUTE_THREAD_OWL",
+			want: "/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gateway[tt.key]; got != tt.want {
+				t.Fatalf("%s = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+
+	var file composeFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		t.Fatal(err)
+	}
+	threadOwl, ok := file.Services["thread-owl"]
+	if !ok {
+		t.Fatal("services.thread-owl not found")
+	}
+	threadOwlEnv, err := environmentMap(threadOwl.Environment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := threadOwlEnv["MCP_HTTP_PATH"]; ok {
+		t.Fatal("thread-owl must use its default /mcp endpoint")
 	}
 }
 


### PR DESCRIPTION
## 概要

mcp-gateway が外部 route prefix を strip した後、`review-raven` と `thread-owl` の root へ転送されて MCP initialize が 404 になる問題を修正します。

## 変更内容

- `ROUTE_REVIEW_RAVEN` の upstream を `http://review-raven:8083/mcp` に変更
- `ROUTE_THREAD_OWL` の upstream を `http://thread-owl:3000/mcp` に変更
- `thread-owl` の `MCP_HTTP_PATH=/mcp/thread-owl` を削除し、内部 endpoint を既定の `/mcp` に統一
- 実際の `docker-compose.yml` を YAML として検証する回帰テストを追加
- `CHANGELOG.md` を更新

## 影響

外部 URL `/mcp/review-raven` と `/mcp/thread-owl` は変更しません。gateway と MCP server の内部転送契約のみを整合させます。

## 検証

- `golangci-lint run ./...`
- `go vet ./...`
- `go test -coverprofile coverage.out -covermode atomic ./...`（total 77.8%）
- `go build ./cmd/mcp-docker`
- `docker compose config --quiet`
- Codex CLI 経由の MCP initialize
  - `review-raven`: HTTP 200、upstream `/mcp`
  - `thread-owl`: HTTP 200、upstream `/mcp`
  - `github`: HTTP 200（回帰確認）
  - `playwright`: HTTP 200（回帰確認）

Closes #180