### PR TITLE
feat: Add default auth context and token envs for review-raven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ 機能追加
 
+- review-raven の `auth=none` フォールバック対応として、gateway / review-raven コンテナに必要な環境変数を注入 — #182
+  - gateway: `GITHUB_PERSONAL_ACCESS_TOKEN` を環境変数として追加し、`ROUTE_GITHUB` に `upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN` を設定
+  - `ROUTE_REVIEW_RAVEN` / `ROUTE_THREAD_OWL` に `auth=none` を追加
+  - review-raven: `GITHUB_PERSONAL_ACCESS_TOKEN` と `REVIEW_RAVEN_DEFAULT_USER` を注入
+
 - MCP ゲートウェイの GitHub トークン自動ローテーションをデフォルトで有効化（`MCP_GATEWAY_GITHUB_REFRESH_ENABLED=true`） — #178
   - `docker-compose.yml` でのデフォルト値を `true` に設定
   - `.env.template` に `MCP_GATEWAY_GITHUB_REFRESH_ENABLED=true` を明記し、自動ローテーション機能の利用を推奨するドキュメントを追加

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,10 +70,11 @@ services:
       - MCP_GATEWAY_PORT=${MCP_GATEWAY_PORT:-8080}
       - MCP_GATEWAY_KEY_PATH=${MCP_GATEWAY_KEY_PATH:-/data/gateway.key}
       - MCP_CONFIG_FILE=${MCP_CONFIG_FILE:-/data/config.yaml}
-      - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}
-      - ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp
+      - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
+      - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}|auth=none|upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN
+      - ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp|auth=none
       - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
-      - ROUTE_THREAD_OWL=/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp
+      - ROUTE_THREAD_OWL=/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp|auth=none
       # =============================================================================
       # Remote MCP プロバイダー（upstream_bearer_token_env）— mcp-gateway v0.5.0 以降
       # =============================================================================
@@ -134,6 +135,8 @@ services:
       - BIND_ADDR=0.0.0.0
       - MCP_PORT=${REVIEW_RAVEN_PORT:-8083}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
+      - REVIEW_RAVEN_DEFAULT_USER=${REVIEW_RAVEN_DEFAULT_USER:-}
 
     # mcp-gateway 経由でのみアクセス（http://127.0.0.1:8080/mcp/review-raven）。
     # ホストから直接アクセスする場合は下記のコメントを解除してください。

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -60,12 +60,12 @@ func TestRepositoryComposeMCPRouteContract(t *testing.T) {
 		{
 			name: "review-raven の upstream endpoint",
 			key:  "ROUTE_REVIEW_RAVEN",
-			want: "/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp",
+			want: "/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp|auth=none",
 		},
 		{
 			name: "thread-owl の upstream endpoint",
 			key:  "ROUTE_THREAD_OWL",
-			want: "/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp",
+			want: "/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp|auth=none",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## 概要

review-raven の `auth=none` フォールバック対応として、必要な環境変数を gateway / review-raven コンテナに注入する。

- `docker-compose.yml`
  - gateway: `GITHUB_PERSONAL_ACCESS_TOKEN` を環境変数として追加
  - `ROUTE_GITHUB` に `auth=none|upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN` オプションを付与
  - `ROUTE_REVIEW_RAVEN` に `auth=none` を追加
  - `ROUTE_THREAD_OWL` に `auth=none` を追加
  - review-raven: `GITHUB_PERSONAL_ACCESS_TOKEN` と `REVIEW_RAVEN_DEFAULT_USER` を注入
- `internal/compose/parse_test.go`
  - `ROUTE_REVIEW_RAVEN` / `ROUTE_THREAD_OWL` のコントラクトテストを `auth=none` 付き形式に更新

## テスト計画

- [ ] `go test ./internal/compose/...` でコントラクトテストが PASS すること
- [ ] `docker compose up` 起動後、`/mcp/review-raven` へのリクエストが `auth=none` で疎通すること
- [ ] `GITHUB_PERSONAL_ACCESS_TOKEN` が review-raven コンテナ内に反映されていること (`docker compose exec review-raven env | grep GITHUB`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)