### PR TITLE
docs: document GitHub App gateway migration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -45,19 +45,26 @@ LOG_LEVEL=info
 # mcp-gateway — OAuth 2.0 認証ゲートウェイ（github-oauth-proxy の後継）
 # =============================================================================
 #
-# GitHub OAuth App の作成手順:
-#   1. https://github.com/settings/applications/new にアクセス
-#   2. Application name: 任意 (例: "GitHub MCP Gateway")
-#   3. Homepage URL: http://127.0.0.1:8080
-#   4. Authorization callback URL: http://127.0.0.1:8080/callback
-#   5. 作成後に Client ID と Client Secret を取得
+# GitHub App の作成手順:
+#   1. GitHub -> Settings -> Developer settings -> GitHub Apps -> New GitHub App
+#   2. Homepage URL: <MCP_GATEWAY_PUBLIC_URL>（例: http://127.0.0.1:8080）
+#   3. Authorization callback URLs（2本とも登録）:
+#        <MCP_GATEWAY_PUBLIC_URL>/callback
+#        <MCP_GATEWAY_PUBLIC_URL>/device_callback
+#   4. Permissions（推奨）:
+#        Repository: Metadata (Read-only, auto), Contents (Read-only),
+#                    Issues (Read and write), Pull requests (Read and write)
+#        Account:    Email addresses (Read-only)
+#   5. Webhook: disabled
+#   6. Where can this GitHub App be installed?: 個人利用なら Only on this account
+#   7. 作成後に Client secret を生成し、Client ID と Client Secret を取得
 #
 # mcp-gateway v0.4.0 以降の推奨変数:
-# OAUTH_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
+# OAUTH_CLIENT_ID=Iv23xxxxxxxxxxxxxxxx
 # OAUTH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 #
 # 旧変数名（後方互換。v0.4.0 より OAUTH_* が推奨）:
-# GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
+# GITHUB_MCP_CLIENT_ID=Iv23xxxxxxxxxxxxxxxx
 # GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # mcp-gateway の外部 URL（OAuth callback URL に使用）
@@ -76,6 +83,10 @@ LOG_LEVEL=info
 # mcp-gateway のリッスンポート
 # デフォルト: 8080
 # MCP_GATEWAY_PORT=8080
+
+# OAuth 監査ログ（JSON Lines）
+# docker-compose.yml では /data volume 配下に永続化します。
+# MCP_GATEWAY_AUTH_AUDIT_LOG_PATH=/data/logs/auth-audit.jsonl
 
 # OAuth スコープ（mcp-gateway v0.4.0 以降の推奨変数）
 # デフォルト: repo,user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - タイムアウト発生時は安全にエラー終了させるとともに、OAuth認証フローの失敗やキャンセルが発生した可能性を示す親切なエラーメッセージを出力
   - タイムアウト時間は環境変数 `MCP_DOCKER_REGISTER_TIMEOUT` からカスタマイズ可能に
 
+### 📝 ドキュメント
+
+- mcp-gateway の GitHub App 移行に合わせ、`.env.template` / `README.md` の作成手順・callback URL・permission 設定を更新 — #183
+  - `OAUTH_CLIENT_ID` の例を GitHub App Client ID の `Iv23...` 形式に更新
+  - `docker-compose.yml` で OAuth 監査ログを `/data/logs/auth-audit.jsonl` に永続化
+
 
 ## [2.14.0] - 2026-06-12
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ help: ## 利用可能なターゲット一覧を表示
 
 .PHONY: start-gateway
 start-gateway: ## 全サービスを mcp-gateway 経由で起動（127.0.0.1:8080）
-	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET are required (legacy: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET). Set them in .env or as environment variables.))
+	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET are required for the GitHub App (legacy: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET). Set them in .env or as environment variables.))
 	# --remove-orphans: リネーム前の copilot-review-mcp など compose 定義外の旧コンテナを除去
 	docker compose up -d --remove-orphans github-mcp review-raven mcp-gateway playwright-mcp
 	@echo "Started mcp-gateway endpoint: http://127.0.0.1:$(or $(MCP_GATEWAY_PORT),8080)"
@@ -142,7 +142,7 @@ endif
 
 .PHONY: start-main
 start-main: ## 最新開発版イメージで全サービスを起動
-	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET are required (legacy: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET). Set them in .env or as environment variables.))
+	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET are required for the GitHub App (legacy: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET). Set them in .env or as environment variables.))
 	GITHUB_MCP_GATEWAY_IMAGE=$(MCP_GATEWAY_MAIN_IMAGE) \
 	REVIEW_RAVEN_IMAGE=$(REVIEW_RAVEN_MAIN_IMAGE) \
 	THREAD_OWL_IMAGE=$(THREAD_OWL_MAIN_IMAGE) \

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ OAuth フローは mcp-gateway コンテナ内で完結するため、CLI の起
 
 - Docker 20.10+
 - GitHub Personal Access Token（PAT）
-- GitHub OAuth App の Client ID / Secret（mcp-gateway 経由接続に必要）
+- GitHub App の Client ID / Secret（mcp-gateway 経由接続に必要）
 
 ### セットアップ
 
@@ -50,10 +50,11 @@ cd Mcp-Docker
 cp .env.template .env
 # .env を編集して以下を設定:
 #   GITHUB_PERSONAL_ACCESS_TOKEN     (github-mcp-server 用 PAT)
-#   GITHUB_MCP_CLIENT_ID             (mcp-gateway OAuth App Client ID)
-#   GITHUB_MCP_CLIENT_SECRET         (mcp-gateway OAuth App Client Secret)
+#   OAUTH_CLIENT_ID                  (mcp-gateway GitHub App Client ID)
+#   OAUTH_CLIENT_SECRET              (mcp-gateway GitHub App Client Secret)
 # ※ review-raven では OAuth を mcp-gateway が一元管理します。
 # ※ GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET の個別設定は不要です。
+# ※ 旧 GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET も互換目的で受け付けます。
 
 # 3. 全サービス起動
 make start-gateway
@@ -85,22 +86,35 @@ make start-gateway
 
 **Classic token（非推奨）**: スコープ `repo, workflow, read:org, read:user`
 
-### GitHub OAuth App 登録
+### GitHub App 登録
 
-mcp-gateway 経由で接続するには GitHub OAuth App が必要です。
+mcp-gateway 経由で接続するには GitHub App が必要です。
 
-1. [https://github.com/settings/applications/new](https://github.com/settings/applications/new) にアクセス
+1. GitHub の **Settings > Developer settings > GitHub Apps > New GitHub App** を開く
 2. 設定：
    - Homepage URL: `http://127.0.0.1:8080`
-   - Authorization callback URL: `http://127.0.0.1:8080/callback`
-3. Client ID / Secret を取得し `.env` に設定：
+   - Authorization callback URLs:
+     - `http://127.0.0.1:8080/callback`
+     - `http://127.0.0.1:8080/device_callback`
+   - Repository permissions:
+     - Metadata: Read-only（自動選択）
+     - Contents: Read-only
+     - Issues: Read and write
+     - Pull requests: Read and write
+   - Account permissions:
+     - Email addresses: Read-only
+   - Webhook: disabled
+   - Where can this GitHub App be installed?: 個人利用なら `Only on this account`
+3. 作成後、Client secret を生成し、Client ID / Secret を `.env` に設定：
 
 ```bash
-GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
-GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+OAUTH_CLIENT_ID=Iv23xxxxxxxxxxxxxxxx
+OAUTH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-> callback URL は `MCP_GATEWAY_PUBLIC_URL`（未設定時は `MCP_GATEWAY_BASE_URL`）と一致させてください（末尾に `/callback`）。
+> callback URL のベース URL は `MCP_GATEWAY_PUBLIC_URL`（未設定時は `MCP_GATEWAY_BASE_URL`）と一致させてください。`/callback` と `/device_callback` の 2 本を登録します。
+>
+> GitHub OAuth App から移行する場合は、`.env` の `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` を GitHub App の値に置き換えます。旧 `GITHUB_MCP_CLIENT_ID` / `GITHUB_MCP_CLIENT_SECRET` も互換目的で読み取りますが、新規設定では `OAUTH_*` を使ってください。
 
 
 ## CLI 統合
@@ -365,9 +379,11 @@ make logs-gateway  # mcp-gateway ログ
 docker volume rm mcp-docker_github-mcp-cache
 ```
 
-### mcp-gateway トークンストアボリューム（`mcp-gateway-data`）
+### mcp-gateway トークンストア / 監査ログボリューム（`mcp-gateway-data`）
 
 `mcp-gateway` はブラウザ認証後に取得した OAuth トークンを `/data/tokens.db` に永続化します。
+OAuth 監査ログは `/data/logs/auth-audit.jsonl` に JSON Lines 形式で保存します。
+どちらも `mcp-gateway-data` volume 配下に置かれるため、コンテナ再作成後も保持されます。
 このファイルは **検証済み OAuth トークンのキャッシュ**であり、GitHub 認証情報（PAT）そのものではありません。
 
 ボリューム情報確認（Mountpoint 等のメタデータ）：

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,9 @@ services:
         condition: service_started
 
     environment:
+      # GitHub App の Client ID / Secret を指定します（Client ID は Iv23... 形式）。
+      # GitHub App には <MCP_GATEWAY_PUBLIC_URL>/callback と
+      # <MCP_GATEWAY_PUBLIC_URL>/device_callback の両方を登録してください。
       - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID:-${GITHUB_MCP_CLIENT_ID}}
       - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET:-${GITHUB_MCP_CLIENT_SECRET}}
       # v0.4.0 未満のゲートウェイとの後方互換エイリアス
@@ -93,6 +96,7 @@ services:
       - TOKEN_CACHE_TTL_MIN=${TOKEN_CACHE_TTL_MIN:-30}
       - TOKEN_EXPIRES_IN_SEC=${TOKEN_EXPIRES_IN_SEC:-7776000}
       - MCP_GATEWAY_TOKEN_STORE_PATH=${MCP_GATEWAY_TOKEN_STORE_PATH:-/data/tokens.db}
+      - MCP_GATEWAY_AUTH_AUDIT_LOG_PATH=${MCP_GATEWAY_AUTH_AUDIT_LOG_PATH:-/data/logs/auth-audit.jsonl}
       - MCP_GATEWAY_GITHUB_REFRESH_ENABLED=${MCP_GATEWAY_GITHUB_REFRESH_ENABLED:-true}
 
     volumes:


### PR DESCRIPTION
## Summary

- Update `.env.template` and `README.md` from GitHub OAuth App setup to GitHub App setup.
- Document both required callback URLs and recommended GitHub App permissions.
- Persist the mcp-gateway OAuth audit log under the `/data` volume via `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH`.
- Update Makefile startup error text and the changelog entry for #183.

## Why

mcp-gateway has moved to GitHub App credentials and Device Flow support now requires both `/callback` and `/device_callback` callback URLs. Mcp-Docker should make `make pull-main && make start-main` work with the current gateway contract once the operator has updated credentials.

## Validation

- `docker compose config --quiet`
- `go test ./...`
- `git diff --check`
- `make -n start-main OAUTH_CLIENT_ID=Iv23example OAUTH_CLIENT_SECRET=example-secret`
- pre-push hook: `lint`, `test-go`

Closes #183