### PR TITLE
chore: release v2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.0] - 2026-06-21
+
 ### ✨ 機能追加
 
 - mcp-gateway の OIDC AS（builtin）を Compose に統合 — #185

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -548,7 +548,8 @@ v1.x からの移行:
 ### Fixed
 - Initial bug fixes
 
-[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.14.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.15.0...HEAD
+[2.15.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.14.0...v2.15.0
 [2.14.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.13.0...v2.14.0
 [2.13.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.12.0...v2.13.0
 [2.12.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.11.0...v2.12.0

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ endif
 MCP_DOCKER   := $(BIN_DIR)/mcp-docker$(EXE_EXT)
 GO_SOURCES   := $(shell find cmd internal -name '*.go' 2>/dev/null)
 REGISTER_FLAGS ?=
-VERSION ?= 2.14.0
+VERSION ?= 2.15.0
 GO_LDFLAGS ?= -X main.version=$(VERSION)
 
 $(MCP_DOCKER): go.mod go.sum $(GO_SOURCES)


### PR DESCRIPTION
## Summary

- `CHANGELOG.md`: [Unreleased] → [2.15.0] - 2026-06-21
- `Makefile`: VERSION を 2.14.0 → 2.15.0 に更新

## 含まれる変更（v2.14.0 以降）

### 機能追加
- mcp-gateway の OIDC AS（builtin）を Compose に統合 (#185/#186)

### 変更
- Cloudflare MCP を upstream_oauth 委任から直接接続方式に変更 (#187)
- review-raven の auth=none フォールバック環境変数注入 (#182)
- GitHub トークン自動ローテーションをデフォルト有効化 (#178)

### バグ修正
- route prefix strip 後の 404 問題を修正 (#180)
- mcp-docker register ハングアップ問題を修正 (#175)

### ドキュメント
- GitHub App 移行に合わせた設定手順更新 (#183)

🤖 Generated with [Claude Code](https://claude.com/claude-code)