### PR TITLE
fix: use webhook-mcp-http command for thread-owl (#189)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,7 @@ services:
     image: ${THREAD_OWL_IMAGE:-ghcr.io/scottlz0310/thread-owl:latest}
     container_name: thread-owl
     restart: unless-stopped
-    command: ["--mcp-http"]
+    command: ["--webhook-mcp-http"]
 
     environment:
       - GITHUB_APP_ID=${THREAD_OWL_GITHUB_APP_ID}


### PR DESCRIPTION
Closes #189. Changes thread-owl command from \--mcp-http\ to \--webhook-mcp-http\ to enable both webhook queue subscriptions and MCP HTTP protocol features.