### PR TITLE
fix(security): gateway OAuth 認証を github / review-raven / thread-owl ルートに適用

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🔐 セキュリティ
+
+- `ROUTE_GITHUB` / `ROUTE_REVIEW_RAVEN` / `ROUTE_THREAD_OWL` の `auth=none` を削除し、gateway OAuth 認証を必須化 — mcp-gateway#184
+  - `ROUTE_GITHUB`: オーナーの PAT を注入する `upstream_bearer_token_env` は引き続き機能する。認証なしで 44 ツールが公開されていたリスクを解消
+  - `ROUTE_REVIEW_RAVEN`: `auth=none` は review-raven が `X-Authenticated-User` ヘッダーを期待する設計と不整合であり、MCP 認証が機能しない状態だった
+  - `ROUTE_THREAD_OWL`: GitHub App トークンによる高権限操作（Issue / PR / レビュー書き込み）が認証なしで露出していたリスクを解消
+  - `ROUTE_PLAYWRIGHT` は認証不要な設計のまま維持（ローカルブラウザ制御専用）
+
 ## [2.15.0] - 2026-06-21
 
 ### ✨ 機能追加

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,10 +78,10 @@ services:
       - MCP_GATEWAY_KEY_PATH=${MCP_GATEWAY_KEY_PATH:-/data/gateway.key}
       - MCP_CONFIG_FILE=${MCP_CONFIG_FILE:-/data/config.yaml}
       - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
-      - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}|auth=none|upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN
-      - ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp|auth=none
+      - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}|upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN
+      - ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp
       - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
-      - ROUTE_THREAD_OWL=/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp|auth=none
+      - ROUTE_THREAD_OWL=/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp
       - OAUTH_SCOPES=${OAUTH_SCOPES:-${GITHUB_MCP_OAUTH_SCOPES:-repo,user}}
       - GITHUB_MCP_OAUTH_SCOPES=${OAUTH_SCOPES:-${GITHUB_MCP_OAUTH_SCOPES:-repo,user}}
       - LOG_LEVEL=${LOG_LEVEL:-info}

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -58,6 +58,11 @@ func TestRepositoryComposeMCPRouteContract(t *testing.T) {
 		want string
 	}{
 		{
+			name: "github の upstream endpoint（PAT 注入・auth=none なし）",
+			key:  "ROUTE_GITHUB",
+			want: "/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}|upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN",
+		},
+		{
 			name: "review-raven の upstream endpoint",
 			key:  "ROUTE_REVIEW_RAVEN",
 			want: "/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp",

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -60,12 +60,12 @@ func TestRepositoryComposeMCPRouteContract(t *testing.T) {
 		{
 			name: "review-raven の upstream endpoint",
 			key:  "ROUTE_REVIEW_RAVEN",
-			want: "/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp|auth=none",
+			want: "/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp",
 		},
 		{
 			name: "thread-owl の upstream endpoint",
 			key:  "ROUTE_THREAD_OWL",
-			want: "/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp|auth=none",
+			want: "/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## 概要

`ROUTE_GITHUB` / `ROUTE_REVIEW_RAVEN` / `ROUTE_THREAD_OWL` の `auth=none` を削除し、3 ルートに gateway OAuth 認証を適用する。

ref: scottlz0310/mcp-gateway#184

## 変更内容

```diff
- ROUTE_GITHUB=...|auth=none|upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN
+ ROUTE_GITHUB=...|upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN

- ROUTE_REVIEW_RAVEN=...|auth=none
+ ROUTE_REVIEW_RAVEN=...

- ROUTE_THREAD_OWL=...|auth=none
+ ROUTE_THREAD_OWL=...

  ROUTE_PLAYWRIGHT=...|auth=none  # 変更なし（認証不要な設計）
```

テスト: `TestRepositoryComposeMCPRouteContract` の期待値を更新（`auth=none` なし）

## セキュリティ上の問題（修正前）

| ルート | リスク |
|--------|--------|
| `ROUTE_GITHUB` | オーナー PAT + 44 ツールが localhost から無認証アクセス可能 |
| `ROUTE_REVIEW_RAVEN` | `X-Authenticated-User` を必要とする設計なのに auth=none で MCP 認証が機能不全 |
| `ROUTE_THREAD_OWL` | GitHub App トークンによる高権限操作（Issue/PR/レビュー）が認証なしで露出 |

## 注意事項

- `ROUTE_GITHUB` の `upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN` は `auth=none` と独立して動作するため、削除後も PAT 注入は継続される
- `ROUTE_PLAYWRIGHT` は認証不要サーバーの設計のまま `auth=none` を維持

## テスト計画

- [ ] `make restart` 後に `http://127.0.0.1:8080/mcp/github` へ未認証でアクセスし、401 が返ることを確認
- [ ] `http://127.0.0.1:8080/mcp/review-raven` へ未認証でアクセスし、401 が返ることを確認
- [ ] `http://127.0.0.1:8080/mcp/thread-owl` へ未認証でアクセスし、401 が返ることを確認
- [ ] OAuth 認証後に各 MCP ツールが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)