### PR TITLE
fix: credential ローテーション後の config.yaml 削除を make rotate-secret で自動化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ test-shell: ## シェルスクリプトのテスト実行
 .PHONY: rotate-secret
 rotate-secret: ## credential ローテーション後に永続 config を消去して再起動（tokens.db は保持）
 	docker compose down
-	$(SHELL) scripts/rotate-secret.sh
+	./scripts/rotate-secret.sh
 	$(MAKE) start-gateway
 
 # ----------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,16 @@ test-shell: ## シェルスクリプトのテスト実行
 	fi
 
 # ----------------------------------------
+# クレデンシャル管理
+# ----------------------------------------
+
+.PHONY: rotate-secret
+rotate-secret: ## credential ローテーション後に永続 config を消去して再起動（tokens.db は保持）
+	docker compose down
+	$(SHELL) scripts/rotate-secret.sh
+	$(MAKE) start-gateway
+
+# ----------------------------------------
 # クリーンアップ
 # ----------------------------------------
 

--- a/scripts/rotate-secret.sh
+++ b/scripts/rotate-secret.sh
@@ -1,10 +1,25 @@
 #!/bin/bash
 set -euo pipefail
 
-VOLUME=$(docker volume ls --filter label=com.docker.compose.volume=mcp-gateway-data -q | head -1 | tr -d '\r')
-if [ -z "$VOLUME" ]; then
+PROJECT=$(docker compose config 2>/dev/null | grep -E '^name:' | awk '{print $2}' | tr -d '\r')
+if [ -z "$PROJECT" ]; then
+  echo "エラー: Compose project 名を取得できませんでした" >&2
+  exit 1
+fi
+
+VOLUME=$(docker volume ls \
+  --filter label=com.docker.compose.volume=mcp-gateway-data \
+  --filter label=com.docker.compose.project="$PROJECT" \
+  -q | tr -d '\r')
+
+COUNT=$(printf '%s' "$VOLUME" | grep -c . || true)
+if [ "$COUNT" -eq 0 ]; then
   echo "mcp-gateway-data volume が見つかりません（初回起動前の状態です）"
   exit 0
+elif [ "$COUNT" -gt 1 ]; then
+  echo "エラー: mcp-gateway-data volume が複数見つかりました:" >&2
+  printf '%s\n' "$VOLUME" >&2
+  exit 1
 fi
 
 docker run --rm -v "$VOLUME:/data" alpine rm -f /data/config.yaml

--- a/scripts/rotate-secret.sh
+++ b/scripts/rotate-secret.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+VOLUME=$(docker volume ls --filter label=com.docker.compose.volume=mcp-gateway-data -q | head -1 | tr -d '\r')
+if [ -z "$VOLUME" ]; then
+  echo "mcp-gateway-data volume が見つかりません（初回起動前の状態です）"
+  exit 0
+fi
+
+docker run --rm -v "$VOLUME:/data" alpine rm -f /data/config.yaml
+echo "config.yaml を削除しました ($VOLUME)"


### PR DESCRIPTION
## Summary

- `make rotate-secret` ターゲットを追加（`Makefile`）
- `scripts/rotate-secret.sh` を追加

mcp-gateway は `/data/config.yaml` に暗号化済み client_secret を永続化し、環境変数より優先して使用する。そのため `docker compose down && up` でコンテナを再作成するだけでは新しい credential が反映されず、ローテーション後も `incorrect_client_credentials` が継続する。

`make rotate-secret` は以下を順に実行する:

1. `docker compose down` でコンテナを停止
2. `scripts/rotate-secret.sh` で `/data/config.yaml` を削除（`tokens.db` は保持）
3. `make start-gateway` でコンテナを再作成・起動

`scripts/rotate-secret.sh` は `docker volume ls` 出力に Windows 環境で混入する `\r` を `tr -d '\r'` で除去し、volume 名の誤解釈を防ぐ。

ローテーション後の手順:

```
bw sync ; dsx-env ; make rotate-secret
```

main ブランチの最新イメージで起動したい場合は追加で:

```
make pull-main ; make start-main
```

## Test plan

- [x] `make rotate-secret` 実行後にコンテナが起動すること
- [x] `/data/config.yaml` が削除され、起動時に環境変数から再生成されること
- [x] OAuth token exchange が成功すること（`incorrect_client_credentials` が出ないこと）
- [x] `tokens.db` が保持されること（既存セッションが維持される）

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)