### PR TITLE
[codex] fix: Windowsでrotate-secretのBashとパス解決を安定化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 バグ修正
+
+- Windows 版 GNU Make からシェルスクリプトを実行した際、`/bin/bash` が WSL の `bash.exe` に誤解決される問題を修正
+  - Windows では検出済みの Git for Windows Bash を明示し、`make lint-shell` と `make rotate-secret` を安定して実行可能に変更
+
 ### 🔐 セキュリティ
 
 - `ROUTE_GITHUB` / `ROUTE_REVIEW_RAVEN` / `ROUTE_THREAD_OWL` の `auth=none` を削除し、gateway OAuth 認証を必須化 — mcp-gateway#184

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Windows 版 GNU Make からシェルスクリプトを実行した際、`/bin/bash` が WSL の `bash.exe` に誤解決される問題を修正
   - Windows では検出済みの Git for Windows Bash を明示し、`make lint-shell` と `make rotate-secret` を安定して実行可能に変更
+  - `rotate-secret.sh` では Git Bash のパス変換を無効化し、永続 `config.yaml` の削除結果を検証
 
 ### 🔐 セキュリティ
 

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,11 @@ ifeq ($(OS),Windows_NT)
   endif
   SHELL       := $(GIT_BASH)
   .SHELLFLAGS := -c
+  BASH_CMD    := $(GIT_BASH)
   export LANG   := C.UTF-8
   export LC_ALL := C.UTF-8
+else
+  BASH_CMD    := bash
 endif
 
 # 環境変数優先、.env フォールバック（安全な awk テキスト抽出）
@@ -211,7 +214,7 @@ build-go: $(MCP_DOCKER) ## Go CLI をビルド
 
 .PHONY: lint-shell
 lint-shell: ## シェルスクリプトのlint実行
-	./scripts/lint-shell.sh
+	"$(BASH_CMD)" ./scripts/lint-shell.sh
 
 .PHONY: lint-go
 lint-go: ## Go 静的解析（golangci-lint + go vet フォールバック）
@@ -239,7 +242,7 @@ test-shell: ## シェルスクリプトのテスト実行
 .PHONY: rotate-secret
 rotate-secret: ## credential ローテーション後に永続 config を消去して再起動（tokens.db は保持）
 	docker compose down
-	./scripts/rotate-secret.sh
+	"$(BASH_CMD)" ./scripts/rotate-secret.sh
 	$(MAKE) start-gateway
 
 # ----------------------------------------

--- a/scripts/rotate-secret.sh
+++ b/scripts/rotate-secret.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-PROJECT=$(docker compose config 2>/dev/null | grep -E '^name:' | awk '{print $2}' | tr -d '\r')
+DOCKER_BIN=${DOCKER_BIN:-docker}
+
+PROJECT=$("$DOCKER_BIN" compose config 2>/dev/null | grep -E '^name:' | awk '{print $2}' | tr -d '\r')
 if [ -z "$PROJECT" ]; then
   echo "エラー: Compose project 名を取得できませんでした" >&2
   exit 1
 fi
 
-VOLUME=$(docker volume ls \
+VOLUME=$("$DOCKER_BIN" volume ls \
   --filter label=com.docker.compose.volume=mcp-gateway-data \
   --filter label=com.docker.compose.project="$PROJECT" \
   -q | tr -d '\r')
@@ -22,5 +24,7 @@ elif [ "$COUNT" -gt 1 ]; then
   exit 1
 fi
 
-docker run --rm -v "$VOLUME:/data" alpine rm -f /data/config.yaml
+# Git Bash によるコンテナ内パスの Windows パス変換を無効化する。
+MSYS_NO_PATHCONV=1 "$DOCKER_BIN" run --rm -v "$VOLUME:/data" alpine \
+  sh -c 'rm -f /data/config.yaml && test ! -e /data/config.yaml'
 echo "config.yaml を削除しました ($VOLUME)"

--- a/scripts/rotate-secret.sh
+++ b/scripts/rotate-secret.sh
@@ -25,6 +25,9 @@ elif [ "$COUNT" -gt 1 ]; then
 fi
 
 # Git Bash によるコンテナ内パスの Windows パス変換を無効化する。
-MSYS_NO_PATHCONV=1 "$DOCKER_BIN" run --rm -v "$VOLUME:/data" alpine \
-  sh -c 'rm -f /data/config.yaml && test ! -e /data/config.yaml'
+if ! MSYS_NO_PATHCONV=1 "$DOCKER_BIN" run --rm -v "$VOLUME:/data" alpine \
+  sh -c 'rm -f /data/config.yaml && test ! -e /data/config.yaml'; then
+  echo "エラー: /data/config.yaml の削除を確認できませんでした ($VOLUME)" >&2
+  exit 1
+fi
 echo "config.yaml を削除しました ($VOLUME)"

--- a/tests/shell/test_scripts.bats
+++ b/tests/shell/test_scripts.bats
@@ -7,6 +7,33 @@ setup() {
     export SCRIPTS_DIR="${PROJECT_ROOT}/scripts"
 }
 
+create_docker_mock() {
+    local mock_path="$1"
+    cat >"$mock_path" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+case "$1" in
+    compose)
+        printf 'name: test-project\n'
+        ;;
+    volume)
+        printf 'test-volume\n'
+        ;;
+    run)
+        printf 'MSYS_NO_PATHCONV=%s\n' "${MSYS_NO_PATHCONV:-}" >"${DOCKER_MOCK_LOG:?}"
+        printf 'arg=%s\n' "$@" >>"${DOCKER_MOCK_LOG}"
+        exit "${DOCKER_MOCK_RUN_STATUS:-0}"
+        ;;
+    *)
+        printf 'unexpected docker command: %s\n' "$1" >&2
+        exit 2
+        ;;
+esac
+EOF
+    chmod +x "$mock_path"
+}
+
 @test "health-check.sh: スクリプトが存在し実行可能" {
     [ -f "${SCRIPTS_DIR}/health-check.sh" ]
     [ -x "${SCRIPTS_DIR}/health-check.sh" ]
@@ -47,4 +74,36 @@ setup() {
 
 @test "lint-shell.sh: 構文エラーがない" {
     bash -n "${SCRIPTS_DIR}/lint-shell.sh"
+}
+
+@test "rotate-secret.sh: Git Bashのパス変換を無効化して削除を検証する" {
+    local mock_docker="${BATS_TEST_TMPDIR}/docker"
+    local mock_log="${BATS_TEST_TMPDIR}/docker.log"
+    create_docker_mock "$mock_docker"
+
+    run env \
+        DOCKER_BIN="$mock_docker" \
+        DOCKER_MOCK_LOG="$mock_log" \
+        "${SCRIPTS_DIR}/rotate-secret.sh"
+
+    [ "$status" -eq 0 ]
+    grep -Fx 'MSYS_NO_PATHCONV=1' "$mock_log"
+    grep -Fx 'arg=test-volume:/data' "$mock_log"
+    grep -Fx "arg=rm -f /data/config.yaml && test ! -e /data/config.yaml" "$mock_log"
+    [[ "$output" =~ "config.yaml を削除しました (test-volume)" ]]
+}
+
+@test "rotate-secret.sh: config削除の検証失敗を伝播する" {
+    local mock_docker="${BATS_TEST_TMPDIR}/docker"
+    local mock_log="${BATS_TEST_TMPDIR}/docker.log"
+    create_docker_mock "$mock_docker"
+
+    run env \
+        DOCKER_BIN="$mock_docker" \
+        DOCKER_MOCK_LOG="$mock_log" \
+        DOCKER_MOCK_RUN_STATUS=1 \
+        "${SCRIPTS_DIR}/rotate-secret.sh"
+
+    [ "$status" -eq 1 ]
+    [[ ! "$output" =~ "config.yaml を削除しました" ]]
 }

--- a/tests/shell/test_scripts.bats
+++ b/tests/shell/test_scripts.bats
@@ -90,7 +90,7 @@ EOF
     grep -Fx 'MSYS_NO_PATHCONV=1' "$mock_log"
     grep -Fx 'arg=test-volume:/data' "$mock_log"
     grep -Fx "arg=rm -f /data/config.yaml && test ! -e /data/config.yaml" "$mock_log"
-    [[ "$output" =~ "config.yaml を削除しました (test-volume)" ]]
+    [ "$output" = "config.yaml を削除しました (test-volume)" ]
 }
 
 @test "rotate-secret.sh: config削除の検証失敗を伝播する" {
@@ -105,5 +105,6 @@ EOF
         "${SCRIPTS_DIR}/rotate-secret.sh"
 
     [ "$status" -eq 1 ]
+    [[ "$output" == *"エラー: /data/config.yaml の削除を確認できませんでした (test-volume)"* ]]
     [[ ! "$output" =~ "config.yaml を削除しました" ]]
 }


### PR DESCRIPTION
## 概要

- Windows では検出済みの Git for Windows Bash を `BASH_CMD` として明示
- `make lint-shell` と `make rotate-secret` が同じ Bash を使うよう統一
- `rotate-secret.sh` のDocker CLI呼び出しでMSYSパス変換を無効化
- `config.yaml` 削除後のpostconditionを追加し、偽成功を防止
- mock Dockerを注入できる `DOCKER_BIN` と回帰テストを追加
- 変更内容を `CHANGELOG.md` のUnreleasedへ追記

## 原因

Windowsでは2段階の実行環境差がありました。

1. Windows版 GNU Makeが単純なrecipeを直接実行した際、`#!/bin/bash` がWindowsの `PATH` で解決され、Git for Windowsより先にある `C:\Windows\System32\bash.exe`（WSL relay）が選択される。
2. Git Bashで実行できるようになると、MSYSがコンテナ内パス `/data/config.yaml` を `C:/Program Files/Git/data/config.yaml` に変換する。`rm -f` は誤ったパスでも成功するため、古い永続configが残っていました。

残存した暗号化済みsecretは環境変数より優先され、GitHub OAuth exchangeが `incorrect_client_credentials` で失敗していました。

## 影響

Windows環境でもGit for Windows Bashのフルパスを使用し、Dockerコンテナ内パスを変換せずに処理します。削除結果を検証するため、同様の誤解決が再発した場合は成功表示せずエラー終了します。Unix環境では従来どおり `bash` を使用します。

## 検証

- `make lint-shell`
- `go test ./...`
- `make -n rotate-secret`
- `git diff --check`
- ShellCheck（`koalaman/shellcheck:stable`）
- Bats 10件（`bats/bats:latest`）
- Git Bash上で `MSYS_NO_PATHCONV=1` により `/data/config.yaml` が変換されないことを確認