### PR TITLE
feat(config): ROUTE_REVIEW_RAVEN に upstream_provider_token=true を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ 機能追加
+
+- `ROUTE_REVIEW_RAVEN` に `upstream_provider_token=true` を追加 — #197
+  - `OAUTH_PROVIDER=builtin` モードで gateway JWT の代わりに GitHub provider token が review-raven upstream に注入されるようになる
+  - gateway が独自 JWT を発行して provider token を破棄することで発生していた GitHub API 401 / `REAUTH_REQUIRED` を解消（mcp-gateway#186 の根本修正）
+
 ### 🐛 バグ修正
 
 - Windows 版 GNU Make からシェルスクリプトを実行した際、`/bin/bash` が WSL の `bash.exe` に誤解決される問題を修正

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - MCP_CONFIG_FILE=${MCP_CONFIG_FILE:-/data/config.yaml}
       - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
       - ROUTE_GITHUB=/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}|upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN
-      - ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp
+      - ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp|upstream_provider_token=true
       - ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:${PLAYWRIGHT_MCP_PORT:-8931}|auth=none
       - ROUTE_THREAD_OWL=/mcp/thread-owl|http://thread-owl:${THREAD_OWL_PORT:-3000}/mcp
       - OAUTH_SCOPES=${OAUTH_SCOPES:-${GITHUB_MCP_OAUTH_SCOPES:-repo,user}}

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -63,9 +63,9 @@ func TestRepositoryComposeMCPRouteContract(t *testing.T) {
 			want: "/mcp/github|http://github-mcp:${GITHUB_MCP_HTTP_PORT:-8082}|upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN",
 		},
 		{
-			name: "review-raven の upstream endpoint",
+			name: "review-raven の upstream endpoint（provider token 注入）",
 			key:  "ROUTE_REVIEW_RAVEN",
-			want: "/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp",
+			want: "/mcp/review-raven|http://review-raven:${REVIEW_RAVEN_PORT:-8083}/mcp|upstream_provider_token=true",
 		},
 		{
 			name: "thread-owl の upstream endpoint",


### PR DESCRIPTION
## Summary

- `ROUTE_REVIEW_RAVEN` に `upstream_provider_token=true` オプションを追加
- `OAUTH_PROVIDER=builtin` モードで gateway JWT の代わりに GitHub provider token が review-raven upstream に注入されるようになる
- コントラクトテスト（`TestRepositoryComposeMCPRouteContract`）の期待値を新しいルート文字列に更新

## Background

`OAUTH_PROVIDER=builtin` では gateway が独自 JWT を発行し GitHub provider token を破棄していた。
その結果、proxy が gateway JWT を review-raven upstream の `Authorization: Bearer` に設定し、
review-raven が JWT を GitHub token として使用 → GitHub API 401 → `REAUTH_REQUIRED` が発生していた。

`upstream_provider_token=true`（mcp-gateway#187 で実装）により、
`EnsureFreshAccessTokenForSubject` でサブジェクトの provider token を解決して upstream に注入する。

Closes #197

## Test plan

- [ ] `go test ./...` が全て PASS することを確認
- [ ] `docker compose up -d` 後に mcp-gateway ログで `"upstream_provider_token":true` が出力されることを確認
- [ ] Claude Code から thread-owl / review-raven MCP サーバーへの認証接続が成功することを確認

## References

- mcp-gateway PR: scottlz0310/mcp-gateway#187
- 修正対象 ISSUE: scottlz0310/mcp-gateway#186

🤖 Generated with [Claude Code](https://claude.com/claude-code)