### PR TITLE
fix: thread-owl の起動モードを実体に合わせて --mcp-http に修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 バグ修正
 
+- `thread-owl` サービスの起動モードを実体に合わせて修正 — #199
+  - `command` を `--webhook-mcp-http` から `--mcp-http` に変更（Webhook 受信経路が存在しないため）
+  - 未使用の `GITHUB_WEBHOOK_SECRET` 環境変数を削除（Webhook 受信を再導入する際に thread-owl#112 / Mcp-Docker#195 側で改めて追加）
 - Windows 版 GNU Make からシェルスクリプトを実行した際、`/bin/bash` が WSL の `bash.exe` に誤解決される問題を修正
   - Windows では検出済みの Git for Windows Bash を明示し、`make lint-shell` と `make rotate-secret` を安定して実行可能に変更
   - `rotate-secret.sh` では Git Bash のパス変換を無効化し、永続 `config.yaml` の削除結果を検証

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,7 @@ services:
     image: ${THREAD_OWL_IMAGE:-ghcr.io/scottlz0310/thread-owl:latest}
     container_name: thread-owl
     restart: unless-stopped
-    command: ["--webhook-mcp-http"]
+    command: ["--mcp-http"]
 
     environment:
       - GITHUB_APP_ID=${THREAD_OWL_GITHUB_APP_ID}
@@ -177,7 +177,6 @@ services:
       # volumes に ${THREAD_OWL_PEM_PATH}:/data/github-app.pem:ro を追加してください。
       - GITHUB_APP_PRIVATE_KEY_B64=${THREAD_OWL_GITHUB_APP_PRIVATE_KEY_B64}
       - ALLOWED_REPOS=${THREAD_OWL_ALLOWED_REPOS}
-      - GITHUB_WEBHOOK_SECRET=${THREAD_OWL_GITHUB_WEBHOOK_SECRET}
       - HOST=0.0.0.0
       - PORT=${THREAD_OWL_PORT:-3000}
       - LOG_LEVEL=${LOG_LEVEL:-info}


### PR DESCRIPTION
## 概要

`docker-compose.yml` の `thread-owl` サービスが `--webhook-mcp-http`（webhook + mcp-http 複合モード）で起動しており、未使用の `GITHUB_WEBHOOK_SECRET` 環境変数を必須要求していた。実際には Webhook 受信の実装・運用を行っておらず（host port 公開や tunnel も無く、GitHub からの配信を受け取れる経路が存在しない）、設定が実体より先走っていたため修正した。

## 変更内容

- `thread-owl` の `command` を `--webhook-mcp-http` から `--mcp-http` に変更
- 未使用の `GITHUB_WEBHOOK_SECRET` 環境変数を `docker-compose.yml` から削除
- CHANGELOG.md に変更内容を追記

## 非目標

- Webhook ingress（Cloudflare Tunnel 等）の実装自体はスコープ外（Mcp-Docker#195 で再評価）
- Webhook 受信の再導入時は thread-owl#112 / Mcp-Docker#195 側で `GITHUB_WEBHOOK_SECRET` を改めて追加する

## テスト計画

- [x] `docker compose config -q` で構文検証
- [x] `go test ./...` （lefthook pre-push で自動実行、全パス）
- [ ] `make restart` 後に thread-owl コンテナが `--mcp-http` モードで正常起動することを確認

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)