### PR TITLE
chore: mcp-gateway デフォルトイメージを :latest に復帰

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🔄 変更
+
+- `GITHUB_MCP_GATEWAY_IMAGE` のデフォルトを `:main` から `:latest` に復帰
+  - mcp-gateway v0.9.0 リリースにより、builtin AS（v0.8.0 収録）と TLS 終端（v0.9.0 収録、mcp-gateway#201）の両方が `:latest` に揃ったため
+  - リリース前の main ブランチビルドが必要な場合は従来どおり `make pull-main` / `make start-main` を使用
+
 ### ✨ 機能追加
 
 - ローカル HTTPS (TLS) 接続のための自動セットアップ機能を追加 — #202

--- a/Makefile
+++ b/Makefile
@@ -124,11 +124,9 @@ pull: pull-gateway ## 全サービスの Docker イメージを取得（pull-gat
 status: status-gateway ## 全サービスの状態確認（status-gateway のエイリアス）
 
 # :main イメージ
-# OAUTH_PROVIDER=builtin（gateway 自身が OIDC AS として動作）は未リリース（:latest 未収録）のため、
-# docker-compose.yml は :main をデフォルトとして使用する。
-# :latest にリリースされたら :main を :latest に戻すこと。
-# review-raven / thread-owl は :latest がリリース時のみ更新されるため、
-# 最新の main ブランチビルドを使いたい場合はこれらのターゲットを使用する。
+# docker-compose.yml のデフォルトは :latest（mcp-gateway v0.9.0 で builtin AS / TLS 終端とも収録済み）。
+# mcp-gateway / review-raven / thread-owl の :latest はリリース時のみ更新されるため、
+# リリース前の最新 main ブランチビルドを使いたい場合はこれらのターゲットを使用する。
 # ?= により環境変数・make コマンドライン引数での上書きが可能
 # 例: make pull-main MCP_GATEWAY_MAIN_IMAGE=ghcr.io/scottlz0310/mcp-gateway:edge
 MCP_GATEWAY_MAIN_IMAGE       ?= ghcr.io/scottlz0310/mcp-gateway:main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
           memory: 256M
 
   mcp-gateway:
-    image: ${GITHUB_MCP_GATEWAY_IMAGE:-ghcr.io/scottlz0310/mcp-gateway:main}
+    image: ${GITHUB_MCP_GATEWAY_IMAGE:-ghcr.io/scottlz0310/mcp-gateway:latest}
     container_name: mcp-gateway
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## 概要

mcp-gateway [v0.9.0](https://github.com/scottlz0310/mcp-gateway/releases/tag/v0.9.0) のリリースを受け、`GITHUB_MCP_GATEWAY_IMAGE` のデフォルトを `:main` から `:latest` に戻します。

## 背景

`:main` をデフォルトにしていた理由は「builtin AS（`OAUTH_PROVIDER=builtin`、mcp-gateway#126）が `:latest` 未収録」だったためです（Makefile のコメントに「`:latest` にリリースされたら戻すこと」と明記）。現在は以下の両方が `:latest` に収録済みで、戻す条件が揃いました:

- builtin AS: v0.8.0 で収録
- TLS 終端（mcp-gateway#201、Mcp-Docker#202 とペア）: v0.9.0 で収録

`ghcr.io/scottlz0310/mcp-gateway:latest` の manifest digest が `0.9` タグと一致（`sha256:28c0f67...`）することを確認済みです。

## 変更内容

- docker-compose.yml: デフォルトイメージを `:latest` に変更
- Makefile: `:main` 系ターゲット（`pull-main` / `start-main`）のコメントを「リリース前ビルドを使いたい場合の手段」として更新
- CHANGELOG.md 更新

.env.template は元々 `:latest` をデフォルトと記載していたため、本変更により記述と実態が一致します。

## 検証

- `docker compose config`: パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)