### PR TITLE
docs: GitHub App の Web UI 作業手順を詳細ドキュメント化 (#207)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -45,7 +45,7 @@ LOG_LEVEL=info
 # mcp-gateway — OAuth 2.0 認証ゲートウェイ（github-oauth-proxy の後継）
 # =============================================================================
 #
-# GitHub App の作成手順:
+# GitHub App の作成手順（画面遷移・フィールドの詳細は docs/github-app-setup.md を参照）:
 #   1. GitHub -> Settings -> Developer settings -> GitHub Apps -> New GitHub App
 #   2. Homepage URL: <MCP_GATEWAY_PUBLIC_URL>（例: http://127.0.0.1:8080）
 #   3. Authorization callback URLs（2本とも登録）:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ROUTE_THREAD_OWL`: GitHub App トークンによる高権限操作（Issue / PR / レビュー書き込み）が認証なしで露出していたリスクを解消
   - `ROUTE_PLAYWRIGHT` は認証不要な設計のまま維持（ローカルブラウザ制御専用）
 
+### 📝 ドキュメント
+
+- GitHub App の Web UI 作業手順を `docs/github-app-setup.md` に詳細化 — #207
+  - 現行 GitHub Web UI（2026-07 時点）の画面遷移・フィールドラベルに基づく新規登録手順、Client ID / Client secret の取得、TLS 切替時の Homepage URL / Callback URL 変更手順、トラブルシューティングを記載
+  - README の「GitHub App 登録」を要点のみに縮約し、詳細ドキュメントへの導線を追加。「ローカル HTTPS (TLS)」節を新設（`make setup-tls` と切替後の手作業の案内）
+  - `.env.template` のコメントから詳細ドキュメントを参照
+
 ## [2.15.0] - 2026-06-21
 
 ### ✨ 機能追加

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ make start-gateway
 
 mcp-gateway 経由で接続するには GitHub App が必要です。要点：
 
-- Homepage URL / Callback URL のベースは `MCP_GATEWAY_PUBLIC_URL`（未設定時は `http://127.0.0.1:8080`）と一致させる
+- Homepage URL / Callback URL のベースは gateway の公開 URL と一致させる（解決順: `MCP_GATEWAY_PUBLIC_URL` → 旧名 `MCP_GATEWAY_BASE_URL` → 既定 `http://127.0.0.1:8080`）
 - Callback URL は `<PUBLIC_URL>/callback` と `<PUBLIC_URL>/device_callback` の 2 本を登録する
 - 作成後に Client secret を生成し、`.env` の `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` に設定する
 

--- a/README.md
+++ b/README.md
@@ -88,33 +88,21 @@ make start-gateway
 
 ### GitHub App 登録
 
-mcp-gateway 経由で接続するには GitHub App が必要です。
+mcp-gateway 経由で接続するには GitHub App が必要です。要点：
 
-1. GitHub の **Settings > Developer settings > GitHub Apps > New GitHub App** を開く
-2. 設定：
-   - Homepage URL: `http://127.0.0.1:8080`
-   - Authorization callback URLs:
-     - `http://127.0.0.1:8080/callback`
-     - `http://127.0.0.1:8080/device_callback`
-   - Repository permissions:
-     - Metadata: Read-only（自動選択）
-     - Contents: Read-only
-     - Issues: Read and write
-     - Pull requests: Read and write
-   - Account permissions:
-     - Email addresses: Read-only
-   - Webhook: disabled
-   - Where can this GitHub App be installed?: 個人利用なら `Only on this account`
-3. 作成後、Client secret を生成し、Client ID / Secret を `.env` に設定：
+- Homepage URL / Callback URL のベースは `MCP_GATEWAY_PUBLIC_URL`（未設定時は `http://127.0.0.1:8080`）と一致させる
+- Callback URL は `<PUBLIC_URL>/callback` と `<PUBLIC_URL>/device_callback` の 2 本を登録する
+- 作成後に Client secret を生成し、`.env` の `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` に設定する
 
-```bash
-OAUTH_CLIENT_ID=Iv23xxxxxxxxxxxxxxxx
-OAUTH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```
+画面遷移・入力フィールド・Permissions の詳細は **[docs/github-app-setup.md](docs/github-app-setup.md)** を参照してください。
 
-> callback URL のベース URL は `MCP_GATEWAY_PUBLIC_URL`（未設定時は `MCP_GATEWAY_BASE_URL`）と一致させてください。`/callback` と `/device_callback` の 2 本を登録します。
->
 > GitHub OAuth App から移行する場合は、`.env` の `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` を GitHub App の値に置き換えます。旧 `GITHUB_MCP_CLIENT_ID` / `GITHUB_MCP_CLIENT_SECRET` も互換目的で読み取りますが、新規設定では `OAUTH_*` を使ってください。
+
+### ローカル HTTPS (TLS)
+
+`make setup-tls`（Windows）で mkcert による証明書生成と `.env` の自動構成（`MCP_GATEWAY_PUBLIC_URL` / TLS 証明書パス / `NODE_EXTRA_CA_CERTS`）を行い、gateway を HTTPS で公開できます。
+
+切替後は **GitHub App の Homepage URL / Callback URL の更新（GitHub Web UI での手作業）** と `make restart-gateway` / `make register-all` が必要です。手順は [docs/github-app-setup.md](docs/github-app-setup.md) を参照してください。
 
 
 ## CLI 統合

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -12,13 +12,20 @@ mcp-gateway 経由で MCP サーバーに接続するために必要な GitHub A
 
 ## 前提: ベース URL
 
-以降 `<PUBLIC_URL>` と表記する URL は `.env` の `MCP_GATEWAY_PUBLIC_URL` の値。
+以降 `<PUBLIC_URL>` と表記する URL は、gateway の公開 URL として実際に解決される値。
 GitHub App に登録する URL は**必ずこの値と一致させる**。
+
+解決順（`docker-compose.yml` と `mcp-docker register` で共通）:
+
+1. `MCP_GATEWAY_PUBLIC_URL`（推奨。新規設定はこちらを使う）
+2. `MCP_GATEWAY_BASE_URL`（旧名・後方互換エイリアス）
+3. `http://127.0.0.1:<port>`（既定。port は `MCP_GATEWAY_PORT`、未設定時 `8080`）
 
 | 構成 | `<PUBLIC_URL>` |
 |---|---|
-| デフォルト（HTTP） | `http://127.0.0.1:8080`（`MCP_GATEWAY_PORT` に追従） |
-| `make setup-tls` 実行後（HTTPS） | `https://localhost:8080`（setup-tls が `.env` に自動設定） |
+| デフォルト（HTTP、上記 1〜2 とも未設定） | `http://127.0.0.1:8080`（`MCP_GATEWAY_PORT` に追従） |
+| 旧変数 `MCP_GATEWAY_BASE_URL` のみ設定済みの既存環境 | その設定値（既定値より優先される点に注意） |
+| `make setup-tls` 実行後（HTTPS） | `https://localhost:8080`（setup-tls が `MCP_GATEWAY_PUBLIC_URL` を自動設定） |
 
 ## 1. GitHub App の新規登録
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -1,0 +1,105 @@
+# GitHub App セットアップガイド（GitHub Web UI 作業）
+
+mcp-gateway 経由で MCP サーバーに接続するために必要な GitHub App について、
+**GitHub Web UI 側で行う作業**（新規登録・TLS 切替時の URL 変更・Client secret 管理）を説明する。
+`.env` への設定値は [README](../README.md) および `.env.template` のコメントを参照。
+
+> 本書の画面遷移・ラベルは 2026-07 時点の GitHub Web UI（表示は英語）に基づく。
+> UI が変更された場合は公式ドキュメント
+> [Registering a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app) /
+> [Modifying a GitHub App registration](https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app-registration)
+> を参照。
+
+## 前提: ベース URL
+
+以降 `<PUBLIC_URL>` と表記する URL は `.env` の `MCP_GATEWAY_PUBLIC_URL` の値。
+GitHub App に登録する URL は**必ずこの値と一致させる**。
+
+| 構成 | `<PUBLIC_URL>` |
+|---|---|
+| デフォルト（HTTP） | `http://127.0.0.1:8080`（`MCP_GATEWAY_PORT` に追従） |
+| `make setup-tls` 実行後（HTTPS） | `https://localhost:8080`（setup-tls が `.env` に自動設定） |
+
+## 1. GitHub App の新規登録
+
+1. GitHub 右上のプロフィール画像 → **Settings** をクリック
+2. 左サイドバー最下部の **Developer settings** をクリック
+3. **GitHub Apps** → **New GitHub App** をクリック
+4. 各フィールドを設定する:
+
+   | フィールド / 項目 | 設定値 |
+   |---|---|
+   | **GitHub App name** | 任意の一意な名前（例: `mcp-docker-gateway-<user>`） |
+   | **Homepage URL** | `<PUBLIC_URL>` |
+   | **Callback URL** | `<PUBLIC_URL>/callback` を入力し、**Add Callback URL** をクリックして 2 本目に `<PUBLIC_URL>/device_callback` を追加（最大 10 本まで登録可能） |
+   | **Expire user authorization tokens** | チェックしたまま（既定）を推奨。refresh_token が発行され、`MCP_GATEWAY_GITHUB_REFRESH_ENABLED=true` による自動ローテーションが機能する |
+   | **Enable Device Flow** | チェック不要。`/device_callback` は mcp-gateway 自身が実装する Device Authorization Grant 用のエンドポイントであり、GitHub 側の device flow は使用しない |
+   | **Webhook** の **Active** | チェックを**外す**（Webhook は使用しない。外すと Webhook URL の入力は不要になる） |
+
+5. **Permissions** で以下を設定する（各権限は **No access** / **Read-only** / **Read & write** から選択）:
+
+   | カテゴリ | Permission | Access |
+   |---|---|---|
+   | Repository permissions | Metadata | Read-only（自動選択） |
+   | Repository permissions | Contents | Read-only |
+   | Repository permissions | Issues | Read and write |
+   | Repository permissions | Pull requests | Read and write |
+   | Account permissions | Email addresses | Read-only |
+
+6. **Where can this GitHub App be installed?** は、個人利用なら **Only on this account** を選択
+7. **Create GitHub App** をクリック
+
+## 2. Client ID / Client secret の取得
+
+App 作成直後は App の settings ページ（General）に遷移する。あとから開く場合は
+**Settings → Developer settings → GitHub Apps** で対象 App の右側の **Edit** をクリックする。
+
+1. settings ページ上部の **About** に表示される **Client ID**（`Iv23...` 形式）を控える
+   （**App ID とは別物**である点に注意）
+2. **Client secrets** セクションの **Generate a new client secret** をクリックし、
+   表示された secret を控える（**この画面を離れると再表示できない**。紛失時は再生成する）
+3. `.env` に設定する:
+
+   ```bash
+   OAUTH_CLIENT_ID=Iv23xxxxxxxxxxxxxxxx
+   OAUTH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+   ```
+
+## 3. TLS 切替時の変更（既存 App の URL 更新）
+
+`make setup-tls` は `.env` の `MCP_GATEWAY_PUBLIC_URL` を `https://localhost:<port>` に
+書き換えるが、**GitHub App 側の URL は自動では変わらない**。以下を手動で行う。
+
+1. **Settings → Developer settings → GitHub Apps** で対象 App の **Edit** をクリック
+2. General ページで以下を変更する:
+   - **Basic information** の **Homepage URL** → `https://localhost:<port>`
+   - **Identifying and authorizing users** の **Callback URL** 2 本:
+     - `https://localhost:<port>/callback`
+     - `https://localhost:<port>/device_callback`
+3. **Save changes** をクリック
+4. サービスを再起動し、CLI の登録 URL を更新する:
+
+   ```bash
+   make restart-gateway
+   make register-all
+   ```
+
+> **旧 URL を残す場合**: Callback URL は最大 10 本登録できるため、HTTP へ戻す可能性が
+> あるなら旧 `http://127.0.0.1:<port>/...` の 2 本を残したまま https の 2 本を追加してもよい。
+> ただし認可リクエストの `redirect_uri` を省略した場合は**先頭の Callback URL** が使われるため、
+> 並び順には注意する。
+
+## 4. トラブルシューティング
+
+| 症状 | 原因と対処 |
+|---|---|
+| 認可時に `redirect_uri` エラー（"The redirect_uri is not associated with this application." 等） | GitHub App の Callback URL が `<PUBLIC_URL>` と一致していない。scheme（http/https）・host（`127.0.0.1`/`localhost`）・port のいずれかの食い違いでも発生する。セクション 3 の手順で更新する |
+| TLS 切替後にブラウザが証明書警告を出す | mkcert のローカル CA が信頼されていない。`make setup-tls` を再実行する（CA の生成・信頼登録は冪等） |
+| Node.js 製 MCP クライアントが TLS 接続に失敗する | `NODE_EXTRA_CA_CERTS`（setup-tls が `.env` に自動設定）がクライアントのプロセス環境に渡っていない |
+| 認可後に 401 が続く | Client secret の値違い・失効の可能性。セクション 2 の手順で再生成し `.env` を更新、`make restart-gateway` |
+
+## 関連
+
+- [README — GitHub App 登録](../README.md#github-app-登録)（最低限の要点）
+- [mcp-gateway](https://github.com/scottlz0310/mcp-gateway) — `/callback` / `/device_callback` の実装元
+- Mcp-Docker #202 / #207、mcp-gateway #201（ローカル TLS 終端）


### PR DESCRIPTION
## 概要

GitHub App の Web UI 作業手順（新規登録・TLS 切替時の Callback URL 変更）を `docs/github-app-setup.md` に詳細化し、README は最低限の案内に縮約します。

Closes #207

## 背景

TLS 切替（`make setup-tls`、#202/#203）後は GitHub App の Homepage URL / Callback URL の変更が必要ですが、案内が `setup-tls.ps1` 完了時のターミナル出力のみで、ファイルとして文書化されていませんでした（README には TLS セクション自体が存在しない）。

## 変更内容

- **`docs/github-app-setup.md` 新設**: 現行 GitHub Web UI（2026-07 時点）を調査した上で以下を文書化
  - 新規登録手順（画面遷移・フィールドラベル・Permissions・`Create GitHub App` まで）
  - Client ID / Client secret の取得（`Generate a new client secret`、App ID との違いの注記）
  - TLS 切替時の既存 App 変更手順（`Edit` → Homepage URL / Callback URL → `Save changes` → `make restart-gateway` / `make register-all`）
  - トラブルシューティング（redirect_uri 不一致・証明書警告・`NODE_EXTRA_CA_CERTS`）
  - UI ラベルは GitHub 公式 docs / github/docs リポジトリ原文で照合
- **README**: 「GitHub App 登録」を要点のみに縮約し詳細へリンク。「ローカル HTTPS (TLS)」節を新設
- **.env.template**: コメントから詳細ドキュメントを参照
- **CHANGELOG.md**: 更新

## 検証

- `go test ./...` / lint: パス（pre-push フック）
- ドキュメント記載の UI ラベルは docs.github.com（Registering a GitHub App / Modifying a GitHub App registration）および github/docs 原文と照合済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
