### PR TITLE
fix(register): prune の stale 判定を複数 origin 照合に拡張 (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 バグ修正
 
+- `mcp-docker register --prune` が TLS 切替前の旧 origin で登録されたエントリを検出できない問題を修正 — #206
+  - stale 判定を複数 origin 照合に拡張し、`MCP_GATEWAY_PUBLIC_URL` 由来の現 origin に加えてデフォルト origin（`http://127.0.0.1:<port>/`）も既知の gateway origin として照合
+  - compose から削除済みかつ旧 origin で登録されたエントリが「削除対象の stale エントリはありません」と誤報告されたまま残留していた
 - Windows で `TestRegisterTimeoutOnAddCommand` / `TestRegisterTimeoutOnPruneCommand` が cmd.exe の起動オーバーヘッドにより `claude list` 段階で誤ってタイムアウトする flaky を修正（タイムアウトを 100ms から 2s に緩和）
 - `thread-owl` サービスの起動モードを実体に合わせて修正 — #199
   - `command` を `--webhook-mcp-http` から `--mcp-http` に変更（Webhook 受信経路が存在しないため）

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -150,9 +150,9 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		return err
 	}
 	pruneEnabled := opts.prune || useInteractive
-	var gatewayOrigin string
+	var gatewayOrigins []string
 	if pruneEnabled {
-		gatewayOrigin, err = compose.GatewayOrigin(opts.composePath)
+		gatewayOrigins, err = compose.GatewayOrigins(opts.composePath)
 		if err != nil {
 			return err
 		}
@@ -193,7 +193,7 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		if !pruneEnabled {
 			continue
 		}
-		err := pruneAgent(ctx, stdinReader, stdout, agent, existing, servers, gatewayOrigin, opts, useInteractive)
+		err := pruneAgent(ctx, stdinReader, stdout, agent, existing, servers, gatewayOrigins, opts, useInteractive)
 		if err != nil {
 			return err
 		}
@@ -204,8 +204,8 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 // pruneAgent は agent に登録済みで定義ファイルに含まれない gateway 配下のエントリを削除する。
 // interactive では候補を個別選択（既定は削除しない）し、削除前に必ず最終確認を行う。
 // 非対話では --yes 指定時のみ確認を省略する。
-func pruneAgent(ctx context.Context, reader *bufio.Reader, stdout io.Writer, agent register.Agent, existing []register.Entry, available []register.Server, gatewayOrigin string, opts registerOptions, interactive bool) error {
-	stale := register.StaleEntries(existing, available, gatewayOrigin)
+func pruneAgent(ctx context.Context, reader *bufio.Reader, stdout io.Writer, agent register.Agent, existing []register.Entry, available []register.Server, gatewayOrigins []string, opts registerOptions, interactive bool) error {
+	stale := register.StaleEntries(existing, available, gatewayOrigins)
 	if len(stale) == 0 {
 		fmt.Fprintf(stdout, "%s: 削除対象の stale エントリはありません\n", agent.Name())
 		return nil

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -490,7 +490,7 @@ func TestPruneAgent(t *testing.T) {
 		{Name: "old-route", URL: "http://127.0.0.1:8080/mcp/old-route"},
 	}
 	available := []register.Server{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}}
-	const origin = "http://127.0.0.1:8080/"
+	origins := []string{"http://127.0.0.1:8080/"}
 
 	cases := []struct {
 		name        string
@@ -561,7 +561,7 @@ func TestPruneAgent(t *testing.T) {
 			var stdout bytes.Buffer
 			reader := bufio.NewReader(strings.NewReader(tc.input))
 
-			err := pruneAgent(context.Background(), reader, &stdout, agent, tc.entries, available, origin, tc.opts, tc.interactive)
+			err := pruneAgent(context.Background(), reader, &stdout, agent, tc.entries, available, origins, tc.opts, tc.interactive)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/compose/parse.go
+++ b/internal/compose/parse.go
@@ -79,22 +79,30 @@ func Parse(data []byte, lookup func(string) (string, bool)) ([]register.Server, 
 	return servers, nil
 }
 
-// GatewayOrigin は register が生成する URL の接頭辞
-// （MCP_GATEWAY_PUBLIC_URL 由来、既定は http://127.0.0.1:<port>/）を返す。
-func GatewayOrigin(path string) (string, error) {
+// GatewayOrigins は register が生成しうる URL の接頭辞の集合
+// （MCP_GATEWAY_PUBLIC_URL 由来の origin と、既定の http://127.0.0.1:<port>/）を返す。
+func GatewayOrigins(path string) ([]string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return gatewayOrigin(data, os.LookupEnv)
+	return gatewayOrigins(data, os.LookupEnv)
 }
 
-func gatewayOrigin(data []byte, lookup func(string) (string, bool)) (string, error) {
+// gatewayOrigins は現在の origin に加え、常に導出可能なデフォルト origin
+// （http://127.0.0.1:<port>/）を返す。TLS 切替等で MCP_GATEWAY_PUBLIC_URL が
+// 変わると、旧 origin で登録済みのエントリが stale 判定から漏れて残留するため、
+// デフォルト origin も既知の gateway origin として prune 判定に含める。
+func gatewayOrigins(data []byte, lookup func(string) (string, bool)) ([]string, error) {
 	env, err := gatewayEnv(data)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return gatewayBaseURL(env, lookup) + "/", nil
+	origins := []string{gatewayBaseURL(env, lookup) + "/"}
+	if def := "http://127.0.0.1:" + gatewayPort(env, lookup) + "/"; def != origins[0] {
+		origins = append(origins, def)
+	}
+	return origins, nil
 }
 
 // gatewayBaseURL は register が生成する URL のベース（scheme://host:port）を返す。

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -239,7 +239,7 @@ services:
 	}
 }
 
-func TestGatewayOrigin(t *testing.T) {
+func TestGatewayOrigins(t *testing.T) {
 	const portYAML = `
 services:
   mcp-gateway:
@@ -250,42 +250,53 @@ services:
 		name string
 		yaml string
 		env  map[string]string
-		want string
+		want []string
 	}{
 		{
 			name: "environment 未定義ならデフォルトポート",
 			yaml: "services:\n  mcp-gateway: {}\n",
-			want: "http://127.0.0.1:8080/",
+			want: []string{"http://127.0.0.1:8080/"},
 		},
 		{
 			name: "compose の既定値を展開",
 			yaml: portYAML,
-			want: "http://127.0.0.1:9090/",
+			want: []string{"http://127.0.0.1:9090/"},
 		},
 		{
 			name: "実環境変数が優先される",
 			yaml: portYAML,
 			env:  map[string]string{"MCP_GATEWAY_PORT": "7000"},
-			want: "http://127.0.0.1:7000/",
+			want: []string{"http://127.0.0.1:7000/"},
 		},
 		{
-			name: "MCP_GATEWAY_PUBLIC_URL が origin に反映される",
+			name: "PUBLIC_URL 設定時はデフォルト origin も併せて返す",
 			yaml: portYAML,
 			env:  map[string]string{"MCP_GATEWAY_PUBLIC_URL": "https://localhost:8080"},
-			want: "https://localhost:8080/",
+			want: []string{"https://localhost:8080/", "http://127.0.0.1:9090/"},
+		},
+		{
+			name: "PUBLIC_URL がデフォルト origin と同値なら重複しない",
+			yaml: portYAML,
+			env:  map[string]string{"MCP_GATEWAY_PUBLIC_URL": "http://127.0.0.1:9090"},
+			want: []string{"http://127.0.0.1:9090/"},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := gatewayOrigin([]byte(tc.yaml), func(key string) (string, bool) {
+			got, err := gatewayOrigins([]byte(tc.yaml), func(key string) (string, bool) {
 				val, ok := tc.env[key]
 				return val, ok
 			})
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got != tc.want {
-				t.Fatalf("origin = %q, want %q", got, tc.want)
+			if len(got) != len(tc.want) {
+				t.Fatalf("origins = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("origins = %v, want %v", got, tc.want)
+				}
 			}
 		})
 	}

--- a/internal/register/agent.go
+++ b/internal/register/agent.go
@@ -71,8 +71,10 @@ func Register(ctx context.Context, out io.Writer, agent Agent, servers []Server,
 
 // StaleEntries は agent に登録済みのエントリのうち、gateway 配下の URL を持ち、
 // かつ定義ファイル（available）に含まれないものを返す。
+// gatewayOrigins には現在の origin に加え、TLS 切替前のデフォルト origin など
+// 既知の gateway origin を複数渡せる。
 // URL が特定できないエントリは mcp-docker 管理外の可能性があるため候補にしない。
-func StaleEntries(entries []Entry, available []Server, gatewayOrigin string) []Entry {
+func StaleEntries(entries []Entry, available []Server, gatewayOrigins []string) []Entry {
 	availableNames := make(map[string]struct{}, len(available))
 	for _, server := range available {
 		availableNames[server.Name] = struct{}{}
@@ -82,12 +84,21 @@ func StaleEntries(entries []Entry, available []Server, gatewayOrigin string) []E
 		if _, ok := availableNames[entry.Name]; ok {
 			continue
 		}
-		if entry.URL == "" || !strings.HasPrefix(entry.URL, gatewayOrigin) {
+		if entry.URL == "" || !hasAnyPrefix(entry.URL, gatewayOrigins) {
 			continue
 		}
 		stale = append(stale, entry)
 	}
 	return stale
+}
+
+func hasAnyPrefix(url string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(url, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func Prune(ctx context.Context, out io.Writer, agent Agent, entries []Entry) error {

--- a/internal/register/prune_test.go
+++ b/internal/register/prune_test.go
@@ -32,11 +32,12 @@ func (f *fakeAgent) RemoveCommand(name string) []string { return []string{"remov
 
 func TestStaleEntries(t *testing.T) {
 	available := []Server{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}}
-	const origin = "http://127.0.0.1:8080/"
+	defaultOrigins := []string{"http://127.0.0.1:8080/"}
 
 	cases := []struct {
 		name    string
 		entries []Entry
+		origins []string
 		want    []string
 	}{
 		{
@@ -68,10 +69,26 @@ func TestStaleEntries(t *testing.T) {
 			},
 			want: []string{"old-a", "old-b"},
 		},
+		{
+			name:    "TLS 切替後も旧 origin のエントリを候補にする",
+			entries: []Entry{{Name: "old-http", URL: "http://127.0.0.1:8080/mcp/old-http"}},
+			origins: []string{"https://localhost:8080/", "http://127.0.0.1:8080/"},
+			want:    []string{"old-http"},
+		},
+		{
+			name:    "どの origin にも一致しない URL は候補外",
+			entries: []Entry{{Name: "other-host", URL: "http://192.168.0.10:8080/mcp/other"}},
+			origins: []string{"https://localhost:8080/", "http://127.0.0.1:8080/"},
+			want:    nil,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			stale := StaleEntries(tc.entries, available, origin)
+			origins := tc.origins
+			if origins == nil {
+				origins = defaultOrigins
+			}
+			stale := StaleEntries(tc.entries, available, origins)
 			got := make([]string, 0, len(stale))
 			for _, entry := range stale {
 				got = append(got, entry.Name)


### PR DESCRIPTION
## 概要

`mcp-docker register --prune` の stale 判定を複数 origin 照合に拡張し、TLS 切替前の旧 origin で登録されたエントリを prune 対象にできるようにします。

Closes #206

> **チェーン**: base は #208（docs/207-github-app-web-ui-guide）。#208 マージ後に base を main に変更してください。

## 背景

`make setup-tls` は `MCP_GATEWAY_PUBLIC_URL=https://localhost:<port>` を書き込むため、gateway origin は `http://127.0.0.1:<port>/` から scheme・host の両方が変わります。`StaleEntries` は現 origin の前方一致のみで判定していたため、「compose から削除済み かつ 旧 origin で登録」のエントリが候補から漏れ、「削除対象の stale エントリはありません」と誤報告されたまま残留していました（現役ルートは `Register` の名前照合で上書きされるため影響なし）。

## 変更内容

- `compose.GatewayOrigin` → `GatewayOrigins`: 現 origin に加え、常に導出可能なデフォルト origin（`http://127.0.0.1:<port>/`）を返す（同値なら重複排除）
- `register.StaleEntries`: `gatewayOrigins []string` を受け取り、いずれかの origin に前方一致すれば gateway 配下と判定
- `cmd/mcp-docker` の配線・テストを追従
- パラメータ化テストに「TLS 切替後も旧 origin のエントリを候補にする」「どの origin にも一致しない URL は候補外」を追加

## 誤検出リスクについて

デフォルト origin は gateway 自身の既定エンドポイントであり、prune は対話選択（既定は削除しない）＋最終確認付きのため、誤検出リスクは許容範囲と判断しています。

## 検証

- `go vet ./...` / `go test ./...`: パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
