### PR TITLE
test: setup-tls.ps1 の Pester テスト基盤を整備 (#204)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -45,7 +45,7 @@ LOG_LEVEL=info
 # mcp-gateway — OAuth 2.0 認証ゲートウェイ（github-oauth-proxy の後継）
 # =============================================================================
 #
-# GitHub App の作成手順:
+# GitHub App の作成手順（画面遷移・フィールドの詳細は docs/github-app-setup.md を参照）:
 #   1. GitHub -> Settings -> Developer settings -> GitHub Apps -> New GitHub App
 #   2. Homepage URL: <MCP_GATEWAY_PUBLIC_URL>（例: http://127.0.0.1:8080）
 #   3. Authorization callback URLs（2本とも登録）:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -36,6 +36,28 @@ jobs:
       - name: シェルスクリプトテスト実行
         run: bats tests/shell/*.bats
 
+  test-powershell:
+    name: PowerShell Lint・テスト（PSScriptAnalyzer/Pester）
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+          $results = @('scripts', 'tests/powershell') | ForEach-Object {
+            Invoke-ScriptAnalyzer -Path $_ -Recurse -Settings PSScriptAnalyzerSettings.psd1
+          }
+          $results | Format-Table RuleName, Severity, ScriptName, Line -AutoSize
+          if ($results) { exit 1 }
+
+      - name: Pester テスト
+        shell: pwsh
+        run: |
+          Install-Module Pester -MinimumVersion 5.5 -Force -Scope CurrentUser -SkipPublisherCheck
+          Invoke-Pester -Path tests/powershell -Output Detailed -CI
+
   test-go:
     name: Go CLI チェック（vet/test/build）
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 バグ修正
 
+- `mcp-docker register --prune` が TLS 切替前の旧 origin で登録されたエントリを検出できない問題を修正 — #206
+  - stale 判定を複数 origin 照合に拡張し、`MCP_GATEWAY_PUBLIC_URL` 由来の現 origin に加えてデフォルト origin（`http://127.0.0.1:<port>/`）も既知の gateway origin として照合
+  - compose から削除済みかつ旧 origin で登録されたエントリが「削除対象の stale エントリはありません」と誤報告されたまま残留していた
 - Windows で `TestRegisterTimeoutOnAddCommand` / `TestRegisterTimeoutOnPruneCommand` が cmd.exe の起動オーバーヘッドにより `claude list` 段階で誤ってタイムアウトする flaky を修正（タイムアウトを 100ms から 2s に緩和）
 - `thread-owl` サービスの起動モードを実体に合わせて修正 — #199
   - `command` を `--webhook-mcp-http` から `--mcp-http` に変更（Webhook 受信経路が存在しないため）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `setup-tls.ps1` は証明書生成時の CA fingerprint を `config/certs/.ca-fingerprint` に記録し、CA 再生成後の旧証明書再利用を防止
   - mcp-gateway 側の TLS 終端実装（mcp-gateway#201）とペアで機能
 
+- PowerShell テスト基盤（Pester + PSScriptAnalyzer）を整備 — #204
+  - `scripts/setup-tls.ps1` の `.env` 更新・証明書再利用判定ロジックを `scripts/lib/setup-tls-functions.ps1` に分離（mkcert / winget / UAC 昇格などの環境依存処理は本体に残置）
+  - `tests/powershell/setup-tls.Tests.ps1`（Pester 5 形式）: `Set-EnvValue` / `Get-EnvValue` の置換・追記・BOM なし UTF-8 書き込み、CA fingerprint 比較による証明書再生成判定（PR #203 レビュー指摘の固定化）を検証
+  - CI に `windows-latest` の PSScriptAnalyzer + Pester ジョブを追加。除外ルールは `PSScriptAnalyzerSettings.psd1` に理由付きで明文化
+
 - `ROUTE_REVIEW_RAVEN` に `upstream_provider_token=true` を追加 — #197
   - `OAUTH_PROVIDER=builtin` モードで gateway JWT の代わりに GitHub provider token が review-raven upstream に注入されるようになる
   - gateway が独自 JWT を発行して provider token を破棄することで発生していた GitHub API 401 / `REAUTH_REQUIRED` を解消（mcp-gateway#186 の根本修正）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ROUTE_THREAD_OWL`: GitHub App トークンによる高権限操作（Issue / PR / レビュー書き込み）が認証なしで露出していたリスクを解消
   - `ROUTE_PLAYWRIGHT` は認証不要な設計のまま維持（ローカルブラウザ制御専用）
 
+### 📝 ドキュメント
+
+- GitHub App の Web UI 作業手順を `docs/github-app-setup.md` に詳細化 — #207
+  - 現行 GitHub Web UI（2026-07 時点）の画面遷移・フィールドラベルに基づく新規登録手順、Client ID / Client secret の取得、TLS 切替時の Homepage URL / Callback URL 変更手順、トラブルシューティングを記載
+  - README の「GitHub App 登録」を要点のみに縮約し、詳細ドキュメントへの導線を追加。「ローカル HTTPS (TLS)」節を新設（`make setup-tls` と切替後の手作業の案内）
+  - `.env.template` のコメントから詳細ドキュメントを参照
+
 ## [2.15.0] - 2026-06-21
 
 ### ✨ 機能追加

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,10 @@
+@{
+    ExcludeRules = @(
+        # 対話型セットアップスクリプトの進行表示に意図的に使用している
+        # （PowerShell 5.0+ では information stream に乗るため抑止・リダイレクト可能）
+        'PSAvoidUsingWriteHost',
+        # リポジトリ標準は BOM なし UTF-8（BOM は Makefile の awk 抽出や
+        # docker compose の .env 解析を壊すため、.ps1 も同一ポリシーで統一する）
+        'PSUseBOMForUnicodeEncodedFile'
+    )
+}

--- a/README.md
+++ b/README.md
@@ -88,33 +88,21 @@ make start-gateway
 
 ### GitHub App 登録
 
-mcp-gateway 経由で接続するには GitHub App が必要です。
+mcp-gateway 経由で接続するには GitHub App が必要です。要点：
 
-1. GitHub の **Settings > Developer settings > GitHub Apps > New GitHub App** を開く
-2. 設定：
-   - Homepage URL: `http://127.0.0.1:8080`
-   - Authorization callback URLs:
-     - `http://127.0.0.1:8080/callback`
-     - `http://127.0.0.1:8080/device_callback`
-   - Repository permissions:
-     - Metadata: Read-only（自動選択）
-     - Contents: Read-only
-     - Issues: Read and write
-     - Pull requests: Read and write
-   - Account permissions:
-     - Email addresses: Read-only
-   - Webhook: disabled
-   - Where can this GitHub App be installed?: 個人利用なら `Only on this account`
-3. 作成後、Client secret を生成し、Client ID / Secret を `.env` に設定：
+- Homepage URL / Callback URL のベースは `MCP_GATEWAY_PUBLIC_URL`（未設定時は `http://127.0.0.1:8080`）と一致させる
+- Callback URL は `<PUBLIC_URL>/callback` と `<PUBLIC_URL>/device_callback` の 2 本を登録する
+- 作成後に Client secret を生成し、`.env` の `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` に設定する
 
-```bash
-OAUTH_CLIENT_ID=Iv23xxxxxxxxxxxxxxxx
-OAUTH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```
+画面遷移・入力フィールド・Permissions の詳細は **[docs/github-app-setup.md](docs/github-app-setup.md)** を参照してください。
 
-> callback URL のベース URL は `MCP_GATEWAY_PUBLIC_URL`（未設定時は `MCP_GATEWAY_BASE_URL`）と一致させてください。`/callback` と `/device_callback` の 2 本を登録します。
->
 > GitHub OAuth App から移行する場合は、`.env` の `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` を GitHub App の値に置き換えます。旧 `GITHUB_MCP_CLIENT_ID` / `GITHUB_MCP_CLIENT_SECRET` も互換目的で読み取りますが、新規設定では `OAUTH_*` を使ってください。
+
+### ローカル HTTPS (TLS)
+
+`make setup-tls`（Windows）で mkcert による証明書生成と `.env` の自動構成（`MCP_GATEWAY_PUBLIC_URL` / TLS 証明書パス / `NODE_EXTRA_CA_CERTS`）を行い、gateway を HTTPS で公開できます。
+
+切替後は **GitHub App の Homepage URL / Callback URL の更新（GitHub Web UI での手作業）** と `make restart-gateway` / `make register-all` が必要です。手順は [docs/github-app-setup.md](docs/github-app-setup.md) を参照してください。
 
 
 ## CLI 統合

--- a/cmd/mcp-docker/main.go
+++ b/cmd/mcp-docker/main.go
@@ -150,9 +150,9 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		return err
 	}
 	pruneEnabled := opts.prune || useInteractive
-	var gatewayOrigin string
+	var gatewayOrigins []string
 	if pruneEnabled {
-		gatewayOrigin, err = compose.GatewayOrigin(opts.composePath)
+		gatewayOrigins, err = compose.GatewayOrigins(opts.composePath)
 		if err != nil {
 			return err
 		}
@@ -193,7 +193,7 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 		if !pruneEnabled {
 			continue
 		}
-		err := pruneAgent(ctx, stdinReader, stdout, agent, existing, servers, gatewayOrigin, opts, useInteractive)
+		err := pruneAgent(ctx, stdinReader, stdout, agent, existing, servers, gatewayOrigins, opts, useInteractive)
 		if err != nil {
 			return err
 		}
@@ -204,8 +204,8 @@ func runRegister(ctx context.Context, args []string, stdout, stderr io.Writer, s
 // pruneAgent は agent に登録済みで定義ファイルに含まれない gateway 配下のエントリを削除する。
 // interactive では候補を個別選択（既定は削除しない）し、削除前に必ず最終確認を行う。
 // 非対話では --yes 指定時のみ確認を省略する。
-func pruneAgent(ctx context.Context, reader *bufio.Reader, stdout io.Writer, agent register.Agent, existing []register.Entry, available []register.Server, gatewayOrigin string, opts registerOptions, interactive bool) error {
-	stale := register.StaleEntries(existing, available, gatewayOrigin)
+func pruneAgent(ctx context.Context, reader *bufio.Reader, stdout io.Writer, agent register.Agent, existing []register.Entry, available []register.Server, gatewayOrigins []string, opts registerOptions, interactive bool) error {
+	stale := register.StaleEntries(existing, available, gatewayOrigins)
 	if len(stale) == 0 {
 		fmt.Fprintf(stdout, "%s: 削除対象の stale エントリはありません\n", agent.Name())
 		return nil

--- a/cmd/mcp-docker/main_test.go
+++ b/cmd/mcp-docker/main_test.go
@@ -490,7 +490,7 @@ func TestPruneAgent(t *testing.T) {
 		{Name: "old-route", URL: "http://127.0.0.1:8080/mcp/old-route"},
 	}
 	available := []register.Server{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}}
-	const origin = "http://127.0.0.1:8080/"
+	origins := []string{"http://127.0.0.1:8080/"}
 
 	cases := []struct {
 		name        string
@@ -561,7 +561,7 @@ func TestPruneAgent(t *testing.T) {
 			var stdout bytes.Buffer
 			reader := bufio.NewReader(strings.NewReader(tc.input))
 
-			err := pruneAgent(context.Background(), reader, &stdout, agent, tc.entries, available, origin, tc.opts, tc.interactive)
+			err := pruneAgent(context.Background(), reader, &stdout, agent, tc.entries, available, origins, tc.opts, tc.interactive)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -1,0 +1,105 @@
+# GitHub App セットアップガイド（GitHub Web UI 作業）
+
+mcp-gateway 経由で MCP サーバーに接続するために必要な GitHub App について、
+**GitHub Web UI 側で行う作業**（新規登録・TLS 切替時の URL 変更・Client secret 管理）を説明する。
+`.env` への設定値は [README](../README.md) および `.env.template` のコメントを参照。
+
+> 本書の画面遷移・ラベルは 2026-07 時点の GitHub Web UI（表示は英語）に基づく。
+> UI が変更された場合は公式ドキュメント
+> [Registering a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app) /
+> [Modifying a GitHub App registration](https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app-registration)
+> を参照。
+
+## 前提: ベース URL
+
+以降 `<PUBLIC_URL>` と表記する URL は `.env` の `MCP_GATEWAY_PUBLIC_URL` の値。
+GitHub App に登録する URL は**必ずこの値と一致させる**。
+
+| 構成 | `<PUBLIC_URL>` |
+|---|---|
+| デフォルト（HTTP） | `http://127.0.0.1:8080`（`MCP_GATEWAY_PORT` に追従） |
+| `make setup-tls` 実行後（HTTPS） | `https://localhost:8080`（setup-tls が `.env` に自動設定） |
+
+## 1. GitHub App の新規登録
+
+1. GitHub 右上のプロフィール画像 → **Settings** をクリック
+2. 左サイドバー最下部の **Developer settings** をクリック
+3. **GitHub Apps** → **New GitHub App** をクリック
+4. 各フィールドを設定する:
+
+   | フィールド / 項目 | 設定値 |
+   |---|---|
+   | **GitHub App name** | 任意の一意な名前（例: `mcp-docker-gateway-<user>`） |
+   | **Homepage URL** | `<PUBLIC_URL>` |
+   | **Callback URL** | `<PUBLIC_URL>/callback` を入力し、**Add Callback URL** をクリックして 2 本目に `<PUBLIC_URL>/device_callback` を追加（最大 10 本まで登録可能） |
+   | **Expire user authorization tokens** | チェックしたまま（既定）を推奨。refresh_token が発行され、`MCP_GATEWAY_GITHUB_REFRESH_ENABLED=true` による自動ローテーションが機能する |
+   | **Enable Device Flow** | チェック不要。`/device_callback` は mcp-gateway 自身が実装する Device Authorization Grant 用のエンドポイントであり、GitHub 側の device flow は使用しない |
+   | **Webhook** の **Active** | チェックを**外す**（Webhook は使用しない。外すと Webhook URL の入力は不要になる） |
+
+5. **Permissions** で以下を設定する（各権限は **No access** / **Read-only** / **Read & write** から選択）:
+
+   | カテゴリ | Permission | Access |
+   |---|---|---|
+   | Repository permissions | Metadata | Read-only（自動選択） |
+   | Repository permissions | Contents | Read-only |
+   | Repository permissions | Issues | Read and write |
+   | Repository permissions | Pull requests | Read and write |
+   | Account permissions | Email addresses | Read-only |
+
+6. **Where can this GitHub App be installed?** は、個人利用なら **Only on this account** を選択
+7. **Create GitHub App** をクリック
+
+## 2. Client ID / Client secret の取得
+
+App 作成直後は App の settings ページ（General）に遷移する。あとから開く場合は
+**Settings → Developer settings → GitHub Apps** で対象 App の右側の **Edit** をクリックする。
+
+1. settings ページ上部の **About** に表示される **Client ID**（`Iv23...` 形式）を控える
+   （**App ID とは別物**である点に注意）
+2. **Client secrets** セクションの **Generate a new client secret** をクリックし、
+   表示された secret を控える（**この画面を離れると再表示できない**。紛失時は再生成する）
+3. `.env` に設定する:
+
+   ```bash
+   OAUTH_CLIENT_ID=Iv23xxxxxxxxxxxxxxxx
+   OAUTH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+   ```
+
+## 3. TLS 切替時の変更（既存 App の URL 更新）
+
+`make setup-tls` は `.env` の `MCP_GATEWAY_PUBLIC_URL` を `https://localhost:<port>` に
+書き換えるが、**GitHub App 側の URL は自動では変わらない**。以下を手動で行う。
+
+1. **Settings → Developer settings → GitHub Apps** で対象 App の **Edit** をクリック
+2. General ページで以下を変更する:
+   - **Basic information** の **Homepage URL** → `https://localhost:<port>`
+   - **Identifying and authorizing users** の **Callback URL** 2 本:
+     - `https://localhost:<port>/callback`
+     - `https://localhost:<port>/device_callback`
+3. **Save changes** をクリック
+4. サービスを再起動し、CLI の登録 URL を更新する:
+
+   ```bash
+   make restart-gateway
+   make register-all
+   ```
+
+> **旧 URL を残す場合**: Callback URL は最大 10 本登録できるため、HTTP へ戻す可能性が
+> あるなら旧 `http://127.0.0.1:<port>/...` の 2 本を残したまま https の 2 本を追加してもよい。
+> ただし認可リクエストの `redirect_uri` を省略した場合は**先頭の Callback URL** が使われるため、
+> 並び順には注意する。
+
+## 4. トラブルシューティング
+
+| 症状 | 原因と対処 |
+|---|---|
+| 認可時に `redirect_uri` エラー（"The redirect_uri is not associated with this application." 等） | GitHub App の Callback URL が `<PUBLIC_URL>` と一致していない。scheme（http/https）・host（`127.0.0.1`/`localhost`）・port のいずれかの食い違いでも発生する。セクション 3 の手順で更新する |
+| TLS 切替後にブラウザが証明書警告を出す | mkcert のローカル CA が信頼されていない。`make setup-tls` を再実行する（CA の生成・信頼登録は冪等） |
+| Node.js 製 MCP クライアントが TLS 接続に失敗する | `NODE_EXTRA_CA_CERTS`（setup-tls が `.env` に自動設定）がクライアントのプロセス環境に渡っていない |
+| 認可後に 401 が続く | Client secret の値違い・失効の可能性。セクション 2 の手順で再生成し `.env` を更新、`make restart-gateway` |
+
+## 関連
+
+- [README — GitHub App 登録](../README.md#github-app-登録)（最低限の要点）
+- [mcp-gateway](https://github.com/scottlz0310/mcp-gateway) — `/callback` / `/device_callback` の実装元
+- Mcp-Docker #202 / #207、mcp-gateway #201（ローカル TLS 終端）

--- a/internal/compose/parse.go
+++ b/internal/compose/parse.go
@@ -79,22 +79,30 @@ func Parse(data []byte, lookup func(string) (string, bool)) ([]register.Server, 
 	return servers, nil
 }
 
-// GatewayOrigin は register が生成する URL の接頭辞
-// （MCP_GATEWAY_PUBLIC_URL 由来、既定は http://127.0.0.1:<port>/）を返す。
-func GatewayOrigin(path string) (string, error) {
+// GatewayOrigins は register が生成しうる URL の接頭辞の集合
+// （MCP_GATEWAY_PUBLIC_URL 由来の origin と、既定の http://127.0.0.1:<port>/）を返す。
+func GatewayOrigins(path string) ([]string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return gatewayOrigin(data, os.LookupEnv)
+	return gatewayOrigins(data, os.LookupEnv)
 }
 
-func gatewayOrigin(data []byte, lookup func(string) (string, bool)) (string, error) {
+// gatewayOrigins は現在の origin に加え、常に導出可能なデフォルト origin
+// （http://127.0.0.1:<port>/）を返す。TLS 切替等で MCP_GATEWAY_PUBLIC_URL が
+// 変わると、旧 origin で登録済みのエントリが stale 判定から漏れて残留するため、
+// デフォルト origin も既知の gateway origin として prune 判定に含める。
+func gatewayOrigins(data []byte, lookup func(string) (string, bool)) ([]string, error) {
 	env, err := gatewayEnv(data)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return gatewayBaseURL(env, lookup) + "/", nil
+	origins := []string{gatewayBaseURL(env, lookup) + "/"}
+	if def := "http://127.0.0.1:" + gatewayPort(env, lookup) + "/"; def != origins[0] {
+		origins = append(origins, def)
+	}
+	return origins, nil
 }
 
 // gatewayBaseURL は register が生成する URL のベース（scheme://host:port）を返す。

--- a/internal/compose/parse_test.go
+++ b/internal/compose/parse_test.go
@@ -239,7 +239,7 @@ services:
 	}
 }
 
-func TestGatewayOrigin(t *testing.T) {
+func TestGatewayOrigins(t *testing.T) {
 	const portYAML = `
 services:
   mcp-gateway:
@@ -250,42 +250,53 @@ services:
 		name string
 		yaml string
 		env  map[string]string
-		want string
+		want []string
 	}{
 		{
 			name: "environment 未定義ならデフォルトポート",
 			yaml: "services:\n  mcp-gateway: {}\n",
-			want: "http://127.0.0.1:8080/",
+			want: []string{"http://127.0.0.1:8080/"},
 		},
 		{
 			name: "compose の既定値を展開",
 			yaml: portYAML,
-			want: "http://127.0.0.1:9090/",
+			want: []string{"http://127.0.0.1:9090/"},
 		},
 		{
 			name: "実環境変数が優先される",
 			yaml: portYAML,
 			env:  map[string]string{"MCP_GATEWAY_PORT": "7000"},
-			want: "http://127.0.0.1:7000/",
+			want: []string{"http://127.0.0.1:7000/"},
 		},
 		{
-			name: "MCP_GATEWAY_PUBLIC_URL が origin に反映される",
+			name: "PUBLIC_URL 設定時はデフォルト origin も併せて返す",
 			yaml: portYAML,
 			env:  map[string]string{"MCP_GATEWAY_PUBLIC_URL": "https://localhost:8080"},
-			want: "https://localhost:8080/",
+			want: []string{"https://localhost:8080/", "http://127.0.0.1:9090/"},
+		},
+		{
+			name: "PUBLIC_URL がデフォルト origin と同値なら重複しない",
+			yaml: portYAML,
+			env:  map[string]string{"MCP_GATEWAY_PUBLIC_URL": "http://127.0.0.1:9090"},
+			want: []string{"http://127.0.0.1:9090/"},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := gatewayOrigin([]byte(tc.yaml), func(key string) (string, bool) {
+			got, err := gatewayOrigins([]byte(tc.yaml), func(key string) (string, bool) {
 				val, ok := tc.env[key]
 				return val, ok
 			})
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got != tc.want {
-				t.Fatalf("origin = %q, want %q", got, tc.want)
+			if len(got) != len(tc.want) {
+				t.Fatalf("origins = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("origins = %v, want %v", got, tc.want)
+				}
 			}
 		})
 	}

--- a/internal/register/agent.go
+++ b/internal/register/agent.go
@@ -71,8 +71,10 @@ func Register(ctx context.Context, out io.Writer, agent Agent, servers []Server,
 
 // StaleEntries は agent に登録済みのエントリのうち、gateway 配下の URL を持ち、
 // かつ定義ファイル（available）に含まれないものを返す。
+// gatewayOrigins には現在の origin に加え、TLS 切替前のデフォルト origin など
+// 既知の gateway origin を複数渡せる。
 // URL が特定できないエントリは mcp-docker 管理外の可能性があるため候補にしない。
-func StaleEntries(entries []Entry, available []Server, gatewayOrigin string) []Entry {
+func StaleEntries(entries []Entry, available []Server, gatewayOrigins []string) []Entry {
 	availableNames := make(map[string]struct{}, len(available))
 	for _, server := range available {
 		availableNames[server.Name] = struct{}{}
@@ -82,12 +84,21 @@ func StaleEntries(entries []Entry, available []Server, gatewayOrigin string) []E
 		if _, ok := availableNames[entry.Name]; ok {
 			continue
 		}
-		if entry.URL == "" || !strings.HasPrefix(entry.URL, gatewayOrigin) {
+		if entry.URL == "" || !hasAnyPrefix(entry.URL, gatewayOrigins) {
 			continue
 		}
 		stale = append(stale, entry)
 	}
 	return stale
+}
+
+func hasAnyPrefix(url string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(url, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func Prune(ctx context.Context, out io.Writer, agent Agent, entries []Entry) error {

--- a/internal/register/prune_test.go
+++ b/internal/register/prune_test.go
@@ -32,11 +32,12 @@ func (f *fakeAgent) RemoveCommand(name string) []string { return []string{"remov
 
 func TestStaleEntries(t *testing.T) {
 	available := []Server{{Name: "github", URL: "http://127.0.0.1:8080/mcp/github"}}
-	const origin = "http://127.0.0.1:8080/"
+	defaultOrigins := []string{"http://127.0.0.1:8080/"}
 
 	cases := []struct {
 		name    string
 		entries []Entry
+		origins []string
 		want    []string
 	}{
 		{
@@ -68,10 +69,26 @@ func TestStaleEntries(t *testing.T) {
 			},
 			want: []string{"old-a", "old-b"},
 		},
+		{
+			name:    "TLS 切替後も旧 origin のエントリを候補にする",
+			entries: []Entry{{Name: "old-http", URL: "http://127.0.0.1:8080/mcp/old-http"}},
+			origins: []string{"https://localhost:8080/", "http://127.0.0.1:8080/"},
+			want:    []string{"old-http"},
+		},
+		{
+			name:    "どの origin にも一致しない URL は候補外",
+			entries: []Entry{{Name: "other-host", URL: "http://192.168.0.10:8080/mcp/other"}},
+			origins: []string{"https://localhost:8080/", "http://127.0.0.1:8080/"},
+			want:    nil,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			stale := StaleEntries(tc.entries, available, origin)
+			origins := tc.origins
+			if origins == nil {
+				origins = defaultOrigins
+			}
+			stale := StaleEntries(tc.entries, available, origins)
 			got := make([]string, 0, len(stale))
 			for _, entry := range stale {
 				got = append(got, entry.Name)

--- a/scripts/lib/setup-tls-functions.ps1
+++ b/scripts/lib/setup-tls-functions.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+    setup-tls.ps1 の .env 更新・証明書再利用判定ロジック。
+
+.DESCRIPTION
+    Pester から単体テストできるよう、対象パスはすべて引数で受け取る（#204）。
+    mkcert / winget / UAC 昇格など環境に依存する処理は setup-tls.ps1 本体に残す。
+#>
+
+# BOM 付き UTF-8 は Makefile の awk 抽出や docker compose の .env 解析を壊すため、
+# 書き込みは常に BOM なし UTF-8 で行う。
+function Write-EnvFile {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [string[]]$Lines
+    )
+    [System.IO.File]::WriteAllLines($Path, $Lines, [System.Text.UTF8Encoding]::new($false))
+}
+
+function Set-EnvValue {
+    # .env 1 ファイルへの軽量な書き込みであり -WhatIf / -Confirm の対象にしない
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Key,
+        [Parameter(Mandatory)][string]$Value
+    )
+    # PowerShell 5.1 の Get-Content 既定は BOM なし UTF-8 を ANSI と誤認するため明示する
+    $lines = @(Get-Content -Path $Path -Encoding UTF8)
+    $pattern = "^\s*$([regex]::Escape($Key))\s*="
+    $newLine = "$Key=$Value"
+    $replaced = $false
+    $lines = @($lines | ForEach-Object {
+        if (-not $replaced -and $_ -match $pattern) {
+            $replaced = $true
+            $newLine
+        } else {
+            $_
+        }
+    })
+    if (-not $replaced) {
+        $lines += $newLine
+    }
+    Write-EnvFile -Path $Path -Lines $lines
+    Write-Host "  $newLine"
+}
+
+function Get-EnvValue {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Key
+    )
+    if (-not (Test-Path $Path)) { return $null }
+    $line = @(Get-Content -Path $Path -Encoding UTF8) |
+        Where-Object { $_ -match "^\s*$([regex]::Escape($Key))\s*=" } |
+        Select-Object -Last 1
+    if (-not $line) { return $null }
+    return ($line -split '=', 2)[1].Trim()
+}
+
+# 証明書生成時に記録した CA fingerprint と現在の rootCA.pem の fingerprint を比較し、
+# 既存証明書の扱いを判定する。CA 再生成（CAROOT 削除→再実行等）後に旧 CA 署名の
+# 証明書を再利用して HTTPS 接続が失敗するのを防ぐ（PR #203 レビュー指摘）。
+#   reusable   — 証明書・鍵・fingerprint 記録が揃っており、現在の CA と一致
+#   ca-changed — ファイルは揃っているが CA が変わっている（要再生成）
+#   missing    — いずれかのファイルが存在しない（要生成）
+function Get-CertReuseState {
+    param(
+        [Parameter(Mandatory)][string]$CertFile,
+        [Parameter(Mandatory)][string]$KeyFile,
+        [Parameter(Mandatory)][string]$FingerprintFile,
+        [Parameter(Mandatory)][string]$CaFingerprint
+    )
+    if (-not ((Test-Path $CertFile) -and (Test-Path $KeyFile) -and (Test-Path $FingerprintFile))) {
+        return 'missing'
+    }
+    $recorded = @(Get-Content -Path $FingerprintFile -Encoding UTF8)[0]
+    if ($recorded -and $recorded.Trim() -eq $CaFingerprint) {
+        return 'reusable'
+    }
+    return 'ca-changed'
+}

--- a/scripts/setup-tls.ps1
+++ b/scripts/setup-tls.ps1
@@ -23,49 +23,13 @@ $CertDir = Join-Path $RepoRoot 'config\certs'
 $EnvFile = Join-Path $RepoRoot '.env'
 $EnvTemplate = Join-Path $RepoRoot '.env.template'
 
+# .env 更新・証明書再利用判定は Pester で単体テストするため lib に分離している（#204）
+. (Join-Path $PSScriptRoot 'lib\setup-tls-functions.ps1')
+
 function Resolve-MkcertPath {
     $cmd = Get-Command mkcert -ErrorAction SilentlyContinue
     if ($cmd) { return $cmd.Source }
     return $null
-}
-
-# BOM 付き UTF-8 は Makefile の awk 抽出や docker compose の .env 解析を壊すため、
-# 書き込みは常に BOM なし UTF-8 で行う。
-function Write-EnvFileLines {
-    param([string[]]$Lines)
-    [System.IO.File]::WriteAllLines($EnvFile, $Lines, [System.Text.UTF8Encoding]::new($false))
-}
-
-function Set-EnvValue {
-    param([string]$Key, [string]$Value)
-    # PowerShell 5.1 の Get-Content 既定は BOM なし UTF-8 を ANSI と誤認するため明示する
-    $lines = @(Get-Content -Path $EnvFile -Encoding UTF8)
-    $pattern = "^\s*$([regex]::Escape($Key))\s*="
-    $newLine = "$Key=$Value"
-    $replaced = $false
-    $lines = @($lines | ForEach-Object {
-        if (-not $replaced -and $_ -match $pattern) {
-            $replaced = $true
-            $newLine
-        } else {
-            $_
-        }
-    })
-    if (-not $replaced) {
-        $lines += $newLine
-    }
-    Write-EnvFileLines -Lines $lines
-    Write-Host "  $newLine"
-}
-
-function Get-EnvValue {
-    param([string]$Key)
-    if (-not (Test-Path $EnvFile)) { return $null }
-    $line = @(Get-Content -Path $EnvFile -Encoding UTF8) |
-        Where-Object { $_ -match "^\s*$([regex]::Escape($Key))\s*=" } |
-        Select-Object -Last 1
-    if (-not $line) { return $null }
-    return ($line -split '=', 2)[1].Trim()
 }
 
 # ---------------------------------------------------------------------------
@@ -128,17 +92,12 @@ $keyFile = Join-Path $CertDir 'localhost-key.pem'
 $caFingerprintFile = Join-Path $CertDir '.ca-fingerprint'
 $caFingerprint = (Get-FileHash -Path $rootCaPem -Algorithm SHA256).Hash
 
-$reuseCert = $false
-if ((Test-Path $certFile) -and (Test-Path $keyFile) -and (Test-Path $caFingerprintFile)) {
-    $recorded = @(Get-Content -Path $caFingerprintFile -Encoding UTF8)[0]
-    if ($recorded -and $recorded.Trim() -eq $caFingerprint) {
-        $reuseCert = $true
-    } else {
-        Write-Host '⚠️  ローカル CA が変更されています。証明書を再生成します...'
-    }
+$certState = Get-CertReuseState -CertFile $certFile -KeyFile $keyFile -FingerprintFile $caFingerprintFile -CaFingerprint $caFingerprint
+if ($certState -eq 'ca-changed') {
+    Write-Host '⚠️  ローカル CA が変更されています。証明書を再生成します...'
 }
 
-if ($reuseCert) {
+if ($certState -eq 'reusable') {
     Write-Host "✅ サーバー証明書は生成済みです（現在の CA と一致）: $certFile"
 } else {
     Write-Host '📜 localhost / 127.0.0.1 宛ての証明書を生成します...'
@@ -158,17 +117,17 @@ if (-not (Test-Path $EnvFile)) {
     Write-Host "📄 .env を .env.template から作成しました"
 }
 
-$port = Get-EnvValue 'MCP_GATEWAY_PORT'
+$port = Get-EnvValue -Path $EnvFile -Key 'MCP_GATEWAY_PORT'
 if (-not $port) { $port = '8080' }
 
 Write-Host '🔧 .env を HTTPS 用に更新します:'
-Set-EnvValue 'MCP_GATEWAY_PUBLIC_URL' "https://localhost:$port"
+Set-EnvValue -Path $EnvFile -Key 'MCP_GATEWAY_PUBLIC_URL' -Value "https://localhost:$port"
 # コンテナ内パス（docker-compose.yml の ./config/certs -> /data/certs マウントに対応）
-Set-EnvValue 'MCP_GATEWAY_TLS_CERT_PATH' '/data/certs/localhost.pem'
-Set-EnvValue 'MCP_GATEWAY_TLS_KEY_PATH' '/data/certs/localhost-key.pem'
+Set-EnvValue -Path $EnvFile -Key 'MCP_GATEWAY_TLS_CERT_PATH' -Value '/data/certs/localhost.pem'
+Set-EnvValue -Path $EnvFile -Key 'MCP_GATEWAY_TLS_KEY_PATH' -Value '/data/certs/localhost-key.pem'
 # Node.js はバックスラッシュ区切りパスをエスケープと誤認するためスラッシュに変換する
 $rootCaPemFwd = $rootCaPem -replace '\\', '/'
-Set-EnvValue 'NODE_EXTRA_CA_CERTS' $rootCaPemFwd
+Set-EnvValue -Path $EnvFile -Key 'NODE_EXTRA_CA_CERTS' -Value $rootCaPemFwd
 
 Write-Host ''
 Write-Host '🎉 TLS セットアップが完了しました'

--- a/tests/powershell/setup-tls.Tests.ps1
+++ b/tests/powershell/setup-tls.Tests.ps1
@@ -1,0 +1,152 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    scripts/lib/setup-tls-functions.ps1 の単体テスト（#204）。
+
+.DESCRIPTION
+    mkcert / winget / UAC 昇格などの環境依存処理は setup-tls.ps1 本体に残されており、
+    ここではパス引数のみで動作する純粋なロジックを $TestDrive 上で検証する。
+#>
+
+BeforeAll {
+    . (Join-Path -Path $PSScriptRoot -ChildPath '../../scripts/lib/setup-tls-functions.ps1')
+}
+
+Describe 'Set-EnvValue' {
+    BeforeEach {
+        $script:envFile = Join-Path $TestDrive '.env'
+        Write-EnvFile -Path $envFile -Lines @(
+            '# comment',
+            'MCP_GATEWAY_PORT=8080',
+            'LOG_LEVEL=info'
+        )
+    }
+
+    It '既存キーの値を置換する' {
+        Set-EnvValue -Path $envFile -Key 'MCP_GATEWAY_PORT' -Value '9443'
+
+        Get-EnvValue -Path $envFile -Key 'MCP_GATEWAY_PORT' | Should -Be '9443'
+    }
+
+    It '他の行は変更しない' {
+        Set-EnvValue -Path $envFile -Key 'MCP_GATEWAY_PORT' -Value '9443'
+
+        $lines = Get-Content -Path $envFile
+        $lines[0] | Should -Be '# comment'
+        $lines[2] | Should -Be 'LOG_LEVEL=info'
+    }
+
+    It '存在しないキーは末尾に追記する' {
+        Set-EnvValue -Path $envFile -Key 'NODE_EXTRA_CA_CERTS' -Value 'C:/Users/dev/rootCA.pem'
+
+        $lines = Get-Content -Path $envFile
+        $lines[-1] | Should -Be 'NODE_EXTRA_CA_CERTS=C:/Users/dev/rootCA.pem'
+        $lines.Count | Should -Be 4
+    }
+
+    It '値に = を含んでも分割しない' {
+        Set-EnvValue -Path $envFile -Key 'EXTRA' -Value 'a=b=c'
+
+        Get-EnvValue -Path $envFile -Key 'EXTRA' | Should -Be 'a=b=c'
+    }
+
+    It 'BOM なし UTF-8 で書き込む' {
+        Set-EnvValue -Path $envFile -Key 'MCP_GATEWAY_PORT' -Value '9443'
+
+        $bytes = [System.IO.File]::ReadAllBytes($envFile)
+        $bytes.Length | Should -BeGreaterThan 3
+        @($bytes[0], $bytes[1], $bytes[2]) | Should -Not -Be @(0xEF, 0xBB, 0xBF)
+    }
+
+    It 'BOM 付きで書かれた既存ファイルも BOM なしに正規化する' {
+        [System.IO.File]::WriteAllLines(
+            $envFile,
+            [string[]]@('MCP_GATEWAY_PORT=8080'),
+            [System.Text.UTF8Encoding]::new($true)
+        )
+
+        Set-EnvValue -Path $envFile -Key 'MCP_GATEWAY_PORT' -Value '9443'
+
+        $bytes = [System.IO.File]::ReadAllBytes($envFile)
+        @($bytes[0], $bytes[1], $bytes[2]) | Should -Not -Be @(0xEF, 0xBB, 0xBF)
+        Get-EnvValue -Path $envFile -Key 'MCP_GATEWAY_PORT' | Should -Be '9443'
+    }
+}
+
+Describe 'Get-EnvValue' {
+    BeforeEach {
+        $script:envFile = Join-Path $TestDrive '.env'
+    }
+
+    It 'ファイルが存在しなければ $null を返す' {
+        Get-EnvValue -Path (Join-Path $TestDrive 'missing.env') -Key 'ANY' | Should -BeNullOrEmpty
+    }
+
+    It '<name>' -TestCases @(
+        @{ name = 'キーが存在すれば値を返す'
+           lines = @('MCP_GATEWAY_PORT=8080'); key = 'MCP_GATEWAY_PORT'; expected = '8080' }
+        @{ name = 'キーが存在しなければ $null を返す'
+           lines = @('MCP_GATEWAY_PORT=8080'); key = 'MISSING'; expected = $null }
+        @{ name = '同一キーが複数あれば最後の値を返す'
+           lines = @('KEY=first', 'KEY=last'); key = 'KEY'; expected = 'last' }
+        @{ name = '値の前後の空白を取り除く'
+           lines = @('KEY=  padded  '); key = 'KEY'; expected = 'padded' }
+        @{ name = '行頭に空白があってもキーに一致する'
+           lines = @('  KEY=indented'); key = 'KEY'; expected = 'indented' }
+        @{ name = 'コメント行のキー風文字列には一致しない'
+           lines = @('# KEY=commented'); key = 'KEY'; expected = $null }
+    ) {
+        param($lines, $key, $expected)
+        Write-EnvFile -Path $envFile -Lines $lines
+
+        Get-EnvValue -Path $envFile -Key $key | Should -Be $expected
+    }
+}
+
+Describe 'Get-CertReuseState' {
+    BeforeEach {
+        $script:certFile = Join-Path $TestDrive 'localhost.pem'
+        $script:keyFile = Join-Path $TestDrive 'localhost-key.pem'
+        $script:fpFile = Join-Path $TestDrive '.ca-fingerprint'
+        Set-Content -Path $certFile -Value 'cert'
+        Set-Content -Path $keyFile -Value 'key'
+        Set-Content -Path $fpFile -Value 'ABCDEF0123456789'
+    }
+
+    It 'fingerprint が一致すれば reusable' {
+        Get-CertReuseState -CertFile $certFile -KeyFile $keyFile -FingerprintFile $fpFile -CaFingerprint 'ABCDEF0123456789' |
+            Should -Be 'reusable'
+    }
+
+    It '記録に末尾改行や空白があっても一致と判定する' {
+        [System.IO.File]::WriteAllText($fpFile, "ABCDEF0123456789`n")
+
+        Get-CertReuseState -CertFile $certFile -KeyFile $keyFile -FingerprintFile $fpFile -CaFingerprint 'ABCDEF0123456789' |
+            Should -Be 'reusable'
+    }
+
+    It '<name>' -TestCases @(
+        @{ name = 'fingerprint が不一致なら ca-changed（CA 再生成後の旧証明書再利用を防ぐ）'
+           fpContent = 'OUTDATED'; expected = 'ca-changed' }
+        @{ name = 'fingerprint 記録が空なら ca-changed'
+           fpContent = ''; expected = 'ca-changed' }
+    ) {
+        param($fpContent, $expected)
+        Set-Content -Path $fpFile -Value $fpContent
+
+        Get-CertReuseState -CertFile $certFile -KeyFile $keyFile -FingerprintFile $fpFile -CaFingerprint 'ABCDEF0123456789' |
+            Should -Be $expected
+    }
+
+    It '<name>' -TestCases @(
+        @{ name = '証明書がなければ missing'; remove = 'localhost.pem' }
+        @{ name = '秘密鍵がなければ missing'; remove = 'localhost-key.pem' }
+        @{ name = 'fingerprint 記録がなければ missing'; remove = '.ca-fingerprint' }
+    ) {
+        param($remove)
+        Remove-Item -Path (Join-Path $TestDrive $remove)
+
+        Get-CertReuseState -CertFile $certFile -KeyFile $keyFile -FingerprintFile $fpFile -CaFingerprint 'ABCDEF0123456789' |
+            Should -Be 'missing'
+    }
+}


### PR DESCRIPTION
## 概要

`scripts/setup-tls.ps1` の分岐ロジックを Pester で単体テストできるようにし、CI に PowerShell の lint・テストジョブを追加します。

Closes #204

> **チェーン**: base は fix/206-prune-multi-origin（PR #211）。#211 マージ前に本 PR の base を main に付け替えてください（#211 → 本 PR の順でマージ。親を先にマージ・ブランチ削除すると本 PR が自動クローズされるため注意）。

## 変更内容

- **`scripts/lib/setup-tls-functions.ps1` に分離**: `.env` 更新（`Set-EnvValue` / `Get-EnvValue` / `Write-EnvFile`）と証明書再利用判定（`Get-CertReuseState`: `reusable` / `ca-changed` / `missing` の 3 状態）を、パス引数のみで動作する形に抽出。mkcert / winget / UAC 昇格などの環境依存処理は本体に残置
- **`tests/powershell/setup-tls.Tests.ps1`**（Pester 5 形式・20 ケース、`-TestCases` でパラメータ化）:
  - `Set-EnvValue`: 既存キー置換・新規追記・他行の保全・`=` を含む値・BOM なし UTF-8 書き込み・BOM 付き既存ファイルの正規化
  - `Get-EnvValue`: 欠損ファイル・キー有無・重複キーの最後優先・trim・コメント行の除外
  - `Get-CertReuseState`: fingerprint 一致 / 不一致 / 空記録 / ファイル欠損（PR #203 レビュー指摘 PRRT_kwDORYgN4M6PyCdH の CA 再生成判定を固定化）
- **CI**: `windows-latest` の `test-powershell` ジョブを追加（PSScriptAnalyzer → Pester）
- **`PSScriptAnalyzerSettings.psd1`**: 除外ルール（`PSAvoidUsingWriteHost` / `PSUseBOMForUnicodeEncodedFile`）を理由付きで明文化。`Write-EnvFileLines` は `PSUseSingularNouns` 解消のため `Write-EnvFile` にリネーム

## 検証

- ローカル（Windows / pwsh 7）: Pester 20 ケース全パス、PSScriptAnalyzer 指摘 0 件（CI と同一設定）
- リファクタ後の `setup-tls.ps1` / lib は AST パース検証済み（本体は winget / UAC を伴うため実行検証は対象外）
- `go test ./...` パス（pre-push フック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

