### PR TITLE
chore(release): v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.0] - 2026-07-10
+
 ### 🔄 変更
 
 - `GITHUB_MCP_GATEWAY_IMAGE` のデフォルトを `:main` から `:latest` に復帰
@@ -601,7 +603,8 @@ v1.x からの移行:
 ### Fixed
 - Initial bug fixes
 
-[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.15.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.16.0...HEAD
+[2.16.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.15.0...v2.16.0
 [2.15.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.14.0...v2.15.0
 [2.14.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.13.0...v2.14.0
 [2.13.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.12.0...v2.13.0

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ endif
 MCP_DOCKER   := $(BIN_DIR)/mcp-docker$(EXE_EXT)
 GO_SOURCES   := $(shell find cmd internal -name '*.go' 2>/dev/null)
 REGISTER_FLAGS ?=
-VERSION ?= 2.15.0
+VERSION ?= 2.16.0
 GO_LDFLAGS ?= -X main.version=$(VERSION)
 
 $(MCP_DOCKER): go.mod go.sum $(GO_SOURCES)


### PR DESCRIPTION
## 概要

v2.16.0 リリース準備。`CHANGELOG.md` の `[Unreleased]` を `[2.16.0] - 2026-07-10` として確定し、`Makefile` の `VERSION` を追従させます。

## 含まれる変更（Unreleased からの繰り上げ）

### 🔄 変更
- `GITHUB_MCP_GATEWAY_IMAGE` のデフォルトを `:main` から `:latest` に復帰

### ✨ 機能追加
- ローカル HTTPS (TLS) 接続のための自動セットアップ機能 — #202
- PowerShell テスト基盤（Pester + PSScriptAnalyzer） — #204
- `ROUTE_REVIEW_RAVEN` に `upstream_provider_token=true` — #197

### 🐛 バグ修正
- `mcp-docker register --prune` の複数 origin 照合対応 — #206
- Windows タイムアウトテストの flaky 修正
- `thread-owl` 起動モードの修正 — #199
- Windows 版 GNU Make での bash パス誤解決の修正

### 🔐 セキュリティ
- `ROUTE_GITHUB` / `ROUTE_REVIEW_RAVEN` / `ROUTE_THREAD_OWL` の `auth=none` を削除し gateway OAuth 認証を必須化 — mcp-gateway#184

### 📝 ドキュメント
- GitHub App の Web UI 作業手順を `docs/github-app-setup.md` に詳細化 — #207

新機能追加（TLS 自動セットアップ、`upstream_provider_token`）を含むため semver に基づき minor バージョンアップ（v2.15.0 → v2.16.0）としています。

## 検証

- `go vet ./...` / `go test ./...`: パス

## 手順

マージ後、`git tag v2.16.0 && git push origin v2.16.0` でタグを push すると `.github/workflows/release.yml` が GitHub Release を自動作成します（バイナリビルド・チェックサム同梱）。Release ノートの編集はタグ push 後に行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
