### PR TITLE
fix(gateway): start-gateway に thread-owl が含まれておらず restart で消失する問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 バグ修正
+
+- `make start-gateway`（および `restart-gateway`）が起動するサービス一覧に `thread-owl` が含まれておらず、`make restart-gateway` を実行すると `thread-owl` コンテナが停止したまま復帰しない問題を修正
+  - `start-main` / `pull-main` は #163/#164 で既に対応済みだったが、`start-gateway` 側は同じ修正が漏れていた
+  - `docker compose up -d --remove-orphans` の対象サービスに `thread-owl` を追加
+
 ## [2.16.0] - 2026-07-10
 
 ### 🔄 変更

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ help: ## 利用可能なターゲット一覧を表示
 start-gateway: ## 全サービスを mcp-gateway 経由で起動（127.0.0.1:8080）
 	$(if $(and $(OAUTH_CLIENT_ID),$(OAUTH_CLIENT_SECRET)),,$(error ERROR: OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET are required for the GitHub App (legacy: GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET). Set them in .env or as environment variables.))
 	# --remove-orphans: リネーム前の copilot-review-mcp など compose 定義外の旧コンテナを除去
-	docker compose up -d --remove-orphans github-mcp review-raven mcp-gateway playwright-mcp
+	docker compose up -d --remove-orphans github-mcp review-raven thread-owl mcp-gateway playwright-mcp
 	@echo "Started mcp-gateway endpoint: $(or $(MCP_GATEWAY_PUBLIC_URL),$(MCP_GATEWAY_BASE_URL),http://127.0.0.1:$(or $(MCP_GATEWAY_PORT),8080))"
 
 .PHONY: stop-gateway


### PR DESCRIPTION
## 概要

TLS 移行作業として `make restart-gateway` を実行する準備中に、`docker compose ps` で発見したバグを修正します。

## 問題

`start-gateway`（`docker compose up -d --remove-orphans github-mcp review-raven mcp-gateway playwright-mcp`）のサービス一覧に `thread-owl` が含まれていません。`stop-gateway` は `docker compose down` で全サービスを停止するため、`restart-gateway`（= `stop-gateway` → `start-gateway`）を実行すると `thread-owl` コンテナだけ復帰せず停止したままになります。

同種の不具合は `start-main` / `pull-main` では #163/#164 で既に修正済みでしたが、`start-gateway` / 対応する変更は当時漏れていました。

## 変更内容

- `Makefile` の `start-gateway`: `docker compose up -d --remove-orphans` 対象に `thread-owl` を追加（`start-main` と同じサービス一覧に統一）

## 検証

- `make -n restart-gateway` で recipe に `thread-owl` が含まれることを確認
- `go vet` / `go test` / shellcheck 含むシェルリント: パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
