### PR TITLE
chore(release): v2.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.1] - 2026-07-10
+
 ### 🐛 バグ修正
 
 - `make start-gateway`（および `restart-gateway`）が起動するサービス一覧に `thread-owl` が含まれておらず、`make restart-gateway` を実行すると `thread-owl` コンテナが停止したまま復帰しない問題を修正
@@ -613,7 +615,8 @@ v1.x からの移行:
 ### Fixed
 - Initial bug fixes
 
-[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.16.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.16.1...HEAD
+[2.16.1]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.16.0...v2.16.1
 [2.16.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.15.0...v2.16.0
 [2.15.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.14.0...v2.15.0
 [2.14.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.13.0...v2.14.0

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ endif
 MCP_DOCKER   := $(BIN_DIR)/mcp-docker$(EXE_EXT)
 GO_SOURCES   := $(shell find cmd internal -name '*.go' 2>/dev/null)
 REGISTER_FLAGS ?=
-VERSION ?= 2.16.0
+VERSION ?= 2.16.1
 GO_LDFLAGS ?= -X main.version=$(VERSION)
 
 $(MCP_DOCKER): go.mod go.sum $(GO_SOURCES)


### PR DESCRIPTION
## 概要

v2.16.1 リリース準備。`CHANGELOG.md` の `[Unreleased]` を `[2.16.1] - 2026-07-10` として確定し、`Makefile` の `VERSION` を追従させます。

## 含まれる変更（Unreleased からの繰り上げ）

TLS ローカル HTTPS 移行作業（v2.16.0 の `make setup-tls` 実運用）で見つかったバグ修正3件のみです。新機能・破壊的変更はないため patch バージョンアップ（v2.16.0 → v2.16.1）としています。

### 🐛 バグ修正
- `make start-gateway`（および `restart-gateway`）に `thread-owl` が含まれておらず、再起動すると停止したまま復帰しない問題を修正 — #215
- `make setup-tls` が Windows PowerShell 5.1 経由だと日本語文字列を誤読しパースエラーで失敗する問題を修正。`pwsh`（PowerShell 7+）を明示使用するよう変更 — #214
- `scripts/setup-tls.ps1` の進捗表示が Git Bash 経由のパイプ実行時に文字化けする問題を修正 — #214

## 検証

- `go vet ./...` / `go test ./...`: パス

## 手順

マージ後、`git tag v2.16.1 && git push origin v2.16.1` でタグを push すると `.github/workflows/release.yml` が GitHub Release を自動作成します。Release ノートの編集はタグ push 後に行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
