### PR TITLE
feat(setup-tls): NODE_EXTRA_CA_CERTS を User スコープ環境変数にも自動設定する (#217)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -125,6 +125,8 @@ MCP_GATEWAY_GITHUB_REFRESH_ENABLED=true
 #
 # Node.js 製クライアント（mcp-resource-subscriber 等）が mkcert ローカル CA を
 # 信頼するためのパス。setup-tls がスラッシュ区切りで自動設定します。
+# この .env は docker compose にしか渡らないため、setup-tls は同じ値を
+# User スコープ環境変数にも設定します（ホスト側で直接起動するクライアント用）。
 # NODE_EXTRA_CA_CERTS=C:/Users/<you>/AppData/Local/mkcert/rootCA.pem
 
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ 機能追加
+
+- `make setup-tls` が `NODE_EXTRA_CA_CERTS` を User スコープ環境変数にも自動設定するよう変更 — #217
+  - `.env` は docker compose にしか渡らず、ホスト側で直接起動する Node 製 MCP クライアント（mcp-resource-subscriber、およびそれを子プロセス起動する Squirrel Notifier 等）が mkcert ローカル CA を信頼できず TLS 接続に失敗していた
+  - 別の値が設定済みの場合は上書きせず、PEM 連結による統合手順を警告表示（`NODE_EXTRA_CA_CERTS` は 1 ファイルのみ指定可能なため）
+  - 判定ロジック `Get-NodeExtraCaCertsAction` は `scripts/lib/setup-tls-functions.ps1` に配置し Pester で単体テスト
+
 ## [2.16.1] - 2026-07-10
 
 ### 🐛 バグ修正

--- a/scripts/lib/setup-tls-functions.ps1
+++ b/scripts/lib/setup-tls-functions.ps1
@@ -58,6 +58,29 @@ function Get-EnvValue {
     return ($line -split '=', 2)[1].Trim()
 }
 
+# User スコープ環境変数 NODE_EXTRA_CA_CERTS の扱いを判定する（#217）。
+# .env は docker compose にしか渡らないため、ホスト側で直接起動する Node 製
+# MCP クライアント（mcp-resource-subscriber 等）には User スコープでの設定が必要。
+#   set      — 未設定（要設定）
+#   noop     — 既に同じパスを指している（区切り文字・大文字小文字の差は無視）
+#   conflict — 別の値が設定済み。NODE_EXTRA_CA_CERTS は 1 ファイルしか指定
+#              できないため上書きせず、呼び出し側で警告する
+function Get-NodeExtraCaCertsAction {
+    param(
+        [string]$CurrentValue,
+        [Parameter(Mandatory)][string]$DesiredValue
+    )
+    if ([string]::IsNullOrWhiteSpace($CurrentValue)) {
+        return 'set'
+    }
+    $current = ($CurrentValue.Trim() -replace '\\', '/')
+    $desired = ($DesiredValue.Trim() -replace '\\', '/')
+    if ($current -ieq $desired) {
+        return 'noop'
+    }
+    return 'conflict'
+}
+
 # 証明書生成時に記録した CA fingerprint と現在の rootCA.pem の fingerprint を比較し、
 # 既存証明書の扱いを判定する。CA 再生成（CAROOT 削除→再実行等）後に旧 CA 署名の
 # 証明書を再利用して HTTPS 接続が失敗するのを防ぐ（PR #203 レビュー指摘）。

--- a/scripts/setup-tls.ps1
+++ b/scripts/setup-tls.ps1
@@ -134,6 +134,30 @@ Set-EnvValue -Path $EnvFile -Key 'MCP_GATEWAY_TLS_KEY_PATH' -Value '/data/certs/
 $rootCaPemFwd = $rootCaPem -replace '\\', '/'
 Set-EnvValue -Path $EnvFile -Key 'NODE_EXTRA_CA_CERTS' -Value $rootCaPemFwd
 
+# ---------------------------------------------------------------------------
+# 5. ユーザー環境変数 NODE_EXTRA_CA_CERTS の設定
+# ---------------------------------------------------------------------------
+# .env は docker compose にしか渡らない。ホスト側で直接起動する Node 製 MCP
+# クライアント（mcp-resource-subscriber 等）は Windows 証明書ストアを参照しない
+# ため、User スコープ環境変数として mkcert ローカル CA を信頼させる（#217）。
+$currentUserCa = [Environment]::GetEnvironmentVariable('NODE_EXTRA_CA_CERTS', 'User')
+switch (Get-NodeExtraCaCertsAction -CurrentValue $currentUserCa -DesiredValue $rootCaPemFwd) {
+    'set' {
+        [Environment]::SetEnvironmentVariable('NODE_EXTRA_CA_CERTS', $rootCaPemFwd, 'User')
+        Write-Host "✅ ユーザー環境変数 NODE_EXTRA_CA_CERTS を設定しました: $rootCaPemFwd"
+        Write-Host '   既に起動中のアプリ・シェルには反映されません。クライアントを再起動してください。'
+    }
+    'noop' {
+        Write-Host "✅ ユーザー環境変数 NODE_EXTRA_CA_CERTS は設定済みです: $currentUserCa"
+    }
+    'conflict' {
+        Write-Host "⚠️  ユーザー環境変数 NODE_EXTRA_CA_CERTS に別の値が設定されています: $currentUserCa"
+        Write-Host '   NODE_EXTRA_CA_CERTS は 1 ファイルしか指定できないため上書きしません。'
+        Write-Host "   mkcert CA も信頼させる場合は、既存 PEM と $rootCaPemFwd を連結した"
+        Write-Host '   ファイルを作成し、NODE_EXTRA_CA_CERTS をそのファイルに変更してください。'
+    }
+}
+
 Write-Host ''
 Write-Host '🎉 TLS セットアップが完了しました'
 Write-Host ''

--- a/tests/powershell/setup-tls.Tests.ps1
+++ b/tests/powershell/setup-tls.Tests.ps1
@@ -103,6 +103,35 @@ Describe 'Get-EnvValue' {
     }
 }
 
+Describe 'Get-NodeExtraCaCertsAction' {
+    It '<name>' -TestCases @(
+        @{ name = '未設定なら set'
+           current = $null; desired = 'C:/Users/dev/AppData/Local/mkcert/rootCA.pem'; expected = 'set' }
+        @{ name = '空文字列なら set'
+           current = ''; desired = 'C:/Users/dev/AppData/Local/mkcert/rootCA.pem'; expected = 'set' }
+        @{ name = '空白のみなら set'
+           current = '   '; desired = 'C:/Users/dev/AppData/Local/mkcert/rootCA.pem'; expected = 'set' }
+        @{ name = '同一パスなら noop'
+           current = 'C:/Users/dev/AppData/Local/mkcert/rootCA.pem'
+           desired = 'C:/Users/dev/AppData/Local/mkcert/rootCA.pem'; expected = 'noop' }
+        @{ name = 'バックスラッシュ区切りでも同一パスなら noop'
+           current = 'C:\Users\dev\AppData\Local\mkcert\rootCA.pem'
+           desired = 'C:/Users/dev/AppData/Local/mkcert/rootCA.pem'; expected = 'noop' }
+        @{ name = '大文字小文字の差だけなら noop'
+           current = 'c:/users/dev/appdata/local/mkcert/rootca.pem'
+           desired = 'C:/Users/dev/AppData/Local/mkcert/rootCA.pem'; expected = 'noop' }
+        @{ name = '前後の空白は無視して比較する'
+           current = ' C:/Users/dev/AppData/Local/mkcert/rootCA.pem '
+           desired = 'C:/Users/dev/AppData/Local/mkcert/rootCA.pem'; expected = 'noop' }
+        @{ name = '別の値が設定済みなら conflict（上書きしない）'
+           current = 'C:/corp/proxy-ca.pem'
+           desired = 'C:/Users/dev/AppData/Local/mkcert/rootCA.pem'; expected = 'conflict' }
+    ) {
+        param($current, $desired, $expected)
+        Get-NodeExtraCaCertsAction -CurrentValue $current -DesiredValue $desired | Should -Be $expected
+    }
+}
+
 Describe 'Get-CertReuseState' {
     BeforeEach {
         $script:certFile = Join-Path $TestDrive 'localhost.pem'


### PR DESCRIPTION
## 概要

`make setup-tls` が `NODE_EXTRA_CA_CERTS` を `.env` に加えて **User スコープ環境変数**にも自動設定するようにする。

Closes #217

## 背景

`.env` は docker compose にしか渡らないため、ホスト側で直接起動する Node 製 MCP クライアント（mcp-resource-subscriber、およびそれを子プロセス起動する Squirrel Notifier 等）は mkcert ローカル CA を信頼できず、TLS 接続が `fetch failed`（`UNABLE_TO_VERIFY_LEAF_SIGNATURE`）で失敗していた。squirrel-notifier v0.4.0 の E2E 再検証（scottlz0310/squirrel-notifier#166）で顕在化。

## 変更内容

- `scripts/setup-tls.ps1`: ステップ 5 として User スコープ環境変数の設定を追加
  - 未設定 → mkcert `rootCA.pem`（スラッシュ区切り）を設定し、既存プロセスへは反映されない旨を案内
  - 同値（区切り文字・大文字小文字・前後空白の差は無視）→ no-op
  - 別値が設定済み → `NODE_EXTRA_CA_CERTS` は 1 ファイルしか指定できないため**上書きせず**、PEM 連結による統合手順を警告表示
- `scripts/lib/setup-tls-functions.ps1`: 判定ロジック `Get-NodeExtraCaCertsAction` を追加（#204 の方針に従い環境非依存ロジックのみ lib に配置）
- `tests/powershell/setup-tls.Tests.ps1`: パラメータ化テスト 8 ケース追加
- `.env.template` / `CHANGELOG.md`: 説明を更新

## 検証

- `Invoke-Pester tests/powershell` — 28 件全パス（既存 20 + 追加 8）
- `Invoke-ScriptAnalyzer`（リポジトリの `PSScriptAnalyzerSettings.psd1` 使用）— 指摘 0 件
- 実環境（Windows 11 / mkcert 導入済み）で User スコープ設定後、`mcp-resource-subscriber` の subscribe probe が `https://localhost:8080/mcp/thread-owl` に対して `subscribed: true` になることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)