### PR TITLE
fix(setup-tls): avoid elevated mkcert install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 バグ修正
+
+- `make setup-tls` が mkcert を UAC 昇格して実行していたため、WinGet のシンボリックリンク経由で異常終了する問題を修正
+  - mkcert は実行ユーザーの証明書ストアへ登録するため、通常ユーザーとして直接実行するよう変更
+  - 管理者として実行して別ユーザーのプロファイル・証明書ストアへ CA を作成してしまう問題も解消
+  - `JAVA_HOME` がある通常ユーザー環境で Java の `cacerts` への登録がアクセス拒否になるため、mkcert の登録先を Windows の証明書ストアだけに限定
+
 ### ✨ 機能追加
 
 - `make setup-tls` が `NODE_EXTRA_CA_CERTS` を User スコープ環境変数にも自動設定するよう変更 — #217

--- a/scripts/lib/setup-tls-functions.ps1
+++ b/scripts/lib/setup-tls-functions.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
     Pester から単体テストできるよう、対象パスはすべて引数で受け取る（#204）。
-    mkcert / winget / UAC 昇格など環境に依存する処理は setup-tls.ps1 本体に残す。
+    mkcert / winget / 証明書ストアなど環境に依存する処理は setup-tls.ps1 本体に残す。
 #>
 
 # BOM 付き UTF-8 は Makefile の awk 抽出や docker compose の .env 解析を壊すため、

--- a/scripts/setup-tls.ps1
+++ b/scripts/setup-tls.ps1
@@ -6,7 +6,7 @@
     mcp-gateway の TLS 終端（MCP_GATEWAY_TLS_CERT_PATH / MCP_GATEWAY_TLS_KEY_PATH）
     に必要なホスト側の環境構築を行う:
       1. winget による mkcert の非対話インストール
-      2. mkcert ローカル CA の生成と信頼登録（この処理のみ UAC 昇格）
+      2. mkcert ローカル CA の生成と信頼登録（実行ユーザーの証明書ストア）
       3. ./config/certs/ への localhost / 127.0.0.1 宛て証明書の生成
       4. .env の自動構成（MCP_GATEWAY_PUBLIC_URL / TLS パス / NODE_EXTRA_CA_CERTS）
 
@@ -72,12 +72,21 @@ $caTrusted = @(Get-ChildItem Cert:\CurrentUser\Root -ErrorAction SilentlyContinu
 if ((Test-Path $rootCaPem) -and $caTrusted) {
     Write-Host "✅ mkcert ローカル CA は信頼登録済みです: $caRoot"
 } else {
-    Write-Host '🔐 ローカル CA を生成・信頼登録します（UAC の確認ダイアログが表示されます）...'
-    # スクリプト全体を管理者として起動するとカレントディレクトリが System32 に
-    # 変わり相対パスが混乱するため、mkcert -install の実行だけを局所的に昇格する。
-    $proc = Start-Process -FilePath $mkcert -ArgumentList '-install' -Verb RunAs -Wait -PassThru
-    if ($proc.ExitCode -ne 0) {
-        throw "mkcert -install に失敗しました (exit=$($proc.ExitCode))"
+    Write-Host '🔐 ローカル CA を生成・信頼登録します...'
+    # mkcert は現在の Windows ユーザーの ROOT 証明書ストアへ登録する。RunAs で
+    # 昇格すると管理者のプロファイル・証明書ストアが対象となり、呼び出し元の
+    # ユーザーには CA が作成・信頼登録されない。Java の cacerts への登録も不要で、
+    # JAVA_HOME がある通常ユーザー環境ではアクセス拒否になるため対象を system に絞る。
+    $previousTrustStores = $env:TRUST_STORES
+    try {
+        $env:TRUST_STORES = 'system'
+        & $mkcert -install
+        $mkcertExitCode = $LASTEXITCODE
+    } finally {
+        $env:TRUST_STORES = $previousTrustStores
+    }
+    if ($mkcertExitCode -ne 0) {
+        throw "mkcert -install に失敗しました (exit=$mkcertExitCode)"
     }
     if (-not (Test-Path $rootCaPem)) {
         throw "mkcert -install 後も rootCA.pem が見つかりません: $rootCaPem"

--- a/tests/powershell/setup-tls.Tests.ps1
+++ b/tests/powershell/setup-tls.Tests.ps1
@@ -4,12 +4,27 @@
     scripts/lib/setup-tls-functions.ps1 の単体テスト（#204）。
 
 .DESCRIPTION
-    mkcert / winget / UAC 昇格などの環境依存処理は setup-tls.ps1 本体に残されており、
+    mkcert / winget / 証明書ストアなどの環境依存処理は setup-tls.ps1 本体に残されており、
     ここではパス引数のみで動作する純粋なロジックを $TestDrive 上で検証する。
 #>
 
 BeforeAll {
     . (Join-Path -Path $PSScriptRoot -ChildPath '../../scripts/lib/setup-tls-functions.ps1')
+    $script:setupTlsScript = Get-Content -Raw -Path (Join-Path -Path $PSScriptRoot -ChildPath '../../scripts/setup-tls.ps1')
+}
+
+Describe 'setup-tls.ps1 の mkcert 実行コンテキスト' {
+    It 'CA を現在のユーザーとして直接生成・信頼登録する' {
+        $setupTlsScript | Should -Match '(?m)^\s*& \$mkcert -install\s*$'
+    }
+
+    It 'mkcert を別ユーザーとして昇格実行しない' {
+        $setupTlsScript | Should -Not -Match '(?i)Start-Process.*-Verb\s+RunAs'
+    }
+
+    It 'Java の証明書ストアへ登録しない' {
+        $setupTlsScript | Should -Match '\$env:TRUST_STORES = ''system'''
+    }
 }
 
 Describe 'Set-EnvValue' {


### PR DESCRIPTION
## 概要

- `make setup-tls` が mkcert を現在のユーザーとして直接実行するよう修正
- mkcert の信頼ストアを Windows の `system` のみに限定
- 回帰テストと CHANGELOG を追加

## 原因

`Start-Process -Verb RunAs` により、WinGet のシンボリックリンク経由で mkcert を昇格実行していました。これは実行ユーザーではなく管理者プロファイルの証明書ストアを対象にし、環境によっては異常終了します。また、`JAVA_HOME` が設定されていると Java の `cacerts` への書き込みでアクセス拒否になります。

## 影響

Windows の通常ユーザーで `make setup-tls` を実行すると、UAC なしでローカル CA・localhost 証明書・TLS 用の `.env` 設定を生成できます。Node.js クライアント向けの `NODE_EXTRA_CA_CERTS` 設定は維持します。

## 検証

- `Invoke-Pester -Path tests/powershell -Output Detailed -CI`（31件成功）
- `Invoke-ScriptAnalyzer -Path scripts -Recurse -Settings PSScriptAnalyzerSettings.psd1`（指摘なし）
- `make setup-tls` の初回実行と再実行（冪等性）
- lefthook pre-commit（`go vet ./...`）