### PR TITLE
fix: update Antigravity config path to ~/.gemini/config/mcp_config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.2] - 2026-07-14
+
 ### 🐛 バグ修正
 
+- `make register` で Antigravity に登録する際の設定ファイルパスを、最新仕様である `~/.gemini/config/mcp_config.json` に更新
 - `make setup-tls` が mkcert を UAC 昇格して実行していたため、WinGet のシンボリックリンク経由で異常終了する問題を修正
   - mkcert は実行ユーザーの証明書ストアへ登録するため、通常ユーザーとして直接実行するよう変更
   - 管理者として実行して別ユーザーのプロファイル・証明書ストアへ CA を作成してしまう問題も解消
@@ -629,7 +632,8 @@ v1.x からの移行:
 ### Fixed
 - Initial bug fixes
 
-[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.16.1...HEAD
+[Unreleased]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.16.2...HEAD
+[2.16.2]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.16.1...v2.16.2
 [2.16.1]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.16.0...v2.16.1
 [2.16.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.15.0...v2.16.0
 [2.15.0]: https://github.com/scottlz0310/Mcp-Docker/compare/v2.14.0...v2.15.0

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ endif
 MCP_DOCKER   := $(BIN_DIR)/mcp-docker$(EXE_EXT)
 GO_SOURCES   := $(shell find cmd internal -name '*.go' 2>/dev/null)
 REGISTER_FLAGS ?=
-VERSION ?= 2.16.1
+VERSION ?= 2.16.2
 GO_LDFLAGS ?= -X main.version=$(VERSION)
 
 $(MCP_DOCKER): go.mod go.sum $(GO_SOURCES)

--- a/docs/e2e-runbook-mcp-docker-cli.md
+++ b/docs/e2e-runbook-mcp-docker-cli.md
@@ -222,7 +222,7 @@ codex mcp list
 
 ```bash
 # グローバル設定ファイルを確認
-cat ~/.gemini/antigravity-cli/mcp_config.json
+cat ~/.gemini/config/mcp_config.json
 ```
 
 ### 5-2. 登録実行
@@ -235,13 +235,13 @@ cat ~/.gemini/antigravity-cli/mcp_config.json
 
 ```bash
 # グローバル設定ファイルが更新され、各サーバーが登録されていることを確認
-cat ~/.gemini/antigravity-cli/mcp_config.json
+cat ~/.gemini/config/mcp_config.json
 ```
 
 または `agy` 起動後に `/mcp` コマンドで確認する。
 
 **確認ポイント:**
-- [ ] `~/.gemini/antigravity-cli/mcp_config.json` に `github`、`review-raven`、`playwright` が登録されている
+- [ ] `~/.gemini/config/mcp_config.json` に `github`、`review-raven`、`playwright` が登録されている
 
 ---
 

--- a/internal/register/agents.go
+++ b/internal/register/agents.go
@@ -181,7 +181,7 @@ func (a AntigravityAgent) getConfigPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json"), nil
+	return filepath.Join(home, ".gemini", "config", "mcp_config.json"), nil
 }
 
 func (a AntigravityAgent) ListEntries(ctx context.Context) ([]Entry, error) {

--- a/internal/register/agents_test.go
+++ b/internal/register/agents_test.go
@@ -425,3 +425,21 @@ func TestAntigravitySafeWriteFileErrors(t *testing.T) {
 		t.Error("expected error when directory creation fails")
 	}
 }
+
+func TestAntigravityAgent_DefaultConfigPath(t *testing.T) {
+	agent := AntigravityAgent{
+		baseAgent: baseAgent{name: "antigravity", runner: &fakeRunner{}},
+	}
+	path, err := agent.getConfigPath()
+	if err != nil {
+		t.Fatalf("getConfigPath failed: %v", err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := filepath.Join(home, ".gemini", "config", "mcp_config.json")
+	if path != expected {
+		t.Errorf("expected config path %q, got %q", expected, path)
+	}
+}


### PR DESCRIPTION
Antigravity (AGY) の MCP 設定ファイルの参照先を最新仕様である `~/.gemini/config/mcp_config.json` に更新し、パッチバージョン 2.16.2 をリリースします。

### 変更内容
- **internal/register/agents.go**: 設定ファイルパスを `~/.gemini/antigravity-cli/mcp_config.json` から `~/.gemini/config/mcp_config.json` に修正
- **docs/e2e-runbook-mcp-docker-cli.md**: E2Eテストランブックに記載されているパス表記を修正
- **Makefile**: バージョンを `2.16.2` に更新
- **CHANGELOG.md**: 2.16.2 リリース情報を追加し、今回のバグ修正内容を追記