### PR TITLE
fix(register): antigravity の空 mcp_config.json をファイル未存在と同様に扱う

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 バグ修正
+
+- `mcp-docker register` で Antigravity を対象に選択した際、`~/.gemini/config/mcp_config.json` が空ファイル（サイズ0）で存在すると `unexpected end of JSON input` で失敗する問題を修正 — #221
+  - `AntigravityAgent` の `ListEntries`/`Add`/`Remove` で、存在するが空のファイルをファイル未存在時と同様に扱うよう修正
+  - 壊れた JSON（非空の不正データ）は従来通りエラーとする
+
 ## [2.16.2] - 2026-07-14
 
 ### 🐛 バグ修正

--- a/internal/register/agents.go
+++ b/internal/register/agents.go
@@ -196,6 +196,9 @@ func (a AntigravityAgent) ListEntries(ctx context.Context) ([]Entry, error) {
 		}
 		return nil, err
 	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil, nil
+	}
 	var config map[string]any
 	if err := json.Unmarshal(data, &config); err != nil {
 		return nil, err
@@ -232,8 +235,10 @@ func (a AntigravityAgent) Add(ctx context.Context, s Server) error {
 
 	data, err := os.ReadFile(path)
 	if err == nil {
-		if err := json.Unmarshal(data, &config); err != nil {
-			return err
+		if len(strings.TrimSpace(string(data))) > 0 {
+			if err := json.Unmarshal(data, &config); err != nil {
+				return err
+			}
 		}
 	} else if !os.IsNotExist(err) {
 		return err
@@ -280,6 +285,9 @@ func (a AntigravityAgent) Remove(ctx context.Context, name string) error {
 			return nil
 		}
 		return err
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil
 	}
 
 	var config map[string]any

--- a/internal/register/agents_test.go
+++ b/internal/register/agents_test.go
@@ -402,6 +402,52 @@ func TestAntigravityMcpServersNotObject(t *testing.T) {
 	}
 }
 
+func TestAntigravityEmptyConfigFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "antigravity-empty-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	configPath := filepath.Join(tmpDir, "mcp_config.json")
+	if err := os.WriteFile(configPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	agent := AntigravityAgent{
+		baseAgent:  baseAgent{name: "antigravity", runner: &fakeRunner{}},
+		configPath: configPath,
+	}
+
+	// List should treat an empty file like a missing file, not error.
+	names, err := listNames(agent)
+	if err != nil {
+		t.Fatalf("List returned error for empty file: %v", err)
+	}
+	if len(names) != 0 {
+		t.Errorf("expected empty list for empty file, got %v", names)
+	}
+
+	// Add should succeed and create a fresh config.
+	if err := agent.Add(context.Background(), Server{Name: "github", URL: "http://127.0.0.1:8080"}); err != nil {
+		t.Fatalf("Add failed for empty file: %v", err)
+	}
+	names, err = listNames(agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 1 || names[0] != "github" {
+		t.Errorf("expected [github], got %v", names)
+	}
+
+	// Remove against an empty file should be a no-op, not an error.
+	if err := os.WriteFile(configPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.Remove(context.Background(), "github"); err != nil {
+		t.Fatalf("Remove failed for empty file: %v", err)
+	}
+}
+
 func TestAntigravitySafeWriteFileErrors(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "antigravity-write-error-*")
 	if err != nil {


### PR DESCRIPTION
## Summary
- `mcp-docker register` で Antigravity を対象に選択した際、`~/.gemini/config/mcp_config.json` が空ファイル（サイズ0）で存在すると `unexpected end of JSON input` で失敗する問題を修正
- `os.ReadFile` が成功した場合に中身の空チェックをしていなかったのが原因。`ListEntries`/`Add`/`Remove` の3箇所に「存在するが空」の判定を追加し、ファイル未存在時と同様に扱うようにした
- 壊れた JSON（非空の不正データ）は従来通りエラーとする挙動は変更していない（既存の `TestAntigravityErrorPaths` で担保）

Closes #221

## Test plan
- [x] `TestAntigravityEmptyConfigFile` を追加（空ファイルに対する List/Add/Remove の挙動を検証）
- [x] `go test ./internal/register/...` 全件 PASS
- [x] `go test ./...` 全件 PASS
- [x] pre-commit / pre-push フック（go vet, lint-shell, go test）全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
