### PR TITLE
chore(release): v2.16.3 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.3] - 2026-07-16
+
 ### 🐛 バグ修正
 
 - `mcp-docker register` で Antigravity を対象に選択した際、`~/.gemini/config/mcp_config.json` が空ファイル（サイズ0）で存在すると `unexpected end of JSON input` で失敗する問題を修正 — #221

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ endif
 MCP_DOCKER   := $(BIN_DIR)/mcp-docker$(EXE_EXT)
 GO_SOURCES   := $(shell find cmd internal -name '*.go' 2>/dev/null)
 REGISTER_FLAGS ?=
-VERSION ?= 2.16.2
+VERSION ?= 2.16.3
 GO_LDFLAGS ?= -X main.version=$(VERSION)
 
 $(MCP_DOCKER): go.mod go.sum $(GO_SOURCES)


### PR DESCRIPTION
## Summary
- v2.16.3 リリース準備: CHANGELOG.md の Unreleased セクションを `[2.16.3] - 2026-07-16` に確定
- Makefile の `VERSION` を `2.16.3` に更新
- 内容は #221 / #222（antigravity 空 mcp_config.json 対応）のみ

## Test plan
- [x] pre-commit / pre-push フック（go vet, lint-shell, go test）全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
